### PR TITLE
feat: add summary comment to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
@@ -39,6 +39,34 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Post review summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: user } = await github.rest.users.getAuthenticated();
+
+            const { data: comments } = await github.rest.pulls.listReviewComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 1,
+              sort: 'created',
+              direction: 'desc',
+            });
+
+            const recentComment = comments.find(c => c.user.login === user.login);
+            const hasFindings = !!recentComment;
+
+            const body = hasFindings
+              ? `**Claude Code Review** completed with inline comments.\n\n_Review posted by \`${user.login}\` (run [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}))_`
+              : `**Claude Code Review** completed — no issues found.\n\n_Review posted by \`${user.login}\` (run [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}))_`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
 


### PR DESCRIPTION
## Summary

- Always post a PR comment after Claude Code Review showing whether issues were found
- Shows the authenticated GitHub account name (to verify which OAuth token is in use)
- Grant `issues: write` permission so the summary comment can be posted

**Must be merged to `main` before it takes effect** — the claude-code-action validates that the workflow file matches the default branch.

## Test plan

- [ ] Merge this PR, then push to any open PR — verify a summary comment appears with the account name

🤖 Generated with [Claude Code](https://claude.com/claude-code)