### PR TITLE
fix(mobile): web tab title no longer shows 'undefined'

### DIFF
--- a/apps/mobile/app/navigators/AppNavigator.tsx
+++ b/apps/mobile/app/navigators/AppNavigator.tsx
@@ -213,7 +213,20 @@ export const AppNavigator = (props: NavigationProps) => {
   useBackButtonHandler((routeName) => exitRoutes.includes(routeName))
 
   return (
-    <NavigationContainer ref={navigationRef} theme={navigationTheme} linking={linking} {...props}>
+    <NavigationContainer
+      ref={navigationRef}
+      theme={navigationTheme}
+      linking={linking}
+      documentTitle={{
+        formatter: (options, route) =>
+          options?.title
+            ? `${options.title} | MapYourHealth`
+            : route?.name
+              ? `${route.name} | MapYourHealth`
+              : "MapYourHealth",
+      }}
+      {...props}
+    >
       <ErrorBoundary catchErrors={Config.catchErrors}>
         <AppStack />
       </ErrorBoundary>

--- a/apps/mobile/app/navigators/AppNavigator.tsx
+++ b/apps/mobile/app/navigators/AppNavigator.tsx
@@ -10,6 +10,7 @@ import { NavigationContainer, LinkingOptions } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 
 import Config from "@/config"
+import { APP_NAME } from "@/config/appConstants"
 import { useAuth } from "@/context/AuthContext"
 import { useAppConfig } from "@/hooks/useAppConfig"
 import { CategoryDetailScreen } from "@/screens/CategoryDetailScreen"
@@ -220,10 +221,10 @@ export const AppNavigator = (props: NavigationProps) => {
       documentTitle={{
         formatter: (options, route) =>
           options?.title
-            ? `${options.title} | MapYourHealth`
+            ? `${options.title} | ${APP_NAME}`
             : route?.name
-              ? `${route.name} | MapYourHealth`
-              : "MapYourHealth",
+              ? `${route.name} | ${APP_NAME}`
+              : APP_NAME,
       }}
       {...props}
     >


### PR DESCRIPTION
## Summary
Browser tab for https://app.mapyourhealth.info/ shows **\"undefined\"** instead of the app name because \`ComingSoonScreen\` renders outside the \`Stack.Navigator\`, so React Navigation's documentTitle plugin has no active route/options to stringify.

Fix: supply a \`documentTitle.formatter\` on \`NavigationContainer\` that falls back to \`\"MapYourHealth\"\` when \`options.title\` is absent, and prefixes the screen name otherwise (\`Dashboard | MapYourHealth\`).

## Test plan
- [ ] Deploy mobile web to \`main\` (app \`d2z5ddqhlc1q5\`).
- [ ] Visit https://app.mapyourhealth.info/ with gate enabled — tab title reads \`MapYourHealth\`.
- [ ] Disable gate, log in — tab title reads e.g. \`Dashboard | MapYourHealth\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)