### PR TITLE
fix(ci): wire staging frontends to staging backend

### DIFF
--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -58,7 +58,7 @@ jobs:
     name: Deploy Admin Portal
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main'
+    if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -2,7 +2,7 @@ name: Mobile Web Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - 'apps/mobile/**'
       - 'packages/backend/amplify/data/**'
@@ -58,9 +58,9 @@ jobs:
     name: Deploy Mobile Web
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main'
+    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
-      name: production
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -73,5 +73,5 @@ jobs:
         run: |
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFY_MOBILE_APP_ID }} \
-            --branch-name main \
+            --branch-name ${{ github.ref_name }} \
             --job-type RELEASE

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -2,7 +2,7 @@ name: Web Landing Page CI/CD
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - 'apps/web/**'
       - 'packages/backend/amplify/data/**'
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: wait-for-checks
     environment:
-      name: production
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -52,5 +52,5 @@ jobs:
         run: |
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFY_WEB_APP_ID }} \
-            --branch-name main \
+            --branch-name ${{ github.ref_name }} \
             --job-type RELEASE

--- a/amplify.yml
+++ b/amplify.yml
@@ -35,7 +35,7 @@ applications:
             - cd ../.. && yarn install --immutable && cd apps/mobile
             # Generate amplify_outputs.json from backend app
             - export AWS_REGION=ca-central-1
-            - npx ampx generate outputs --branch main --app-id d3jl0ykn4qgj9r
+            - npx ampx generate outputs --branch $AWS_BRANCH --app-id d3jl0ykn4qgj9r
             - echo "=== amplify_outputs.json contents ==="
             - cat amplify_outputs.json
         build:


### PR DESCRIPTION
## Summary
Ensure each frontend on the \`staging\` branch fetches \`amplify_outputs.json\` from the **staging** backend, and that a push to \`staging\` actually triggers a deploy.

## Changes
- \`amplify.yml\`: apps/mobile preBuild was pinned to \`--branch main\` for \`ampx generate outputs\`. Replaced with \`\$AWS_BRANCH\` so staging mobile gets the staging backend. apps/web and apps/admin were already correct.
- \`web-deploy.yml\` / \`mobile-deploy.yml\`: add \`staging\` to \`on.push.branches\`, pass \`\${{ github.ref_name }}\` to \`aws amplify start-job --branch-name\`, and set the GH environment conditionally.
- \`admin-deploy.yml\`: trigger was already on \`[main, staging]\`; job-level \`if\` condition was still gated on \`main\`. Relaxed to allow staging.

## After merge
- Push to \`staging\` → each frontend Amplify app runs its build, which now pulls the staging backend outputs. No frontend code change will accidentally load the prod backend.
- Backend staging deployments were already handled via \`backend-ci.yml\` (unchanged).

## Test plan
- [ ] Push a trivial change to \`staging\` touching \`apps/mobile/**\`: verify mobile staging build fetches \`amplify_outputs.json\` for \`--branch staging\` (check Amplify build log).
- [ ] Repeat for \`apps/web/**\` and \`apps/admin/**\`.
- [ ] Visit \`staging.d2z5ddqhlc1q5.amplifyapp.com\` and confirm it points at the staging AppSync URL (not prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)