### PR TITLE
fix(backend): grant newsletter lambdas access to the Data API

### DIFF
--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -732,10 +732,15 @@ const schema = a.schema({
     ]),
 });
 
-export type Schema = ClientSchema<typeof schema>;
+const schemaWithFunctionAccess = schema.authorization((allow) => [
+  allow.resource(subscribeToNewsletter).to(["query", "mutate"]),
+  allow.resource(confirmNewsletter).to(["query", "mutate"]),
+]);
+
+export type Schema = ClientSchema<typeof schemaWithFunctionAccess>;
 
 export const data = defineData({
-  schema,
+  schema: schemaWithFunctionAccess,
   authorizationModes: {
     defaultAuthorizationMode: "userPool",
   },


### PR DESCRIPTION
## Summary

The `subscribeToNewsletter` and `confirmNewsletter` handlers call `dataClient.models.NewsletterSubscriber.*` but their Lambda environment was missing `AMPLIFY_DATA_GRAPHQL_ENDPOINT` and the execution role had no AppSync permissions. Every call hit \`TypeError: Cannot read properties of undefined (reading 'create')\` and surfaced as "Failed to process subscription" in the UI.

Adding schema-level `allow.resource()` entries for both functions makes Amplify inject the env var and attach the IAM policy automatically.

## Why this wasn't caught earlier

Our earlier tests always failed at the callback-URL allowlist step in the handler (runs *before* the data client call). #225 fixed the allowlist and exposed this next layer. Confirmed via CloudWatch after merging #225 — the lambda now gets invoked but throws on `dataClient.models.NewsletterSubscriber.create(...)`.

## Verification

- [x] `yarn workspace @mapyourhealth/backend compile` passes
- [x] `subscribe-to-newsletter` handler Jest: 15/15
- [x] `confirm-newsletter` handler Jest: 5/5
- [ ] After deploy, signup from https://main.dv0j563gt073v.amplifyapp.com/ returns success and a confirmation email arrives

## Deploy path

Backend-only change. Amplify auto-deploys on merge. After deploy, rerun the signup test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)