### PR TITLE
feat(mobile): add sub-category dropdowns for Air Pollution and Pathogens

### DIFF
--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -16,6 +16,7 @@ import { formatDistanceToNow } from "date-fns"
 
 import { CategoryIcon, CATEGORY_COLORS } from "@/components/CategoryIcon"
 import { ContaminantTable, ContaminantTableRow } from "@/components/ContaminantTable"
+import { ExpandableCard } from "@/components/ExpandableCard"
 import { Header } from "@/components/Header"
 import { LinkedText } from "@/components/LinkedText"
 import { Screen } from "@/components/Screen"
@@ -286,6 +287,25 @@ mapyourhealth://zip/${zipData.zipCode}`
     marginLeft: 6,
   }
 
+  const $subCategoriesContainer: ViewStyle = {
+    paddingHorizontal: 0,
+    paddingTop: 8,
+    gap: 8,
+  }
+
+  const $subCategoryHeader: TextStyle = {
+    fontSize: 16,
+    fontWeight: "600",
+    color: theme.colors.text,
+  }
+
+  const $subCategoryDescription: TextStyle = {
+    fontSize: 14,
+    color: theme.colors.text,
+    lineHeight: 20,
+    marginBottom: 12,
+  }
+
   const $offlineBanner: ViewStyle = {
     flexDirection: "row",
     alignItems: "center",
@@ -403,6 +423,36 @@ mapyourhealth://zip/${zipData.zipCode}`
                 <MaterialCommunityIcons name="open-in-new" size={16} color={theme.colors.tint} />
                 <Text style={$linkText}>{link.label}</Text>
               </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        {/* Sub-categories (expandable dropdowns) */}
+        {categoryConfig.subCategories && categoryConfig.subCategories.length > 0 && (
+          <View style={$subCategoriesContainer}>
+            {categoryConfig.subCategories.map((subCategory) => (
+              <ExpandableCard
+                key={subCategory.id}
+                header={<Text style={$subCategoryHeader}>{subCategory.name}</Text>}
+              >
+                <Text style={$subCategoryDescription}>{subCategory.description}</Text>
+                {subCategory.links?.map((link, idx) => (
+                  <TouchableOpacity
+                    key={idx}
+                    style={$linkButton}
+                    onPress={() => handleLinkPress(link.url)}
+                    accessibilityRole="link"
+                    accessibilityLabel={`Open ${link.label}`}
+                  >
+                    <MaterialCommunityIcons
+                      name="open-in-new"
+                      size={16}
+                      color={theme.colors.tint}
+                    />
+                    <Text style={$linkText}>{link.label}</Text>
+                  </TouchableOpacity>
+                ))}
+              </ExpandableCard>
             ))}
           </View>
         )}


### PR DESCRIPTION
## Summary
- Add expandable dropdown sections to CategoryDetailScreen for sub-categories
- Air Pollution screen now shows "Radon" dropdown with description and EPA link
- Pathogens screen now shows "Lyme Disease" dropdown with description and CDC link
- Dropdowns expand/collapse with smooth animation using ExpandableCard component

## Test plan
- [ ] Navigate to Air Pollution category and verify "Radon" dropdown appears
- [ ] Tap dropdown to expand and verify description and EPA link are shown
- [ ] Tap EPA link and verify it opens in browser
- [ ] Navigate to Pathogens category and verify "Lyme Disease" dropdown appears
- [ ] Tap dropdown to expand and verify description and CDC link are shown
- [ ] Tap CDC link and verify it opens in browser
- [ ] Verify dropdowns collapse when tapped again

Closes #68
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)