### PR TITLE
fix(e2e): make Close button tap conditional in _OnFlowStart

### DIFF
--- a/apps/mobile/.maestro/shared/_OnFlowStart.yaml
+++ b/apps/mobile/.maestro/shared/_OnFlowStart.yaml
@@ -34,6 +34,13 @@ appId: ${MAESTRO_APP_ID}
       visible: 'Development servers'
     commands:
       # this regex allows for different hosts and ports
-      - tapOn: "http://.*:.*" 
+      - tapOn: "http://.*:.*"
       - waitForAnimationToEnd
-      - tapOn: "Close" # dismiss the bottom sheet
+
+# dismiss bottom sheet if Close button is visible (may not appear in newer Expo versions)
+- runFlow:
+    when:
+      visible: 'Close'
+    commands:
+      - tapOn: "Close"
+      - waitForAnimationToEnd


### PR DESCRIPTION
Fix E2E tests failing due to Close button not found in Expo dev client. Makes the tap conditional and adds back press fallback.