### PR TITLE
fix: grant write permission for Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

- The `claude-code-review.yml` workflow had `pull-requests: read`, so it ran successfully but could never post review comments on PRs
- Changed to `pull-requests: write` so the action can actually submit reviews

## Test plan

- [x] Verify the workflow triggers on this PR
- [ ] Confirm a review comment is posted by Claude Code Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)