### PR TITLE
fix: use original GITHUB_TOKEN for review summary comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { data: user } = await github.rest.users.getAuthenticated();
 


### PR DESCRIPTION
## Summary

The `claude-code-action` replaces `GITHUB_TOKEN` with an OIDC-exchanged app installation token during its run. The subsequent `github-script` step inherits this swapped token, which doesn't have `issues:write` — causing a 403 on `issues.createComment`.

Fix: explicitly pass `secrets.GITHUB_TOKEN` to the `github-script` step.

## Test plan

- [ ] Merge → push to any open PR → verify summary comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)