### PR TITLE
chore: disable automatic E2E test triggers

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -1,11 +1,11 @@
 name: iOS E2E Tests
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-ios.yml'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - '.github/workflows/e2e-ios.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-orchestrated.yml
+++ b/.github/workflows/e2e-orchestrated.yml
@@ -1,18 +1,18 @@
 name: E2E Orchestrated Testing
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-orchestrated.yml'
-      - 'apps/mobile/.maestro/**'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-orchestrated.yml'
-      - 'apps/mobile/.maestro/**'
+  # pull_request:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - '.github/workflows/e2e-orchestrated.yml'
+  #     - 'apps/mobile/.maestro/**'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - '.github/workflows/e2e-orchestrated.yml'
+  #     - 'apps/mobile/.maestro/**'
   workflow_dispatch:
     inputs:
       test_category:

--- a/.github/workflows/e2e-orchestration.yml
+++ b/.github/workflows/e2e-orchestration.yml
@@ -1,19 +1,19 @@
 name: E2E Test Orchestration v1.0
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - 'scripts/e2e-test-runner.sh'
-      - '.github/workflows/e2e-orchestration.yml'
-      - '.maestro/**'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - 'scripts/e2e-test-runner.sh'
-      - '.github/workflows/e2e-orchestration.yml'
+  # pull_request:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - 'scripts/e2e-test-runner.sh'
+  #     - '.github/workflows/e2e-orchestration.yml'
+  #     - '.maestro/**'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - 'scripts/e2e-test-runner.sh'
+  #     - '.github/workflows/e2e-orchestration.yml'
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,11 +6,11 @@ on:
   #   paths:
   #     - 'apps/mobile/**'
   #     - '.github/workflows/e2e-tests.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-tests.yml'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/mobile/**'
+  #     - '.github/workflows/e2e-tests.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -1,16 +1,16 @@
 name: Playwright Tests
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/admin/**'
-      - '.github/workflows/playwright-tests.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/admin/**'
-      - '.github/workflows/playwright-tests.yml'
+  # pull_request:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/admin/**'
+  #     - '.github/workflows/playwright-tests.yml'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'apps/admin/**'
+  #     - '.github/workflows/playwright-tests.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Commented out automatic `push` and `pull_request` triggers on all 5 E2E workflow files
- Preserved `workflow_dispatch` on every workflow so tests can still be triggered manually
- Affected workflows: `e2e-tests.yml`, `e2e-ios.yml`, `playwright-tests.yml`, `e2e-orchestrated.yml`, `e2e-orchestration.yml`

This reduces CI load by stopping E2E tests from running automatically on every push/PR, while keeping the ability to run them on-demand.

## Test plan
- [ ] Verify no E2E workflows trigger on a push to main
- [ ] Verify workflows can still be triggered manually via Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)