### PR TITLE
fix(web): configure Amplify at module load, not in useEffect

### DIFF
--- a/apps/web/src/providers/amplify-provider.tsx
+++ b/apps/web/src/providers/amplify-provider.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
 import { Amplify } from "aws-amplify";
 import outputs from "@/lib/amplify";
 
-let configured = false;
+Amplify.configure(outputs, { ssr: true });
 
 export function AmplifyProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    if (!configured) {
-      Amplify.configure(outputs);
-      configured = true;
-    }
-  }, []);
-
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- ConfirmPage's \`useEffect\` (child) fires before AmplifyProvider's \`useEffect\` (parent), so \`Amplify.configure\` hadn't run when \`confirmNewsletter\` was called. The IAM client had no guest credentials and the mutation threw client-side — surfacing as \"There was an error confirming your subscription.\" with no Lambda invocation (log group doesn't exist).
- Move \`Amplify.configure(outputs, { ssr: true })\` to module scope in the \`\"use client\"\` provider so it runs at import time.

## Verified
- Guest IAM role DOES have \`appsync:GraphQL\` on \`Mutation/fields/confirmNewsletter\` — authorization wasn't the issue.
- Confirm Lambda \`amplify-d3jl0ykn4qgj9r-ma-confirmnewsletterlambdaC-xxQTe1uGSh9G\` has no CloudWatch log group, confirming the request never reached AppSync.

## Test plan
- [ ] Deploy and hit a fresh \`/confirm/<code>\` link — expect success page
- [ ] Hit an invalid code — expect \"Invalid confirmation code\" (now coming from the Lambda, not the catch block)
- [ ] Verify \`/aws/lambda/amplify-d3jl0ykn4qgj9r-ma-confirmnewsletterlambdaC-xxQTe1uGSh9G\` log group now exists and has invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)