### PR TITLE
fix(admin): handle RESET_REQUIRED Cognito users on sign-in (#238)

### DIFF
--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -131,6 +131,20 @@ export default function LoginPage() {
           const ok = await validateAdminAndRedirect();
           if (ok) return;
         }
+        // Cognito users in status RESET_REQUIRED (admin used "Reset password")
+        // fail sign-in with PasswordResetRequiredException. Kick off the reset
+        // flow automatically so the user can complete it in-app.
+        const name =
+          signInErr && typeof signInErr === "object" && "name" in signInErr
+            ? String((signInErr as { name: unknown }).name)
+            : "";
+        if (
+          name === "PasswordResetRequiredException" ||
+          msg.includes("Password reset required")
+        ) {
+          await startResetFlow();
+          return;
+        }
         throw signInErr;
       }
 
@@ -144,6 +158,10 @@ export default function LoginPage() {
           setAuthStep("NEW_PASSWORD_REQUIRED");
           break;
 
+        case "RESET_PASSWORD":
+          await startResetFlow();
+          break;
+
         default:
           setError(
             `Sign in requires additional step: ${signInResult.nextStep?.signInStep}. Please contact your administrator.`,
@@ -155,6 +173,31 @@ export default function LoginPage() {
       setError(errorMessage);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const startResetFlow = async () => {
+    try {
+      const output = await resetPassword({ username: email });
+      setResetPasswordOutput(output);
+      if (
+        output.nextStep.resetPasswordStep === "CONFIRM_RESET_PASSWORD_WITH_CODE"
+      ) {
+        const destination = output.nextStep.codeDeliveryDetails?.destination;
+        setSuccess(
+          `Your account needs a password reset. A confirmation code has been sent to ${destination}. Enter it below with your new password.`,
+        );
+        setAuthStep("CONFIRM_RESET_PASSWORD");
+      } else {
+        setError(
+          "Your account requires a password reset. Please use the 'Forgot your password?' link.",
+        );
+        setAuthStep("FORGOT_PASSWORD");
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to start password reset";
+      setError(errorMessage);
     }
   };
 


### PR DESCRIPTION
## Summary
Rayane could not sign in to the admin portal after an admin used **Reset password** in the Cognito console. That action sets \`UserStatus = RESET_REQUIRED\`, and on next sign-in Amplify raises \`PasswordResetRequiredException\` (or returns \`signInStep: "RESET_PASSWORD"\`). The login page only handled \`DONE\` and \`CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED\`, so anything else fell into the default "contact your administrator" error.

## Change
- Add a \`RESET_PASSWORD\` case to the next-step switch.
- Catch \`PasswordResetRequiredException\` in the sign-in \`catch\` block.
- Both branches now invoke \`resetPassword({ username: email })\` to email the confirmation code and transition the UI to the existing \`CONFIRM_RESET_PASSWORD\` step.
- Inline success message tells the user a code was sent and which destination it was sent to.

## Test plan
- [ ] In Cognito console: **Reset password** on a test admin user (status → \`RESET_REQUIRED\`).
- [ ] Visit \`/login\`, sign in with that account's old/temporary password.
- [ ] Expect the UI to switch to the "Enter Reset Code" screen with a message about a code being emailed.
- [ ] Complete the flow with the emailed code + a new password; expect redirect into the admin portal.
- [ ] Regression: users in \`FORCE_CHANGE_PASSWORD\` status still hit the Set New Password screen (unchanged).

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)