### PR TITLE
feat(admin): arrange CMS inputs in website reading order

### DIFF
--- a/apps/admin/src/app/(admin)/landing-page/page.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/page.tsx
@@ -8,7 +8,7 @@ import {
   SUPPORTED_LOCALES,
   type Locale,
   flattenContent,
-  sectionForKey,
+  groupKeysBySection,
   isLikelyMultiline,
   parseContent,
   serializeContent,
@@ -123,27 +123,10 @@ export default function LandingPageContentPage() {
     load();
   }, []);
 
-  const sections = useMemo(() => {
-    const keys = Object.keys(bundledFlat[activeLocale]).sort();
-    const grouped: Record<string, string[]> = {};
-    for (const key of keys) {
-      const section = sectionForKey(key);
-      grouped[section] = grouped[section] ?? [];
-      grouped[section].push(key);
-    }
-    const order = [
-      "Branding",
-      "Hero",
-      "Newsletter form",
-      "Benefits",
-      "FAQ",
-      "Confirm page",
-      "Other",
-    ];
-    return order
-      .filter((s) => grouped[s]?.length)
-      .map((s) => ({ section: s, keys: grouped[s] }));
-  }, [bundledFlat, activeLocale]);
+  const sections = useMemo(
+    () => groupKeysBySection(Object.keys(bundledFlat[activeLocale])),
+    [bundledFlat, activeLocale],
+  );
 
   const handleChange = (locale: Locale, key: string, value: string) => {
     setValues((prev) => ({

--- a/packages/backend/shared/landing-page-content.ts
+++ b/packages/backend/shared/landing-page-content.ts
@@ -42,38 +42,104 @@ export function expandFlatContent(
   return out;
 }
 
-export const LANDING_SECTION_ORDER: { section: string; prefix: string }[] = [
-  { section: "Hero", prefix: "home.title" },
-  { section: "Hero", prefix: "home.subtitle" },
-  { section: "Hero", prefix: "home.description" },
-  { section: "Hero", prefix: "home.CTA" },
-  { section: "Hero", prefix: "home.alreadyKnow" },
-  { section: "Hero", prefix: "home.tryWebBeta" },
-  { section: "Hero", prefix: "home.mobileComingSoon" },
-  { section: "Hero", prefix: "home.signUp" },
-  { section: "Newsletter form", prefix: "home.enterEmail" },
-  { section: "Newsletter form", prefix: "home.enterZipCode" },
-  { section: "Newsletter form", prefix: "home.zipCode" },
-  { section: "Newsletter form", prefix: "home.selectCountry" },
-  { section: "Newsletter form", prefix: "home.invalidEmail" },
-  { section: "Newsletter form", prefix: "home.errorMessage" },
-  { section: "Newsletter form", prefix: "home.success" },
-  { section: "Newsletter form", prefix: "home.successAlreadyRegistered" },
-  { section: "Benefits", prefix: "home.benefits" },
-  { section: "Benefits", prefix: "home.benefitsTitle" },
-  { section: "FAQ", prefix: "home.faq" },
-  { section: "FAQ", prefix: "home.faqTitle" },
-  { section: "Confirm page", prefix: "confirm." },
-  { section: "Branding", prefix: "appName" },
+/**
+ * Section + key order shown in the admin CMS. Mirrors the top-to-bottom
+ * reading order of the live landing page so editors find fields where
+ * they see them. Any key not listed here falls into an "Other" section
+ * sorted alphabetically.
+ */
+export const LANDING_SECTIONS: { section: string; keys: string[] }[] = [
+  { section: "Branding", keys: ["appName"] },
+  {
+    section: "Hero",
+    keys: [
+      "home.title",
+      "home.subtitle",
+      "home.CTA1",
+      "home.CTA2",
+      "home.description",
+    ],
+  },
+  {
+    section: "Newsletter form",
+    keys: [
+      "home.enterEmail",
+      "home.selectCountry",
+      "home.zipCode",
+      "home.enterZipCode",
+      "home.signUp",
+      "home.invalidEmail",
+      "home.errorMessage",
+      "home.success",
+      "home.successAlreadyRegistered",
+    ],
+  },
+  {
+    section: "Below form",
+    keys: ["home.alreadyKnow", "home.tryWebBeta", "home.mobileComingSoon"],
+  },
+  {
+    section: "Benefits",
+    keys: [
+      "home.benefitsTitle",
+      "home.benefits.title1",
+      "home.benefits.content1",
+      "home.benefits.title2",
+      "home.benefits.content2",
+      "home.benefits.title3",
+      "home.benefits.content3",
+      "home.benefits.title4",
+      "home.benefits.content4",
+    ],
+  },
+  {
+    section: "FAQ",
+    keys: [
+      "home.faqTitle",
+      "home.faq.question1",
+      "home.faq.answer1",
+      "home.faq.question2",
+      "home.faq.answer2",
+      "home.faq.question3",
+      "home.faq.answer3",
+      "home.faq.question4",
+      "home.faq.answer4",
+      "home.faq.question5",
+      "home.faq.answer5",
+      "home.faq.question6",
+      "home.faq.answer6",
+    ],
+  },
+  {
+    section: "Confirm page",
+    keys: [
+      "confirm.loading",
+      "confirm.success",
+      "confirm.invalidCode",
+      "confirm.error",
+    ],
+  },
 ];
 
-export function sectionForKey(key: string): string {
-  for (const { section, prefix } of LANDING_SECTION_ORDER) {
-    if (key === prefix || key.startsWith(`${prefix}.`) || key.startsWith(prefix)) {
-      return section;
-    }
-  }
-  return "Other";
+/**
+ * Given the full set of keys discovered in the bundled translations,
+ * return grouped sections in the order above. Unknown keys land in
+ * "Other" (alphabetical) so newly-added i18n keys never disappear from
+ * the CMS — they just surface at the bottom until someone slots them
+ * into LANDING_SECTIONS.
+ */
+export function groupKeysBySection(
+  availableKeys: Iterable<string>,
+): { section: string; keys: string[] }[] {
+  const available = new Set(availableKeys);
+  const known = new Set(LANDING_SECTIONS.flatMap((s) => s.keys));
+  const grouped = LANDING_SECTIONS.map(({ section, keys }) => ({
+    section,
+    keys: keys.filter((k) => available.has(k)),
+  })).filter((s) => s.keys.length > 0);
+  const leftover = [...available].filter((k) => !known.has(k)).sort();
+  if (leftover.length) grouped.push({ section: "Other", keys: leftover });
+  return grouped;
 }
 
 export function isLikelyMultiline(value: string): boolean {


### PR DESCRIPTION
## Summary
Rearranges the admin landing-page CMS so inputs appear in the same order the editor sees them on the live site. Previously each section's fields were sorted alphabetically, so \`CTA1\` sat above \`title\` in Hero, \`answer1\` above \`question1\` in FAQ, and editors had to hunt.

**New order (top→bottom of the live page):**
Branding → Hero → Newsletter form → Below form → Benefits → FAQ → Confirm page

- Benefits and FAQ now interleave \`title/content\` and \`question/answer\` so each item reads as a unit.
- \`signUp\` moved from Hero into the Newsletter form (it's the form submit label).
- New \"Below form\" section holds \`alreadyKnow\` / \`tryWebBeta\` / \`mobileComingSoon\`.
- Unknown keys surface at the bottom under \"Other\" (alphabetical) so newly-added i18n keys never silently disappear from the CMS.

Removes now-unused \`LANDING_SECTION_ORDER\` and \`sectionForKey\`; admin grouping is now a single \`groupKeysBySection(availableKeys)\` call.

## Test plan
- [ ] Merge, let staging admin redeploy.
- [ ] https://staging.d26q32gc98goap.amplifyapp.com/landing-page → English tab → confirm Hero order is title → subtitle → CTA1 → CTA2 → description.
- [ ] Confirm Newsletter form starts with enterEmail / selectCountry / zipCode / enterZipCode / signUp.
- [ ] Confirm Benefits lists title1 + content1 together, etc.
- [ ] Confirm FAQ interleaves question1/answer1 through question6/answer6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)