### PR TITLE
feat: enable international location search (#176)

### DIFF
--- a/packages/backend/amplify/functions/places-autocomplete/handler.ts
+++ b/packages/backend/amplify/functions/places-autocomplete/handler.ts
@@ -213,8 +213,6 @@ async function fetchPlacesAutocomplete(
   const params = new URLSearchParams({
     input: query,
     key: GOOGLE_PLACES_API_KEY,
-    // Bias towards US/Canada
-    components: 'country:us|country:ca',
   });
 
   if (sessionToken) {


### PR DESCRIPTION
## Summary
- Removes `components: 'country:us|country:ca'` restriction from Google Places autocomplete Lambda
- Users can now search for cities worldwide (Paris France, London UK, Tokyo Japan, etc.)
- International cities fall back to WHO jurisdiction thresholds

## Why this is safe
- `getJurisdictionForLocation()` already falls back to `"WHO"` for unknown countries
- `sortPlacesPredictions()` sorts by place type, not country — works globally
- `resolveLocation` Lambda has no country restrictions
- Cities without measurement data gracefully show empty state

## Test plan
- [x] Search "Paris" → shows Paris, France (not just Paris, TX)
- [x] Search "London" → shows London, UK
- [x] Search "Montreal" → still shows Montreal, QC, Canada first
- [ ] Select international city → dashboard loads with WHO fallback

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)