### PR TITLE
feat(admin): date-range filter, CSV export, and resend confirmation

### DIFF
--- a/apps/admin/src/app/(admin)/subscribers/page.tsx
+++ b/apps/admin/src/app/(admin)/subscribers/page.tsx
@@ -34,6 +34,7 @@ import {
   Users,
   Search,
   Download,
+  Mail,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -48,6 +49,7 @@ export default function SubscribersPage() {
   const [search, setSearch] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+  const [resendingEmail, setResendingEmail] = useState<string | null>(null);
 
   const fetchSubscribers = async () => {
     try {
@@ -79,6 +81,26 @@ export default function SubscribersPage() {
   useEffect(() => {
     fetchSubscribers();
   }, []);
+
+  const handleResend = async (subscriber: NewsletterSubscriber) => {
+    try {
+      setResendingEmail(subscriber.email);
+      const client = generateClient<Schema>();
+      const result = await client.mutations.resendConfirmation({
+        email: subscriber.email,
+      });
+      if (result.data?.success) {
+        toast.success(`Confirmation email resent to ${subscriber.email}`);
+      } else {
+        toast.error(result.data?.message || "Failed to resend confirmation");
+      }
+    } catch (error) {
+      console.error("Error resending confirmation:", error);
+      toast.error("Failed to resend confirmation");
+    } finally {
+      setResendingEmail(null);
+    }
+  };
 
   const handleDelete = async (subscriber: NewsletterSubscriber) => {
     if (
@@ -359,9 +381,25 @@ export default function SubscribersPage() {
                     </TableCell>
                     <TableCell>{formatDate(subscriber.createdAt)}</TableCell>
                     <TableCell className="text-right">
+                      {!subscriber.confirmed && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="Resend confirmation email"
+                          disabled={resendingEmail === subscriber.email}
+                          onClick={() => handleResend(subscriber)}
+                        >
+                          {resendingEmail === subscriber.email ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Mail className="h-4 w-4 text-blue-500" />
+                          )}
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="icon"
+                        title="Delete subscriber"
                         onClick={() => handleDelete(subscriber)}
                       >
                         <Trash2 className="h-4 w-4 text-red-500" />

--- a/apps/admin/src/app/(admin)/subscribers/page.tsx
+++ b/apps/admin/src/app/(admin)/subscribers/page.tsx
@@ -33,6 +33,7 @@ import {
   Clock,
   Users,
   Search,
+  Download,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -45,6 +46,8 @@ export default function SubscribersPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [filter, setFilter] = useState<FilterValue>("all");
   const [search, setSearch] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
 
   const fetchSubscribers = async () => {
     try {
@@ -107,13 +110,66 @@ export default function SubscribersPage() {
 
   const visible = useMemo(() => {
     const query = search.trim().toLowerCase();
+    const fromMs = dateFrom ? new Date(dateFrom).getTime() : null;
+    // dateTo is inclusive: treat as end-of-day in the user's local zone
+    const toMs = dateTo ? new Date(dateTo).getTime() + 24 * 60 * 60 * 1000 - 1 : null;
     return subscribers.filter((s) => {
       if (filter === "confirmed" && s.confirmed !== true) return false;
       if (filter === "pending" && s.confirmed === true) return false;
       if (query && !s.email.toLowerCase().includes(query)) return false;
+      if (fromMs !== null || toMs !== null) {
+        const createdMs = new Date(s.createdAt).getTime();
+        if (fromMs !== null && createdMs < fromMs) return false;
+        if (toMs !== null && createdMs > toMs) return false;
+      }
       return true;
     });
-  }, [subscribers, filter, search]);
+  }, [subscribers, filter, search, dateFrom, dateTo]);
+
+  const handleExport = () => {
+    if (visible.length === 0) {
+      toast.error("No subscribers to export");
+      return;
+    }
+    const headers = [
+      "email",
+      "name",
+      "source",
+      "country",
+      "zip",
+      "confirmed",
+      "createdAt",
+    ];
+    const escape = (val: unknown) => {
+      const str = val === null || val === undefined ? "" : String(val);
+      return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+    };
+    const rows = visible.map((s) =>
+      [
+        s.email,
+        s.name ?? "",
+        s.source ?? "landingPage",
+        s.country ?? "",
+        s.zip ?? "",
+        s.confirmed ? "true" : "false",
+        s.createdAt,
+      ]
+        .map(escape)
+        .join(","),
+    );
+    const csv = [headers.join(","), ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    const stamp = new Date().toISOString().slice(0, 10);
+    a.href = url;
+    a.download = `subscribers-${stamp}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toast.success(`Exported ${visible.length} subscriber${visible.length !== 1 ? "s" : ""}`);
+  };
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
@@ -182,25 +238,73 @@ export default function SubscribersPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-4">
-            <Tabs
-              value={filter}
-              onValueChange={(v) => setFilter(v as FilterValue)}
-            >
-              <TabsList>
-                <TabsTrigger value="all">All</TabsTrigger>
-                <TabsTrigger value="confirmed">Confirmed</TabsTrigger>
-                <TabsTrigger value="pending">Pending</TabsTrigger>
-              </TabsList>
-            </Tabs>
-            <div className="relative w-full sm:w-72">
-              <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Search by email..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="pl-8"
-              />
+          <div className="flex flex-col gap-4 mb-4">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <Tabs
+                value={filter}
+                onValueChange={(v) => setFilter(v as FilterValue)}
+              >
+                <TabsList>
+                  <TabsTrigger value="all">All</TabsTrigger>
+                  <TabsTrigger value="confirmed">Confirmed</TabsTrigger>
+                  <TabsTrigger value="pending">Pending</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <div className="relative w-full sm:w-72">
+                <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  placeholder="Search by email..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-8"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="flex items-center gap-2">
+                  <label htmlFor="dateFrom" className="text-sm text-muted-foreground">
+                    From
+                  </label>
+                  <Input
+                    id="dateFrom"
+                    type="date"
+                    value={dateFrom}
+                    max={dateTo || undefined}
+                    onChange={(e) => setDateFrom(e.target.value)}
+                    className="w-auto"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <label htmlFor="dateTo" className="text-sm text-muted-foreground">
+                    To
+                  </label>
+                  <Input
+                    id="dateTo"
+                    type="date"
+                    value={dateTo}
+                    min={dateFrom || undefined}
+                    onChange={(e) => setDateTo(e.target.value)}
+                    className="w-auto"
+                  />
+                </div>
+                {(dateFrom || dateTo) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setDateFrom("");
+                      setDateTo("");
+                    }}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+              <Button variant="outline" onClick={handleExport} disabled={visible.length === 0}>
+                <Download className="h-4 w-4 mr-2" />
+                Export CSV
+              </Button>
             </div>
           </div>
 

--- a/apps/admin/src/app/(admin)/subscribers/page.tsx
+++ b/apps/admin/src/app/(admin)/subscribers/page.tsx
@@ -54,7 +54,7 @@ export default function SubscribersPage() {
   const fetchSubscribers = async () => {
     try {
       setIsLoading(true);
-      const client = generateClient<Schema>();
+      const client = generateClient<Schema>({ authMode: "userPool" });
       const { data, errors } = await client.models.NewsletterSubscriber.list({
         limit: 1000,
       });
@@ -85,7 +85,7 @@ export default function SubscribersPage() {
   const handleResend = async (subscriber: NewsletterSubscriber) => {
     try {
       setResendingEmail(subscriber.email);
-      const client = generateClient<Schema>();
+      const client = generateClient<Schema>({ authMode: "userPool" });
       const result = await client.mutations.resendConfirmation({
         email: subscriber.email,
       });
@@ -112,7 +112,7 @@ export default function SubscribersPage() {
     }
 
     try {
-      const client = generateClient<Schema>();
+      const client = generateClient<Schema>({ authMode: "userPool" });
       await client.models.NewsletterSubscriber.delete({
         email: subscriber.email,
       });
@@ -132,9 +132,10 @@ export default function SubscribersPage() {
 
   const visible = useMemo(() => {
     const query = search.trim().toLowerCase();
-    const fromMs = dateFrom ? new Date(dateFrom).getTime() : null;
-    // dateTo is inclusive: treat as end-of-day in the user's local zone
-    const toMs = dateTo ? new Date(dateTo).getTime() + 24 * 60 * 60 * 1000 - 1 : null;
+    // Treat the picker's YYYY-MM-DD as a local-time boundary so filtering
+    // matches what the admin sees in the Created column.
+    const fromMs = dateFrom ? new Date(`${dateFrom}T00:00:00`).getTime() : null;
+    const toMs = dateTo ? new Date(`${dateTo}T23:59:59.999`).getTime() : null;
     return subscribers.filter((s) => {
       if (filter === "confirmed" && s.confirmed !== true) return false;
       if (filter === "pending" && s.confirmed === true) return false;

--- a/packages/backend/amplify/backend.ts
+++ b/packages/backend/amplify/backend.ts
@@ -534,6 +534,11 @@ backend.subscribeToNewsletter.resources.lambda.role?.attachInlinePolicy(subscrib
 const resendConfirmationLambda = backend.resendConfirmation.resources.lambda as LambdaFunction;
 const resendConfirmationStack = Stack.of(resendConfirmationLambda);
 
+resendConfirmationLambda.addEnvironment(
+  'CONFIRM_BASE_URL',
+  process.env.CONFIRM_BASE_URL || 'https://www.mapyourhealth.info',
+);
+
 const resendConfirmationSesPolicy = new Policy(resendConfirmationStack, 'ResendConfirmationSESPolicy', {
   statements: [
     new PolicyStatement({

--- a/packages/backend/amplify/backend.ts
+++ b/packages/backend/amplify/backend.ts
@@ -23,6 +23,7 @@ import { deleteAccount } from './functions/delete-account/resource';
 import { manageData } from './functions/manage-data/resource';
 import { subscribeToNewsletter } from './functions/subscribe-to-newsletter/resource';
 import { confirmNewsletter } from './functions/confirm-newsletter/resource';
+import { resendConfirmation } from './functions/resend-confirmation/resource';
 // import { storage } from './storage/resource';
 
 /**
@@ -44,6 +45,7 @@ const backend = defineBackend({
   manageData,
   subscribeToNewsletter,
   confirmNewsletter,
+  resendConfirmation,
   // storage,
 });
 
@@ -524,6 +526,24 @@ const subscribeToNewsletterSesPolicy = new Policy(subscribeToNewsletterStack, 'S
   ],
 });
 backend.subscribeToNewsletter.resources.lambda.role?.attachInlinePolicy(subscribeToNewsletterSesPolicy);
+
+// ============================================
+// Resend Confirmation Lambda Setup
+// ============================================
+
+const resendConfirmationLambda = backend.resendConfirmation.resources.lambda as LambdaFunction;
+const resendConfirmationStack = Stack.of(resendConfirmationLambda);
+
+const resendConfirmationSesPolicy = new Policy(resendConfirmationStack, 'ResendConfirmationSESPolicy', {
+  statements: [
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ['ses:SendEmail', 'ses:SendRawEmail'],
+      resources: ['*'],
+    }),
+  ],
+});
+backend.resendConfirmation.resources.lambda.role?.attachInlinePolicy(resendConfirmationSesPolicy);
 
 // Add Pinpoint config to amplify_outputs.json
 backend.addOutput({

--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -5,6 +5,7 @@ import { deleteAccount } from "../functions/delete-account/resource";
 import { manageData } from "../functions/manage-data/resource";
 import { subscribeToNewsletter } from "../functions/subscribe-to-newsletter/resource";
 import { confirmNewsletter } from "../functions/confirm-newsletter/resource";
+import { resendConfirmation } from "../functions/resend-confirmation/resource";
 
 /**
  * MapYourHealth Data Schema
@@ -608,6 +609,22 @@ const schema = a.schema({
     .authorization((allow) => [allow.guest(), allow.authenticated()])
     .handler(a.handler.function(confirmNewsletter)),
 
+  /**
+   * resendConfirmation - Admin-only: regenerate code and re-send the
+   * confirmation email for a pending subscriber.
+   */
+  resendConfirmation: a
+    .mutation()
+    .arguments({
+      email: a.string().required(),
+      lang: a.string(),
+    })
+    .returns(
+      a.customType({ success: a.boolean().required(), message: a.string() }),
+    )
+    .authorization((allow) => [allow.group("admin")])
+    .handler(a.handler.function(resendConfirmation)),
+
   // =========================================================================
   // Observations & Measurements (O&M) Data Model
   // Flexible system for tracking various environmental/health properties
@@ -735,6 +752,7 @@ const schema = a.schema({
 const schemaWithFunctionAccess = schema.authorization((allow) => [
   allow.resource(subscribeToNewsletter).to(["query", "mutate"]),
   allow.resource(confirmNewsletter).to(["query", "mutate"]),
+  allow.resource(resendConfirmation).to(["query", "mutate"]),
 ]);
 
 export type Schema = ClientSchema<typeof schemaWithFunctionAccess>;

--- a/packages/backend/amplify/functions/resend-confirmation/handler.ts
+++ b/packages/backend/amplify/functions/resend-confirmation/handler.ts
@@ -1,0 +1,122 @@
+import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - subpath export not visible to some TS module resolutions
+import { getAmplifyDataClientConfig } from "@aws-amplify/backend/function/runtime";
+import { Amplify } from "aws-amplify";
+import { generateClient } from "aws-amplify/data";
+import { randomBytes } from "crypto";
+
+import type { Schema } from "../../data/resource";
+
+const emailFrom = process.env.EMAIL_FROM || "noreply@mapyourhealth.info";
+const confirmBaseUrl =
+  process.env.CONFIRM_BASE_URL || "https://www.mapyourhealth.info";
+
+let configured = false;
+async function ensureConfigured() {
+  if (configured) return;
+  const { resourceConfig, libraryOptions } = await getAmplifyDataClientConfig(
+    process.env as Parameters<typeof getAmplifyDataClientConfig>[0],
+  );
+  Amplify.configure(resourceConfig, libraryOptions);
+  configured = true;
+}
+
+const dataClient = generateClient<Schema>();
+const ses = new SESClient({ region: "us-east-1" });
+
+function generateConfirmationCode(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export const handler: Schema["resendConfirmation"]["functionHandler"] = async (
+  event,
+) => {
+  await ensureConfigured();
+  const { email, lang } = event.arguments;
+
+  if (!email) {
+    return { success: false, message: "Email is required" };
+  }
+
+  try {
+    const { data: subscriber } =
+      await dataClient.models.NewsletterSubscriber.get({ email });
+
+    if (!subscriber) {
+      return { success: false, message: "Subscriber not found" };
+    }
+    if (subscriber.confirmed) {
+      return { success: false, message: "Subscriber already confirmed" };
+    }
+
+    const confirmationCode = generateConfirmationCode();
+    await dataClient.models.NewsletterSubscriber.update({
+      email,
+      confirmationCode,
+    });
+
+    const confirmationUrl = `${confirmBaseUrl.replace(/\/$/, "")}/confirm/${confirmationCode}`;
+
+    const content =
+      lang === "fr"
+        ? {
+            subject: "Confirmez votre inscription à MapYourHealth",
+            greeting: "Bonjour,",
+            body: "Veuillez confirmer votre inscription en cliquant sur le bouton ci-dessous :",
+            button: "Confirmer",
+            signature: "L'équipe de MapYourHealth",
+          }
+        : {
+            subject: "Confirm your MapYourHealth subscription",
+            greeting: "Dear friend,",
+            body: "Please confirm your subscription by clicking the button below:",
+            button: "Confirm Subscription",
+            signature: "The MapYourHealth team",
+          };
+
+    const html = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.7; color: #000000; margin: 0; padding: 0; background-color: #9db835; }
+          .container { max-width: 600px; margin: 0 auto; }
+          .header { background-color: #ffffff; padding: 20px; text-align: center; }
+          .header h1 { color: #000000; font-size: 24px; font-weight: bold; }
+          .content { background-color: #ffffff; padding: 20px; }
+          .action-button { display: inline-block; padding: 10px 20px; background-color: #9db835; color: #ffffff !important; text-decoration: none; border-radius: 4px; margin: 20px 0; }
+          .footer { background-color: #9db835; color: #ffffff; padding: 20px; text-align: center; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header"><h1>MapYourHealth</h1></div>
+          <div class="content">
+            <p>${content.greeting}</p>
+            <p>${content.body}</p>
+            <a href="${confirmationUrl}" class="action-button">${content.button}</a>
+          </div>
+          <div class="footer"><p>${content.signature}</p></div>
+        </div>
+      </body>
+      </html>
+    `;
+
+    await ses.send(
+      new SendEmailCommand({
+        Destination: { ToAddresses: [email] },
+        Message: {
+          Body: { Html: { Data: html } },
+          Subject: { Data: content.subject },
+        },
+        Source: emailFrom,
+      }),
+    );
+
+    return { success: true, message: "Confirmation email resent" };
+  } catch (error) {
+    console.error("Resend confirmation error:", error);
+    return { success: false, message: "Failed to resend confirmation" };
+  }
+};

--- a/packages/backend/amplify/functions/resend-confirmation/resource.ts
+++ b/packages/backend/amplify/functions/resend-confirmation/resource.ts
@@ -1,0 +1,6 @@
+import { defineFunction } from "@aws-amplify/backend";
+
+export const resendConfirmation = defineFunction({
+  name: "resend-confirmation",
+  entry: "./handler.ts",
+});


### PR DESCRIPTION
## Summary
- **Date-range filter**: adds From/To inputs on the subscribers page; filters by \`createdAt\` (To is inclusive, end-of-day local).
- **CSV export**: downloads the currently-visible rows (respects tab, search, and date filters) as \`subscribers-YYYY-MM-DD.csv\` with \`email, name, source, country, zip, confirmed, createdAt\`.
- **Resend confirmation**: new backend Lambda \`resend-confirmation\` + \`resendConfirmation\` mutation (admin-only via \`allow.group(\"admin\")\`). Regenerates the confirmation code, updates the subscriber row, and re-sends the confirmation email via SES. Surfaces a Mail button next to each pending subscriber.

## Notes
- Backend changes require a deploy of the MapYourHealth backend (app \`d3jl0ykn4qgj9r\`) before the admin UI button will work in production.
- Frontend falls back to a toast error if the mutation returns \`success: false\` (e.g., already confirmed).

## Test plan
- [ ] /subscribers tab + search + date filters compose correctly
- [ ] Export CSV with and without filters — output matches visible rows
- [ ] After backend deploy: click Mail on a pending row → subscriber receives a new confirmation email
- [ ] Mail button not rendered for confirmed subscribers
- [ ] Mail button shows spinner while mutation is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)