### PR TITLE
fix: Use valid share links (app.mapyourhealth.info)

### DIFF
--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -138,8 +138,8 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
 
     const deepLink =
       zipData.cityName && zipData.state
-        ? `mapyourhealth://location/${encodeURIComponent(zipData.cityName)}/${zipData.state}/US`
-        : `mapyourhealth://location/${encodeURIComponent(zipData.zipCode)}//US`
+        ? `https://app.mapyourhealth.info/location/${encodeURIComponent(zipData.cityName)}/${zipData.state}/US`
+        : `https://app.mapyourhealth.info/location/${encodeURIComponent(zipData.zipCode)}//US`
 
     const shareMessage = `${categoryName} Risk Report for ${locationName}
 

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -292,7 +292,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
 
 ${categoryRisks || "No risks detected"}
 
-Check MapYourHealth for details.`
+Check MapYourHealth for details: https://app.mapyourhealth.info`
 
     try {
       await Share.share({


### PR DESCRIPTION
Closes #94

## Changes
- **CategoryDetailScreen.tsx**: Updated deep link URLs from `mapyourhealth://` to `https://app.mapyourhealth.info/` in share messages
- **DashboardScreen.tsx**: Added `https://app.mapyourhealth.info` link to share message

## Minimal diff
2 files changed, 3 insertions, 3 deletions. No other files touched.