### PR TITLE
feat(mobile): add expandable category cards on dashboard (#65)

### DIFF
--- a/apps/mobile/app/components/ExpandableCategoryCard.tsx
+++ b/apps/mobile/app/components/ExpandableCategoryCard.tsx
@@ -1,0 +1,234 @@
+import { useState, useRef } from "react"
+import {
+  Animated,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  UIManager,
+  View,
+  ViewStyle,
+  TextStyle,
+  StyleProp,
+} from "react-native"
+import { MaterialCommunityIcons } from "@expo/vector-icons"
+
+import { CATEGORY_CONFIG, SubCategory } from "@/data/categoryConfig"
+import type { StatCategory, StatStatus } from "@/data/types/safety"
+import { useAppTheme } from "@/theme/context"
+
+import { CategoryIcon } from "./CategoryIcon"
+import { StatusIndicator } from "./StatusIndicator"
+import { Text } from "./Text"
+
+// Enable LayoutAnimation for Android
+if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true)
+}
+
+export interface ExpandableCategoryCardProps {
+  /**
+   * The safety category to display
+   */
+  category: StatCategory
+  /**
+   * The display name for the category
+   */
+  categoryName: string
+  /**
+   * The overall status for this category
+   */
+  status: StatStatus
+  /**
+   * Callback when the card (or a sub-category) should navigate to details
+   */
+  onPress: (subCategoryId?: string) => void
+  /**
+   * Optional style override for the container
+   */
+  style?: StyleProp<ViewStyle>
+}
+
+/**
+ * An expandable category card that shows sub-categories when expanded.
+ * Categories without sub-categories behave like a regular pressable card.
+ *
+ * For categories with sub-categories:
+ * - Tapping the card expands/collapses to show sub-categories
+ * - Tapping a sub-category navigates to the category detail with that sub-category focused
+ *
+ * @example
+ * <ExpandableCategoryCard
+ *   category={StatCategory.air}
+ *   categoryName="Air Pollution"
+ *   status="warning"
+ *   onPress={(subCategoryId) => navigation.navigate("CategoryDetail", { category: "air", subCategoryId })}
+ * />
+ */
+export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
+  const { category, categoryName, status, onPress, style } = props
+  const { theme } = useAppTheme()
+
+  const categoryConfig = CATEGORY_CONFIG[category]
+  const subCategories = categoryConfig.subCategories || []
+  const hasSubCategories = subCategories.length > 0
+
+  const [expanded, setExpanded] = useState(false)
+  const rotateAnim = useRef(new Animated.Value(0)).current
+
+  const toggleExpand = () => {
+    const newExpanded = !expanded
+
+    // Animate chevron rotation
+    Animated.timing(rotateAnim, {
+      toValue: newExpanded ? 1 : 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start()
+
+    // Animate content expand/collapse
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+
+    setExpanded(newExpanded)
+  }
+
+  const handlePress = () => {
+    if (hasSubCategories) {
+      toggleExpand()
+    } else {
+      onPress()
+    }
+  }
+
+  const handleSubCategoryPress = (subCategory: SubCategory) => {
+    onPress(subCategory.id)
+  }
+
+  const chevronRotation = rotateAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ["0deg", "180deg"],
+  })
+
+  const $container: ViewStyle = {
+    backgroundColor: theme.colors.background,
+    borderRadius: 12,
+    marginHorizontal: 16,
+    marginVertical: 4,
+    shadowColor: theme.colors.palette.neutral800,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+    overflow: "hidden",
+  }
+
+  const $mainRow: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  }
+
+  const $iconContainer: ViewStyle = {
+    marginRight: 12,
+  }
+
+  const $textContainer: ViewStyle = {
+    flex: 1,
+  }
+
+  const $categoryNameText: TextStyle = {
+    fontSize: 16,
+    fontWeight: "600",
+    color: theme.colors.text,
+  }
+
+  const $statusContainer: ViewStyle = {
+    marginLeft: 12,
+  }
+
+  const $chevronContainer: ViewStyle = {
+    marginLeft: 8,
+  }
+
+  const $subCategoriesContainer: ViewStyle = {
+    paddingBottom: 8,
+  }
+
+  const $subCategoryRow: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingLeft: 56, // Indent: icon (28) + iconMarginRight (12) + extra indent (16)
+    paddingRight: 16,
+  }
+
+  const $subCategoryText: TextStyle = {
+    flex: 1,
+    fontSize: 15,
+    color: theme.colors.text,
+  }
+
+  const $subCategoryChevron: ViewStyle = {
+    marginLeft: 8,
+  }
+
+  const $divider: ViewStyle = {
+    height: 1,
+    backgroundColor: theme.colors.separator,
+    marginHorizontal: 16,
+  }
+
+  return (
+    <View style={[$container, style]}>
+      <Pressable
+        onPress={handlePress}
+        style={({ pressed }) => [$mainRow, pressed && { opacity: 0.8 }]}
+        accessibilityRole="button"
+        accessibilityLabel={`${categoryName}, status: ${status}${hasSubCategories ? ", expandable" : ""}`}
+        accessibilityState={hasSubCategories ? { expanded } : undefined}
+      >
+        <View style={$iconContainer}>
+          <CategoryIcon category={category} size={28} />
+        </View>
+        <View style={$textContainer}>
+          <Text style={$categoryNameText}>{categoryName}</Text>
+        </View>
+        <View style={$statusContainer}>
+          <StatusIndicator status={status} size="medium" />
+        </View>
+        {hasSubCategories && (
+          <Animated.View style={[$chevronContainer, { transform: [{ rotate: chevronRotation }] }]}>
+            <MaterialCommunityIcons name="chevron-down" size={24} color={theme.colors.textDim} />
+          </Animated.View>
+        )}
+      </Pressable>
+
+      {expanded && hasSubCategories && (
+        <View style={$subCategoriesContainer}>
+          <View style={$divider} />
+          {subCategories.map((subCategory) => (
+            <Pressable
+              key={subCategory.id}
+              onPress={() => handleSubCategoryPress(subCategory)}
+              style={({ pressed }) => [
+                $subCategoryRow,
+                pressed && { backgroundColor: theme.colors.palette.neutral100 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`${subCategory.name} sub-category`}
+            >
+              <Text style={$subCategoryText}>{subCategory.name}</Text>
+              <View style={$subCategoryChevron}>
+                <MaterialCommunityIcons
+                  name="chevron-right"
+                  size={20}
+                  color={theme.colors.textDim}
+                />
+              </View>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/apps/mobile/app/navigators/navigationTypes.ts
+++ b/apps/mobile/app/navigators/navigationTypes.ts
@@ -30,7 +30,7 @@ export type AppStackParamList = {
   OnboardingZipCodes: undefined
   Demo: NavigatorScreenParams<DemoTabParamList>
   Dashboard: { zipCode?: string } | undefined
-  CategoryDetail: { category: StatCategory; zipCode: string }
+  CategoryDetail: { category: StatCategory; zipCode: string; subCategoryId?: string }
   Report: undefined
   SubscriptionsSettings: undefined
   Profile: undefined

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -43,7 +43,7 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
   props,
 ) {
   const { navigation, route } = props
-  const { category, zipCode } = route.params
+  const { category, zipCode, subCategoryId } = route.params
   const { theme } = useAppTheme()
   const { statDefinitions } = useStatDefinitions()
   const { getWHOThreshold, getThreshold, jurisdictionMap } = useContaminants()
@@ -434,6 +434,7 @@ mapyourhealth://zip/${zipData.zipCode}`
               <ExpandableCard
                 key={subCategory.id}
                 header={<Text style={$subCategoryHeader}>{subCategory.name}</Text>}
+                initiallyExpanded={subCategoryId === subCategory.id}
               >
                 <Text style={$subCategoryDescription}>{subCategory.description}</Text>
                 {subCategory.links?.map((link, idx) => (

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -13,13 +13,14 @@ import {
 import { MaterialCommunityIcons } from "@expo/vector-icons"
 import { formatDistanceToNow } from "date-fns"
 
+import { ExpandableCategoryCard } from "@/components/ExpandableCategoryCard"
 import { LocationHeader } from "@/components/LocationHeader"
 import { NavHeader } from "@/components/NavHeader"
 import { PlacesSearchBar } from "@/components/PlacesSearchBar"
 import { ProfileMenu } from "@/components/ProfileMenu"
 import { RecommendationsSection } from "@/components/RecommendationsSection"
 import { Screen } from "@/components/Screen"
-import { StatCategoryCard, CATEGORY_DISPLAY_NAMES } from "@/components/StatCategoryCard"
+import { CATEGORY_DISPLAY_NAMES } from "@/components/StatCategoryCard"
 import { Text } from "@/components/Text"
 import { WarningBanner } from "@/components/WarningBanner"
 import { useAuth } from "@/context/AuthContext"
@@ -735,13 +736,17 @@ mapyourhealth://zip/${zipData.zipCode}`
       {/* Category Cards */}
       <View style={$categoriesContainer}>
         {categories.map((category) => (
-          <StatCategoryCard
+          <ExpandableCategoryCard
             key={category}
             category={category}
             categoryName={CATEGORY_DISPLAY_NAMES[category]}
             status={getStatusForCategory(category)}
-            onPress={() => {
-              navigation.navigate("CategoryDetail", { category, zipCode: currentZipCode })
+            onPress={(subCategoryId) => {
+              navigation.navigate("CategoryDetail", {
+                category,
+                zipCode: currentZipCode,
+                subCategoryId,
+              })
             }}
           />
         ))}


### PR DESCRIPTION
## Summary
- Create ExpandableCategoryCard component that combines category card with expand/collapse for sub-categories
- Categories with sub-categories (Air Pollution, Pathogens) show chevron and expand to reveal nested sub-categories
- Categories without sub-categories (Tap Water, Disaster Risk) navigate directly to detail screen
- Add subCategoryId to CategoryDetail navigation params
- Auto-expand matching sub-category when navigating from dashboard

## Changes
- New `ExpandableCategoryCard` component
- Updated `DashboardScreen` to use ExpandableCategoryCard
- Updated `CategoryDetailScreen` to accept subCategoryId and auto-expand
- Updated navigation types for new param

## Test plan
- [ ] Tap "Air Pollution" on dashboard - expands to show "Radon"
- [ ] Tap "Pathogens" on dashboard - expands to show "Lyme Disease"
- [ ] Tap "Tap Water Quality" - navigates directly to detail
- [ ] Tap "Disaster Risk" - navigates directly to detail
- [ ] Tap sub-category (e.g., "Radon") - navigates to detail with sub-category expanded
- [ ] Expand/collapse animation is smooth

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)