### PR TITLE
feat: move status indicators to sub-categories with WHO orange (#149)

### DIFF
--- a/apps/mobile/app/components/ExpandableCategoryCard.tsx
+++ b/apps/mobile/app/components/ExpandableCategoryCard.tsx
@@ -22,6 +22,16 @@ import { Text } from "./Text"
 const ANIMATION_DURATION = 300
 const EASING = Easing.bezier(0.4, 0, 0.2, 1)
 
+/**
+ * Result from getSubCategoryStatus callback
+ */
+export interface SubCategoryStatusResult {
+  /** The safety status for the sub-category */
+  status: StatStatus
+  /** Optional color override (e.g., orange for WHO-only exceedances) */
+  color?: string
+}
+
 export interface ExpandableCategoryCardProps {
   /**
    * The safety category to display
@@ -33,12 +43,18 @@ export interface ExpandableCategoryCardProps {
   categoryName: string
   /**
    * The overall status for this category
+   * @deprecated No longer displayed on the main row; kept for accessibility label
    */
   status: StatStatus
   /**
    * Callback when the card (or a sub-category) should navigate to details
    */
   onPress: (subCategoryId?: string) => void
+  /**
+   * Callback to determine status and color for a sub-category.
+   * Returns status and optional color override.
+   */
+  getSubCategoryStatus?: (subCategoryId: string) => SubCategoryStatusResult
   /**
    * Optional style override for the container
    */
@@ -62,7 +78,7 @@ export interface ExpandableCategoryCardProps {
  * />
  */
 export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
-  const { category, categoryName, status, onPress, style } = props
+  const { category, categoryName, status, onPress, getSubCategoryStatus, style } = props
   const { theme } = useAppTheme()
   const { getSubCategoriesByCategoryId } = useCategories()
 
@@ -189,10 +205,6 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
     color: theme.colors.text,
   }
 
-  const $statusContainer: ViewStyle = {
-    marginLeft: 12,
-  }
-
   const $chevronContainer: ViewStyle = {
     marginLeft: 8,
   }
@@ -219,6 +231,10 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
     color: theme.colors.text,
   }
 
+  const $subCategoryStatusContainer: ViewStyle = {
+    marginLeft: 8,
+  }
+
   const $subCategoryChevron: ViewStyle = {
     marginLeft: 8,
   }
@@ -242,6 +258,7 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
       {subCategories.map((subCategory) => {
         // Handle both dynamic SubCategory (subCategoryId) and legacy SubCategory (id)
         const key = "subCategoryId" in subCategory ? subCategory.subCategoryId : subCategory.id
+        const subCategoryStatusResult = getSubCategoryStatus?.(key)
         return (
           <Pressable
             key={key}
@@ -251,9 +268,18 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
               pressed && { backgroundColor: theme.colors.palette.neutral100 },
             ]}
             accessibilityRole="button"
-            accessibilityLabel={`${subCategory.name} sub-category`}
+            accessibilityLabel={`${subCategory.name} sub-category${subCategoryStatusResult ? `, status: ${subCategoryStatusResult.status}` : ""}`}
           >
             <Text style={$subCategoryText}>{subCategory.name}</Text>
+            {subCategoryStatusResult && (
+              <View style={$subCategoryStatusContainer}>
+                <StatusIndicator
+                  status={subCategoryStatusResult.status}
+                  size="small"
+                  color={subCategoryStatusResult.color}
+                />
+              </View>
+            )}
             <View style={$subCategoryChevron}>
               <MaterialCommunityIcons name="chevron-right" size={20} color={theme.colors.textDim} />
             </View>
@@ -277,9 +303,6 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
         </View>
         <View style={$textContainer}>
           <Text style={$categoryNameText}>{categoryName}</Text>
-        </View>
-        <View style={$statusContainer}>
-          <StatusIndicator status={status} size="medium" />
         </View>
         {hasSubCategories ? (
           <Animated.View style={[$chevronContainer, animatedChevronStyle]}>

--- a/apps/mobile/app/components/StatusIndicator.tsx
+++ b/apps/mobile/app/components/StatusIndicator.tsx
@@ -33,6 +33,10 @@ export interface StatusIndicatorProps {
    */
   size?: IndicatorSize
   /**
+   * Optional color override (e.g., orange for WHO-only exceedances)
+   */
+  color?: string
+  /**
    * Optional style override for the container
    */
   style?: StyleProp<ViewStyle>
@@ -46,10 +50,10 @@ export interface StatusIndicatorProps {
  * <StatusIndicator status="danger" size="large" />
  */
 export function StatusIndicator(props: StatusIndicatorProps) {
-  const { status, size = "medium", style } = props
+  const { status, size = "medium", color, style } = props
 
   const dimension = SIZE_DIMENSIONS[size]
-  const backgroundColor = STATUS_COLORS[status]
+  const backgroundColor = color ?? STATUS_COLORS[status]
 
   const $indicatorStyle: ViewStyle = {
     width: dimension,

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -15,7 +15,10 @@ import { CommonActions } from "@react-navigation/native"
 import { formatDistanceToNow } from "date-fns"
 
 import { Card } from "@/components/Card"
-import { ExpandableCategoryCard } from "@/components/ExpandableCategoryCard"
+import {
+  ExpandableCategoryCard,
+  SubCategoryStatusResult,
+} from "@/components/ExpandableCategoryCard"
 import { LocationHeader } from "@/components/LocationHeader"
 import { NavHeader } from "@/components/NavHeader"
 import { PlacesSearchBar } from "@/components/PlacesSearchBar"
@@ -27,6 +30,7 @@ import { Text } from "@/components/Text"
 import { WarningBanner } from "@/components/WarningBanner"
 import { useAuth } from "@/context/AuthContext"
 import { useCategories } from "@/context/CategoriesContext"
+import { useContaminants } from "@/context/ContaminantsContext"
 import { usePendingAction } from "@/context/PendingActionContext"
 import { useStatDefinitions } from "@/context/StatDefinitionsContext"
 import { useSubscriptions } from "@/context/SubscriptionsContext"
@@ -37,6 +41,9 @@ import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { useAppTheme } from "@/theme/context"
 import { getJurisdictionForState } from "@/utils/jurisdiction"
 // postalCode utilities removed - using city-level granularity
+
+/** Orange color for WHO-only exceedances */
+const WHO_EXCEEDANCE_COLOR = "#F97316"
 
 interface DashboardScreenProps extends AppStackScreenProps<"Dashboard"> {}
 
@@ -80,6 +87,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   const { isAuthenticated, user, logout } = useAuth()
   const { setPendingAction } = usePendingAction()
   const { statDefinitions } = useStatDefinitions()
+  const { contaminants, getThreshold, getWHOThreshold } = useContaminants()
   const { primarySubscription, addSubscription, isLoading: subsLoading } = useSubscriptions()
   const { getLocationZipCode, isLocating } = useLocation()
   const { getCategoryName } = useCategories()
@@ -168,6 +176,83 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
       return getWorstStatusForCategory(zipData, category, statDefinitions)
     },
     [zipData, statDefinitions],
+  )
+
+  // Determine the jurisdiction code for the current location
+  const currentJurisdictionCode = useMemo(() => {
+    if (!currentLocation) return "WHO"
+    return getJurisdictionForState(currentLocation.state, currentLocation.country)
+  }, [currentLocation])
+
+  // Get sub-category status with WHO-vs-national color coding
+  const getSubCategoryStatusForCategory = useCallback(
+    (subCategoryId: string): SubCategoryStatusResult => {
+      if (!zipData) return { status: "safe" }
+
+      // Find contaminants that belong to this sub-category
+      const subCategoryContaminants = contaminants.filter((c) => c.category === subCategoryId)
+      const subCategoryContaminantIds = new Set(subCategoryContaminants.map((c) => c.id))
+
+      // Filter measurements for this sub-category
+      const relevantStats = zipData.stats.filter((stat) =>
+        subCategoryContaminantIds.has(stat.statId),
+      )
+
+      if (relevantStats.length === 0) return { status: "safe" }
+
+      let hasNationalExceedance = false
+      let hasWHOOnlyExceedance = false
+
+      for (const stat of relevantStats) {
+        if (stat.status === "safe") continue
+
+        // Check if this exceedance is against national/state threshold or WHO-only
+        const nationalThreshold = getThreshold(stat.statId, currentJurisdictionCode)
+        const whoThreshold = getWHOThreshold(stat.statId)
+        const contaminant = subCategoryContaminants.find((c) => c.id === stat.statId)
+        const higherIsBad = contaminant?.higherIsBad ?? true
+
+        // Check if the measurement exceeds the national/state threshold
+        let exceedsNational = false
+        if (
+          nationalThreshold &&
+          nationalThreshold.jurisdictionCode !== "WHO" &&
+          nationalThreshold.limitValue !== null
+        ) {
+          const limit = nationalThreshold.limitValue
+          exceedsNational = higherIsBad ? stat.value >= limit : stat.value <= limit
+        }
+
+        // Check if the measurement exceeds the WHO threshold
+        let exceedsWHO = false
+        if (whoThreshold && whoThreshold.limitValue !== null) {
+          const limit = whoThreshold.limitValue
+          exceedsWHO = higherIsBad ? stat.value >= limit : stat.value <= limit
+        }
+
+        if (exceedsNational) {
+          hasNationalExceedance = true
+        } else if (exceedsWHO) {
+          hasWHOOnlyExceedance = true
+        }
+      }
+
+      if (hasNationalExceedance) {
+        return { status: "danger" }
+      }
+      if (hasWHOOnlyExceedance) {
+        return { status: "danger", color: WHO_EXCEEDANCE_COLOR }
+      }
+
+      // Check for warnings (non-exceedance but above warning threshold)
+      const hasWarning = relevantStats.some((stat) => stat.status === "warning")
+      if (hasWarning) {
+        return { status: "warning" }
+      }
+
+      return { status: "safe" }
+    },
+    [zipData, contaminants, getThreshold, getWHOThreshold, currentJurisdictionCode],
   )
 
   // Categories to display (water and air only - health and disaster removed per issue #126)
@@ -795,6 +880,7 @@ View details: ${shareUrl}`
               category={category}
               categoryName={getCategoryDisplayName(category)}
               status={getStatusForCategory(category)}
+              getSubCategoryStatus={getSubCategoryStatusForCategory}
               onPress={(subCategoryId) => {
                 navigation.navigate("CategoryDetail", {
                   category,


### PR DESCRIPTION
## Summary
- Removed `StatusIndicator` from main category rows in `ExpandableCategoryCard`
- Added `StatusIndicator` to each sub-category row with status callback
- WHO-only exceedances show orange (`#F97316`) instead of red
- National/state exceedances continue showing red

Closes #149

## Test plan
- [ ] Verify main category rows no longer show status indicators
- [ ] Verify sub-category rows show status indicators
- [ ] Find a contaminant exceeding WHO threshold only — should show orange
- [ ] Find a contaminant exceeding national/state threshold — should show red
- [ ] Sub-categories with no exceedances show green or no indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)