### PR TITLE
fix: highlight active language on initial load (#221)

### DIFF
--- a/apps/web/src/components/language-selector.tsx
+++ b/apps/web/src/components/language-selector.tsx
@@ -10,7 +10,7 @@ const languages: { code: Language; label: string }[] = [
 
 export function LanguageSelector() {
   const { i18n } = useTranslation();
-  const currentLang = i18n.language as Language;
+  const currentLang = (i18n.resolvedLanguage ?? i18n.language) as Language;
 
   return (
     <div className="z-50 flex gap-1 rounded-full bg-primary-500 p-1 shadow-lg">

--- a/apps/web/src/lib/i18n/index.ts
+++ b/apps/web/src/lib/i18n/index.ts
@@ -9,7 +9,7 @@ i18n
   .init({
     resources,
     fallbackLng: "en",
-    supportedLngs: ["en", "fr", "ar"],
+    supportedLngs: ["en", "fr"],
     load: "languageOnly",
     interpolation: { escapeValue: false },
     detection: {

--- a/apps/web/src/lib/i18n/index.ts
+++ b/apps/web/src/lib/i18n/index.ts
@@ -9,6 +9,8 @@ i18n
   .init({
     resources,
     fallbackLng: "en",
+    supportedLngs: ["en", "fr", "ar"],
+    load: "languageOnly",
     interpolation: { escapeValue: false },
     detection: {
       order: ["localStorage", "navigator"],


### PR DESCRIPTION
## Summary
- Fixes epiphanyapps/mapyourhealth#221 — neither "En" nor "Fr" appeared highlighted on first load of mapyourhealth.info.
- Root cause: `i18next-browser-languagedetector` can return region-scoped codes (e.g. `en-US`) from `navigator.language`, which don't match the resource keys (`en`, `fr`, `ar`). The selector's equality check `i18n.language === code` therefore failed for every button.
- Config fix: add `supportedLngs` and `load: "languageOnly"` so detected locales are normalized to the base language.
- Component fix: read `i18n.resolvedLanguage` (with `i18n.language` fallback) in `language-selector.tsx` so the UI reflects the actually-loaded resource.

## Test plan
- [ ] Load https://mapyourhealth.info/ in a fresh browser profile with `navigator.language = en-US` and confirm "En" is highlighted.
- [ ] Click "Fr" → content switches to French and "Fr" is highlighted; refresh and confirm "Fr" stays highlighted (localStorage persistence).
- [ ] Clear localStorage, set browser language to `fr-CA`, reload, confirm "Fr" is highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)