### PR TITLE
fix(ci): backend deploy missing actions/checkout

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -58,10 +58,14 @@ jobs:
     name: Deploy Backend
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: (needs.detect-changes.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main'
+    if: (needs.detect-changes.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Problem
Backend CI on \`main\` failed with \`fatal: not a git repository\` after PR #253 merged. The \`Deploy Amplify backend\` step runs \`git log\` (added in PR #243 for commit-metadata to \`aws amplify start-job\`) but I never added \`actions/checkout@v4\` to the \`backend-deploy\` job — only to the admin/web/mobile deploy workflows. Every backend deploy since PR #243 merged has been failing the same way.

## Change
- Add \`actions/checkout@v4\` (fetch-depth: 1) before the deploy step.
- Drop the \`github.ref_name == 'main'\` gate so the deploy also runs on \`staging\` pushes (matches the \`on.push.branches: [main, staging]\` trigger and matches the other deploy workflows' behaviour).

Skipping main → staging promotion path and going straight to \`main\` because main is currently blocked.

## Test plan
- [ ] Merge; next push to \`main\` triggers a successful backend deploy with the real commit message visible in Amplify's Deployment history.
- [ ] Unblock the LandingPageContent model deploy from PR #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)