### PR TITLE
chore(ci): show real commit message in Amplify console deploys

### DIFF
--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -69,9 +69,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Deploy Admin Portal
         run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
           aws amplify start-job \
             --app-id d26q32gc98goap \
             --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE
+            --job-type RELEASE \
+            --commit-id ${{ github.sha }} \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -71,7 +71,12 @@ jobs:
 
       - name: Deploy Amplify backend
         run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
             --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE
+            --job-type RELEASE \
+            --commit-id ${{ github.sha }} \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME"

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -69,9 +69,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Deploy Mobile Web
         run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFY_MOBILE_APP_ID }} \
             --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE
+            --job-type RELEASE \
+            --commit-id ${{ github.sha }} \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME"

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -48,9 +48,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Deploy Web Landing Page
         run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFY_WEB_APP_ID }} \
             --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE
+            --job-type RELEASE \
+            --commit-id ${{ github.sha }} \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME"


### PR DESCRIPTION
## Summary
Amplify's Deployment history showed \"Auto-build\" in the Commit message column because \`aws amplify start-job\` was called without commit metadata. Pass \`--commit-id\`, \`--commit-message\`, and \`--commit-time\` pulled from the Actions runner so each build is identifiable at a glance.

Applied to all four deploy workflows:
- backend-ci.yml
- admin-deploy.yml
- web-deploy.yml (also adds an \`actions/checkout@v4\` step since it wasn't checking out before)
- mobile-deploy.yml (same)

## Test plan
- [ ] Trigger any workflow_dispatch or push to \`main\` / \`staging\`.
- [ ] Open the Amplify app's Deployment history — the new row should show the real git subject line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)