### PR TITLE
ci: add web landing page deploy workflow and CI checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,6 +63,27 @@ jobs:
       - name: Lint mobile
         run: yarn workspace @mapyourhealth/mobile lint:check
 
+  lint-web:
+    name: Lint Web
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint web
+        run: yarn workspace @mapyourhealth/web lint:check
+
   lint-admin:
     name: Lint Admin
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,6 @@ jobs:
   lint-web:
     name: Lint Web
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -63,6 +63,41 @@ jobs:
       - name: Type check mobile
         run: yarn workspace @mapyourhealth/mobile compile
 
+  type-check-web:
+    name: Type Check Web
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Generate Amplify outputs
+        run: |
+          npx ampx generate outputs \
+            --branch main \
+            --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
+            --out-dir apps/web
+
+      - name: Type check web
+        run: yarn workspace @mapyourhealth/web compile
+
   type-check-admin:
     name: Type Check Admin
     runs-on: ubuntu-latest

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -66,7 +66,6 @@ jobs:
   type-check-web:
     name: Type Check Web
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -34,31 +34,10 @@ jobs:
           timeoutSeconds: 300
           intervalSeconds: 10
 
-  detect-changes:
-    name: Detect Web Changes
-    runs-on: ubuntu-latest
-    needs: wait-for-checks
-    outputs:
-      web_changed: ${{ steps.changes.outputs.web }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for web changes
-        id: changes
-        run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -qE '^(apps/web/|packages/backend/amplify/data/|amplify\.yml|package\.json|yarn\.lock)'; then
-            echo "web=true" >> $GITHUB_OUTPUT
-          else
-            echo "web=false" >> $GITHUB_OUTPUT
-          fi
-
   web-deploy:
     name: Deploy Web Landing Page
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.web_changed == 'true' || github.event_name == 'workflow_dispatch'
+    needs: wait-for-checks
     environment:
       name: production
     steps:
@@ -72,6 +51,6 @@ jobs:
       - name: Deploy Web Landing Page
         run: |
           aws amplify start-job \
-            --app-id dv0j563gt073v \
+            --app-id ${{ secrets.AMPLIFY_WEB_APP_ID }} \
             --branch-name main \
             --job-type RELEASE

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,77 @@
+name: Web Landing Page CI/CD
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/backend/amplify/data/**'
+      - 'amplify.yml'
+      - 'package.json'
+      - 'yarn.lock'
+  workflow_dispatch:
+
+jobs:
+  wait-for-checks:
+    name: Wait for Lint and Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for lint workflow
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Lint Web
+          ref: ${{ github.sha }}
+          timeoutSeconds: 300
+          intervalSeconds: 10
+
+      - name: Wait for type-check workflow
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Type Check Web
+          ref: ${{ github.sha }}
+          timeoutSeconds: 300
+          intervalSeconds: 10
+
+  detect-changes:
+    name: Detect Web Changes
+    runs-on: ubuntu-latest
+    needs: wait-for-checks
+    outputs:
+      web_changed: ${{ steps.changes.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for web changes
+        id: changes
+        run: |
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -qE '^(apps/web/|packages/backend/amplify/data/|amplify\.yml|package\.json|yarn\.lock)'; then
+            echo "web=true" >> $GITHUB_OUTPUT
+          else
+            echo "web=false" >> $GITHUB_OUTPUT
+          fi
+
+  web-deploy:
+    name: Deploy Web Landing Page
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web_changed == 'true' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: production
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Deploy Web Landing Page
+        run: |
+          aws amplify start-job \
+            --app-id dv0j563gt073v \
+            --branch-name main \
+            --job-type RELEASE


### PR DESCRIPTION
## Summary
- Add `web-deploy.yml` — path-based GitHub Actions deploy workflow for `apps/web` (Next.js landing page), triggered on push to `main` when `apps/web/**`, backend data, `amplify.yml`, `package.json`, or `yarn.lock` change
- Add **Lint Web** job to `lint.yml` — runs `yarn workspace @mapyourhealth/web lint:check`
- Add **Type Check Web** job to `type-check.yml` — generates Amplify outputs then runs `yarn workspace @mapyourhealth/web compile`
- Amplify auto-build disabled on app `dv0j563gt073v` — deployments now controlled exclusively by this workflow

Follows the same pattern as `admin-deploy.yml`: wait for lint/type-check → detect path changes → trigger `aws amplify start-job`.

## Test plan
- [ ] Verify lint and type-check jobs appear in CI for this PR
- [ ] After merge, push a change to `apps/web/` and confirm the deploy workflow triggers
- [ ] Confirm Amplify no longer auto-builds on push (auto-build disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)