### PR TITLE
release: promote staging → main (admin-editable landing content)

### DIFF
--- a/apps/admin/src/app/(admin)/landing-page/page.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { generateClient } from "aws-amplify/data";
+import { fetchAuthSession } from "aws-amplify/auth";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import {
+  SUPPORTED_LOCALES,
+  type Locale,
+  flattenContent,
+  sectionForKey,
+  isLikelyMultiline,
+} from "@mapyourhealth/backend/shared/landing-page-content";
+import enBundled from "../../../../../web/src/translations/en.json";
+import frBundled from "../../../../../web/src/translations/fr.json";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Loader2, RotateCcw, Save } from "lucide-react";
+import { toast } from "sonner";
+
+const BUNDLED: Record<Locale, Record<string, unknown>> = {
+  en: enBundled as Record<string, unknown>,
+  fr: frBundled as Record<string, unknown>,
+};
+
+type FieldState = Record<string, string>;
+
+function lastSegment(key: string): string {
+  const parts = key.split(".");
+  return parts[parts.length - 1] ?? key;
+}
+
+export default function LandingPageContentPage() {
+  const [activeLocale, setActiveLocale] = useState<Locale>("en");
+  const [bundledFlat, setBundledFlat] = useState<Record<Locale, FieldState>>({
+    en: {},
+    fr: {},
+  });
+  const [overrides, setOverrides] = useState<Record<Locale, FieldState>>({
+    en: {},
+    fr: {},
+  });
+  const [values, setValues] = useState<Record<Locale, FieldState>>({
+    en: {},
+    fr: {},
+  });
+  const [dirty, setDirty] = useState<Record<Locale, boolean>>({
+    en: false,
+    fr: false,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<Locale | null>(null);
+
+  useEffect(() => {
+    const flat: Record<Locale, FieldState> = {
+      en: flattenContent(BUNDLED.en),
+      fr: flattenContent(BUNDLED.fr),
+    };
+    setBundledFlat(flat);
+
+    const load = async () => {
+      try {
+        const client = generateClient<Schema>({ authMode: "userPool" });
+        const fetched: Record<Locale, FieldState> = { en: {}, fr: {} };
+        await Promise.all(
+          SUPPORTED_LOCALES.map(async (locale) => {
+            const { data } = await client.models.LandingPageContent.get({
+              locale,
+            });
+            if (data?.content) {
+              fetched[locale] = data.content as FieldState;
+            }
+          }),
+        );
+        setOverrides(fetched);
+        setValues({
+          en: { ...flat.en, ...fetched.en },
+          fr: { ...flat.fr, ...fetched.fr },
+        });
+      } catch (err) {
+        console.error("Failed to load landing content:", err);
+        toast.error("Failed to load landing content");
+        setValues(flat);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const sections = useMemo(() => {
+    const keys = Object.keys(bundledFlat[activeLocale]).sort();
+    const grouped: Record<string, string[]> = {};
+    for (const key of keys) {
+      const section = sectionForKey(key);
+      grouped[section] = grouped[section] ?? [];
+      grouped[section].push(key);
+    }
+    const order = [
+      "Branding",
+      "Hero",
+      "Newsletter form",
+      "Benefits",
+      "FAQ",
+      "Confirm page",
+      "Other",
+    ];
+    return order
+      .filter((s) => grouped[s]?.length)
+      .map((s) => ({ section: s, keys: grouped[s] }));
+  }, [bundledFlat, activeLocale]);
+
+  const handleChange = (locale: Locale, key: string, value: string) => {
+    setValues((prev) => ({
+      ...prev,
+      [locale]: { ...prev[locale], [key]: value },
+    }));
+    setDirty((prev) => ({ ...prev, [locale]: true }));
+  };
+
+  const handleResetField = (locale: Locale, key: string) => {
+    const def = bundledFlat[locale][key] ?? "";
+    setValues((prev) => ({
+      ...prev,
+      [locale]: { ...prev[locale], [key]: def },
+    }));
+    setDirty((prev) => ({ ...prev, [locale]: true }));
+  };
+
+  const handleSave = async (locale: Locale) => {
+    try {
+      setSaving(locale);
+      const next: FieldState = {};
+      for (const [key, value] of Object.entries(values[locale])) {
+        const bundled = bundledFlat[locale][key] ?? "";
+        // Only persist values that differ from the bundled default.
+        if (value.trim() !== "" && value !== bundled) {
+          next[key] = value;
+        }
+      }
+
+      const session = await fetchAuthSession();
+      const email =
+        (session.tokens?.idToken?.payload?.email as string | undefined) ??
+        "admin";
+
+      const client = generateClient<Schema>({ authMode: "userPool" });
+      const existing = overrides[locale];
+      const hasExisting = Object.keys(existing).length > 0;
+
+      if (hasExisting) {
+        await client.models.LandingPageContent.update({
+          locale,
+          content: next,
+          updatedBy: email,
+        });
+      } else {
+        await client.models.LandingPageContent.create({
+          locale,
+          content: next,
+          updatedBy: email,
+        });
+      }
+
+      setOverrides((prev) => ({ ...prev, [locale]: next }));
+      setDirty((prev) => ({ ...prev, [locale]: false }));
+      toast.success(
+        `Saved ${Object.keys(next).length} override${
+          Object.keys(next).length === 1 ? "" : "s"
+        } for ${locale.toUpperCase()}`,
+      );
+    } catch (err) {
+      console.error("Failed to save:", err);
+      toast.error("Failed to save changes");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const isOverridden = (locale: Locale, key: string) =>
+    (values[locale][key] ?? "") !== (bundledFlat[locale][key] ?? "");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Landing Page</h1>
+        <p className="text-muted-foreground">
+          Edit every piece of text shown on mapyourhealth.info. Leave a field
+          blank (or click Reset) to fall back to the bundled default.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <Tabs
+          value={activeLocale}
+          onValueChange={(v) => {
+            if (dirty[activeLocale]) {
+              if (
+                !window.confirm(
+                  "You have unsaved changes. Switch locale and lose them?",
+                )
+              ) {
+                return;
+              }
+            }
+            setActiveLocale(v as Locale);
+          }}
+        >
+          <TabsList>
+            <TabsTrigger value="en">English</TabsTrigger>
+            <TabsTrigger value="fr">Français</TabsTrigger>
+          </TabsList>
+
+          {SUPPORTED_LOCALES.map((locale) => (
+            <TabsContent key={locale} value={locale} className="space-y-6 mt-4">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">
+                  {Object.keys(overrides[locale]).length} override
+                  {Object.keys(overrides[locale]).length === 1 ? "" : "s"}{" "}
+                  persisted.
+                </p>
+                <Button
+                  onClick={() => handleSave(locale)}
+                  disabled={!dirty[locale] || saving === locale}
+                >
+                  {saving === locale ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Save className="h-4 w-4 mr-2" />
+                  )}
+                  Save {locale.toUpperCase()}
+                </Button>
+              </div>
+
+              {sections.map(({ section, keys }) => (
+                <Card key={section}>
+                  <CardHeader>
+                    <CardTitle>{section}</CardTitle>
+                    <CardDescription>
+                      {keys.length} field{keys.length === 1 ? "" : "s"}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {keys.map((key) => {
+                      const value = values[locale][key] ?? "";
+                      const multiline =
+                        isLikelyMultiline(
+                          bundledFlat[locale][key] ?? "",
+                        ) || isLikelyMultiline(value);
+                      const overridden = isOverridden(locale, key);
+                      return (
+                        <div key={key} className="space-y-1.5">
+                          <div className="flex items-center justify-between">
+                            <Label
+                              htmlFor={`${locale}-${key}`}
+                              className="font-mono text-xs"
+                            >
+                              {lastSegment(key)}
+                              <span className="ml-2 text-muted-foreground">
+                                {key}
+                              </span>
+                              {overridden && (
+                                <span className="ml-2 text-amber-600">
+                                  • edited
+                                </span>
+                              )}
+                            </Label>
+                            {overridden && (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleResetField(locale, key)}
+                              >
+                                <RotateCcw className="h-3 w-3 mr-1" />
+                                Reset
+                              </Button>
+                            )}
+                          </div>
+                          {multiline ? (
+                            <Textarea
+                              id={`${locale}-${key}`}
+                              value={value}
+                              onChange={(e) =>
+                                handleChange(locale, key, e.target.value)
+                              }
+                              rows={Math.min(
+                                8,
+                                Math.max(2, value.split("\n").length),
+                              )}
+                            />
+                          ) : (
+                            <Input
+                              id={`${locale}-${key}`}
+                              value={value}
+                              onChange={(e) =>
+                                handleChange(locale, key, e.target.value)
+                              }
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </CardContent>
+                </Card>
+              ))}
+            </TabsContent>
+          ))}
+        </Tabs>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/admin-sidebar.tsx
+++ b/apps/admin/src/components/admin-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   Settings,
   BarChart3,
   Mail,
+  FileText,
 } from "lucide-react";
 
 const menuItems = [
@@ -92,6 +93,11 @@ const menuItems = [
     title: "Warning Banners",
     url: "/banners",
     icon: Megaphone,
+  },
+  {
+    title: "Landing Page",
+    url: "/landing-page",
+    icon: FileText,
   },
   {
     title: "Hazard Reports",

--- a/apps/web/src/components/landing-content-loader.tsx
+++ b/apps/web/src/components/landing-content-loader.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import {
+  SUPPORTED_LOCALES,
+  expandFlatContent,
+} from "@mapyourhealth/backend/shared/landing-page-content";
+
+export function LandingContentLoader() {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const hydrate = async () => {
+      try {
+        const client = generateClient<Schema>({ authMode: "iam" });
+        await Promise.all(
+          SUPPORTED_LOCALES.map(async (locale) => {
+            try {
+              const { data } = await client.models.LandingPageContent.get({
+                locale,
+              });
+              if (cancelled || !data?.content) return;
+              const flat = data.content as Record<string, string>;
+              const expanded = expandFlatContent(flat);
+              i18n.addResourceBundle(
+                locale,
+                "translation",
+                expanded,
+                true,
+                true,
+              );
+            } catch (err) {
+              console.warn(
+                `[landing-content] failed to load ${locale}:`,
+                err,
+              );
+            }
+          }),
+        );
+        if (!cancelled) {
+          // Force a re-render of t()-consumers by re-emitting the active language.
+          await i18n.changeLanguage(i18n.language);
+        }
+      } catch (err) {
+        console.warn("[landing-content] client init failed:", err);
+      }
+    };
+
+    hydrate();
+    return () => {
+      cancelled = true;
+    };
+  }, [i18n]);
+
+  return null;
+}

--- a/apps/web/src/providers/i18n-provider.tsx
+++ b/apps/web/src/providers/i18n-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { I18nextProvider, useTranslation } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { RTL_LANGUAGES, type Language } from "@/lib/i18n/resources";
+import { LandingContentLoader } from "@/components/landing-content-loader";
 
 function DirectionUpdater() {
   const { i18n: i18nInstance } = useTranslation();
@@ -22,6 +23,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
   return (
     <I18nextProvider i18n={i18n}>
       <DirectionUpdater />
+      <LandingContentLoader />
       {children}
     </I18nextProvider>
   );

--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -502,6 +502,24 @@ const schema = a.schema({
     ])
     .secondaryIndexes((index) => [index("configKey")]),
 
+  /**
+   * LandingPageContent - Admin-editable copy for apps/web landing page
+   * One row per locale; `content` is a flat JSON map of i18n dotted keys
+   * to strings. Public read; admin CRUD.
+   */
+  LandingPageContent: a
+    .model({
+      locale: a.string().required(),
+      content: a.json().required(),
+      updatedBy: a.string(),
+    })
+    .identifier(["locale"])
+    .authorization((allow) => [
+      allow.guest().to(["read"]),
+      allow.authenticated().to(["read"]),
+      allow.group("admin").to(["create", "update", "delete", "read"]),
+    ]),
+
   // =========================================================================
   // Pollution Sources
   // =========================================================================

--- a/packages/backend/shared/landing-page-content.ts
+++ b/packages/backend/shared/landing-page-content.ts
@@ -1,0 +1,81 @@
+export const SUPPORTED_LOCALES = ["en", "fr"] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export function isLocale(value: string): value is Locale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+export function flattenContent(
+  obj: Record<string, unknown>,
+  prefix = "",
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value == null) continue;
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      out[path] = value;
+    } else if (typeof value === "object" && !Array.isArray(value)) {
+      Object.assign(out, flattenContent(value as Record<string, unknown>, path));
+    }
+  }
+  return out;
+}
+
+export function expandFlatContent(
+  flat: Record<string, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [path, value] of Object.entries(flat)) {
+    const parts = path.split(".");
+    let cursor = out;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const segment = parts[i];
+      const existing = cursor[segment];
+      if (typeof existing !== "object" || existing === null || Array.isArray(existing)) {
+        cursor[segment] = {};
+      }
+      cursor = cursor[segment] as Record<string, unknown>;
+    }
+    cursor[parts[parts.length - 1]] = value;
+  }
+  return out;
+}
+
+export const LANDING_SECTION_ORDER: { section: string; prefix: string }[] = [
+  { section: "Hero", prefix: "home.title" },
+  { section: "Hero", prefix: "home.subtitle" },
+  { section: "Hero", prefix: "home.description" },
+  { section: "Hero", prefix: "home.CTA" },
+  { section: "Hero", prefix: "home.alreadyKnow" },
+  { section: "Hero", prefix: "home.tryWebBeta" },
+  { section: "Hero", prefix: "home.mobileComingSoon" },
+  { section: "Hero", prefix: "home.signUp" },
+  { section: "Newsletter form", prefix: "home.enterEmail" },
+  { section: "Newsletter form", prefix: "home.enterZipCode" },
+  { section: "Newsletter form", prefix: "home.zipCode" },
+  { section: "Newsletter form", prefix: "home.selectCountry" },
+  { section: "Newsletter form", prefix: "home.invalidEmail" },
+  { section: "Newsletter form", prefix: "home.errorMessage" },
+  { section: "Newsletter form", prefix: "home.success" },
+  { section: "Newsletter form", prefix: "home.successAlreadyRegistered" },
+  { section: "Benefits", prefix: "home.benefits" },
+  { section: "Benefits", prefix: "home.benefitsTitle" },
+  { section: "FAQ", prefix: "home.faq" },
+  { section: "FAQ", prefix: "home.faqTitle" },
+  { section: "Confirm page", prefix: "confirm." },
+  { section: "Branding", prefix: "appName" },
+];
+
+export function sectionForKey(key: string): string {
+  for (const { section, prefix } of LANDING_SECTION_ORDER) {
+    if (key === prefix || key.startsWith(`${prefix}.`) || key.startsWith(prefix)) {
+      return section;
+    }
+  }
+  return "Other";
+}
+
+export function isLikelyMultiline(value: string): boolean {
+  return value.includes("\n") || value.length > 80;
+}


### PR DESCRIPTION
## Summary
Promote PR #254 to production.

- **Backend**: new \`LandingPageContent\` model keyed by locale with flat JSON content map; guest read, admin CRUD.
- **Shared**: \`packages/backend/shared/landing-page-content.ts\` flatten/expand + section grouping helpers.
- **Web**: \`LandingContentLoader\` inside \`I18nProvider\` overlays DB content on top of bundled JSON at runtime. Bundled JSON remains the fallback.
- **Admin**: new \`/landing-page\` page with English/Français tabs, 44 auto-generated fields grouped by section (Branding, Hero, Newsletter form, Benefits, FAQ, Confirm page). Per-field Reset, per-locale Save. Sidebar entry under Warning Banners.

## Deploy order
- Backend CI will deploy the \`LandingPageContent\` resolver first.
- Admin + web frontends redeploy and pick up the new Schema.
- After deploy, admins can save overrides at https://admin.mapyourhealth.info/landing-page and the changes propagate to https://www.mapyourhealth.info/ on next load.

## Test plan
- [ ] Backend CI on \`main\` succeeds and AppSync has \`LandingPageContent\`.
- [ ] Admin page loads without "Failed to load landing content" toast after deploy.
- [ ] Edit \`home.title\`, save, reload \`www.mapyourhealth.info\`, confirm new text.
- [ ] Toggle FR, verify locale isolation.
- [ ] Clear an override → bundled default returns.

## Follow-ups
- #255 tracks live preview panel + theme/color editing as the next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)