### PR TITLE
feat: enhanced standards table UX and contaminant modal cleanup

### DIFF
--- a/apps/admin/src/app/(admin)/zip-codes/[zipCode]/page.tsx
+++ b/apps/admin/src/app/(admin)/zip-codes/[zipCode]/page.tsx
@@ -597,7 +597,7 @@ export default function LocationDetailPage({
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="source">Source</Label>
+                  <Label htmlFor="source">Data Source</Label>
                   <Input
                     id="source"
                     placeholder="e.g., EPA, CDC, Local Health Dept"
@@ -675,7 +675,9 @@ export default function LocationDetailPage({
                   <TableHead>Category</TableHead>
                   <TableHead>Value</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead>Source</TableHead>
+                  <TableHead title="Where the measurement data was obtained — not the regulatory standard">
+                    Data Source
+                  </TableHead>
                   <TableHead>Date</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>

--- a/apps/mobile/app/components/ContaminantTable.tsx
+++ b/apps/mobile/app/components/ContaminantTable.tsx
@@ -143,9 +143,12 @@ export function ContaminantTable(props: ContaminantTableProps) {
 
   const localJurisdictionLabel = rows.length > 0 ? rows[0].localJurisdictionName : "LOCAL"
 
-  const formatValue = (value: number | null, isUnregulated?: boolean): string => {
-    if (isUnregulated) return "UNREGULATED"
-    if (value === null) return "NO STANDARD"
+  const formatValue = (
+    value: number | null,
+    options?: { isUnregulated?: boolean; isLocal?: boolean },
+  ): string => {
+    if (options?.isUnregulated) return "UNREGULATED"
+    if (value === null) return options?.isLocal ? "N/A" : "NO STANDARD"
     return `${value} ${displayUnit}`
   }
 
@@ -197,7 +200,7 @@ export function ContaminantTable(props: ContaminantTableProps) {
             <Text
               style={row.localLimit === null || row.isUnregulated ? $unregulatedText : $valueText}
             >
-              {formatValue(row.localLimit, row.isUnregulated)}
+              {formatValue(row.localLimit, { isUnregulated: row.isUnregulated, isLocal: true })}
             </Text>
           </View>
           <View style={$valueCell}>

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -103,6 +103,7 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
     return stats.map(({ stat, definition }) => {
       const whoThreshold = getWHOThreshold(stat.statId)
       const localThreshold = getThreshold(stat.statId, localJurisdictionCode)
+      const hasLocalThreshold = localThreshold != null && localThreshold.jurisdictionCode !== "WHO"
 
       return {
         name: definition.name,
@@ -110,10 +111,10 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
         value: stat.value,
         unit: definition.unit,
         whoLimit: whoThreshold?.limitValue ?? null,
-        localLimit: localThreshold?.limitValue ?? null,
+        localLimit: hasLocalThreshold ? (localThreshold.limitValue ?? null) : null,
         localJurisdictionName,
         status: stat.status,
-        isUnregulated: localThreshold?.status === "not_controlled",
+        isUnregulated: hasLocalThreshold && localThreshold.status === "not_controlled",
       }
     })
   }, [stats, category, getWHOThreshold, getThreshold, localJurisdictionCode, localJurisdictionName])


### PR DESCRIPTION
## Summary
- Table column headers show actual jurisdiction name (e.g. "NEW YORK STATE", "QUEBEC") instead of "Local"
- Local standards column placed before WHO column
- Local standards link appears above WHO link
- When no local thresholds exist (e.g. Atlanta), LOCAL column shows "N/A" instead of duplicating WHO values
- Added alternating row colors and visible row separators
- Table spans full width (removed horizontal padding)
- Column headers are plain text (not clickable links)
- Removed References section from contaminant health info modal
- Removed auto-generated "Special Warning" banner from dashboard (admin Warning Banners still work)
- Admin portal: renamed "Source" to "Data Source" with tooltip

## Test plan
- [ ] New York → LOCAL header says "NEW YORK STATE" with actual values
- [ ] Montreal → LOCAL header says "QUEBEC" with QC values
- [ ] Atlanta → LOCAL column shows "N/A"
- [ ] No yellow "Special Warning" banner on dashboard
- [ ] Admin Warning Banners still display correctly
- [ ] Contaminant info modal shows only Health Concerns, no References
- [ ] Admin portal shows "Data Source" column header

🤖 Generated with [Claude Code](https://claude.com/claude-code)