### PR TITLE
fix(backend): allow landing page and localhost:3001 as newsletter callback hosts

### DIFF
--- a/packages/backend/amplify/functions/subscribe-to-newsletter/handler.ts
+++ b/packages/backend/amplify/functions/subscribe-to-newsletter/handler.ts
@@ -55,10 +55,13 @@ export const handler: Schema["subscribeToNewsletter"]["functionHandler"] = async
   const ALLOWED_HOSTS = [
     "mapyourhealth.info",
     "www.mapyourhealth.info",
+    "main.dv0j563gt073v.amplifyapp.com",
     "localhost",
     "localhost:3000",
+    "localhost:3001",
     "127.0.0.1",
     "127.0.0.1:3000",
+    "127.0.0.1:3001",
   ];
 
   const host = callbackURL?.replace(/\/$/, "") || "mapyourhealth.info";


### PR DESCRIPTION
## Summary

Adds three entries to the newsletter sign-up lambda's `ALLOWED_HOSTS` allowlist:
- `main.dv0j563gt073v.amplifyapp.com` — current default landing page URL (no custom domain configured yet)
- `localhost:3001` — the port `yarn workspace @mapyourhealth/web dev` falls back to when `3000` is taken
- `127.0.0.1:3001` — IPv4 variant of the above

Without these, the lambda returns "Invalid callback URL" and no confirmation email is sent. Discovered while testing signup from the deployed landing page and during local dev.

Companion to #224 (frontend auth-mode + copy + hydration fixes). Merging both is required for end-to-end signup to work.

## Test plan
- [x] Existing `handler.test.ts` callback-URL-whitelist suite still passes (15/15)
- [ ] After deploy, submit from https://main.dv0j563gt073v.amplifyapp.com/ with a real email and confirm the confirmation email arrives
- [ ] Verify `localhost:3001` signup works locally end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)