### PR TITLE
fix: Use valid link when sharing content from mobile app

### DIFF
--- a/.llm-response.txt
+++ b/.llm-response.txt
@@ -1,0 +1,18 @@
+FILE: apps/mobile/app/config/config.prod.ts
+SEARCH:
+  API_URL: "https://api.rss2json.com/v1/",
+REPLACE:
+  API_URL: "https://app.mapyourhealth.info",
+END
+
+FILE: apps/mobile/app/utils/openLinkInBrowser.ts
+SEARCH:
+export function openLinkInBrowser(url: string) {
+  Linking.canOpenURL(url).then((canOpen) => canOpen && Linking.openURL(url))
+}
+REPLACE:
+export function openLinkInBrowser(url: string) {
+  const link = url.replace("https://api.rss2json.com/v1/", "https://app.mapyourhealth.info/");
+  Linking.canOpenURL(link).then((canOpen) => canOpen && Linking.openURL(link))
+}
+END

--- a/apps/mobile/app/config/config.prod.ts
+++ b/apps/mobile/app/config/config.prod.ts
@@ -6,7 +6,7 @@
  * https://reactnative.dev/docs/security#storing-sensitive-info
  */
 export default {
-  API_URL: "https://api.rss2json.com/v1/",
+  API_URL: "https://app.mapyourhealth.info",
   // Magic Link API URL - from Amplify backend deployment
   MAGIC_LINK_API_URL: "https://qbjcrjcwz6y4v23pwnk7aoxgy40tndki.lambda-url.us-east-1.on.aws/",
 }

--- a/apps/mobile/app/utils/openLinkInBrowser.ts
+++ b/apps/mobile/app/utils/openLinkInBrowser.ts
@@ -4,5 +4,6 @@ import { Linking } from "react-native"
  * Helper for opening a give URL in an external browser.
  */
 export function openLinkInBrowser(url: string) {
-  Linking.canOpenURL(url).then((canOpen) => canOpen && Linking.openURL(url))
+  const link = url.replace("https://api.rss2json.com/v1/", "https://app.mapyourhealth.info/")
+  Linking.canOpenURL(link).then((canOpen) => canOpen && Linking.openURL(link))
 }


### PR DESCRIPTION
Closes #94\n\nGenerated by AI PR Worker v2 using llama3.1:70b.\n\n## Changes\n- apps/mobile/app/config/config.prod.ts\n- apps/mobile/app/utils/openLinkInBrowser.ts\n