### PR TITLE
feat(ci): add E2E test workflow with Maestro Cloud

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -52,7 +54,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Generate native project
         working-directory: apps/mobile


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated E2E testing
- Build Android APK locally using Gradle (no external dependencies)
- Run Maestro tests on Android emulator in GitHub Actions
- Post test results as PR comments

## Triggers
- PRs targeting main (when `apps/mobile/**` changes)
- Pushes to main
- Manual workflow dispatch

## Features
- 45-minute job timeout
- Gradle caching for faster builds
- Test results uploaded as artifacts
- PR comments with pass/fail status

## Required Secrets
**None** - everything runs locally on GitHub Actions

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)