### PR TITLE
fix: resolve undefined in CategoryDetail URL on web

### DIFF
--- a/apps/mobile/app/navigators/AppNavigator.tsx
+++ b/apps/mobile/app/navigators/AppNavigator.tsx
@@ -142,6 +142,7 @@ const linking: LinkingOptions<AppStackParamList> = {
           city: (city: string) => encodeURIComponent(city),
           state: (state: string) => encodeURIComponent(state),
           country: (country: string) => encodeURIComponent(country),
+          category: (category: string) => encodeURIComponent(category),
         },
       },
       StatTrend: {

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -858,7 +858,7 @@ View details: ${shareUrl}`
                   city: currentLocation?.city || "",
                   state: currentLocation?.state || "",
                   country: currentLocation?.country || "",
-                  subCategoryId,
+                  ...(subCategoryId ? { subCategoryId } : {}),
                 })
               }}
             />


### PR DESCRIPTION
## Summary
- Add missing `category` stringify function in the `CategoryDetail` linking config, which caused `/undefined` in the URL path on web
- Conditionally pass `subCategoryId` in navigation params to avoid `?subCategoryId=undefined` in the query string

## Test plan
- [ ] Navigate to a category from the Dashboard on web and verify the URL is `/location/{city}/{state}/{country}/category/{category}` (no `undefined`)
- [ ] Navigate to a sub-category and verify `?subCategoryId={id}` appears only when a sub-category is selected
- [ ] Verify category navigation still works correctly on iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)