### PR TITLE
fix(ci): remove duplicate lint-web and type-check-web jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,26 +103,6 @@ jobs:
       - name: Lint mobile
         run: yarn workspace @mapyourhealth/mobile lint:check
 
-  lint-web:
-    name: Lint Web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Lint web
-        run: yarn workspace @mapyourhealth/web lint:check
-
   lint-admin:
     name: Lint Admin
     needs: changes

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -102,40 +102,6 @@ jobs:
       - name: Type check mobile
         run: yarn workspace @mapyourhealth/mobile compile
 
-  type-check-web:
-    name: Type Check Web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-
-      - name: Generate Amplify outputs
-        run: |
-          npx ampx generate outputs \
-            --branch main \
-            --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
-            --out-dir apps/web
-
-      - name: Type check web
-        run: yarn workspace @mapyourhealth/web compile
-
   type-check-admin:
     name: Type Check Admin
     needs: changes


### PR DESCRIPTION
## Summary

Removes the duplicate `lint-web` and `type-check-web` job definitions from `.github/workflows/lint.yml` and `type-check.yml`. Both files currently define the web job twice — once as a standalone block (landed with #220) and once as part of the path-aware rewrite. GitHub Actions rejects this as a workflow-file error, which is why every recent PR's CI run fails in 0s with "This run likely failed because of a workflow file issue."

Kept the path-aware version (with `needs: changes` and the web filter) and dropped the orphan.

Blocks #224 and #225 (and any other PR) from passing CI until merged.

## Test plan
- [x] `grep -c "^  lint-web:" lint.yml` → 1
- [x] `grep -c "^  type-check-web:" type-check.yml` → 1
- [ ] After merge, confirm #224 and #225 see real CI results

🤖 Generated with [Claude Code](https://claude.com/claude-code)