### PR TITLE
feat(admin,web,backend): upload + render a configurable landing logo

### DIFF
--- a/apps/admin/src/app/(admin)/landing-page/logo-editor.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/logo-editor.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { uploadData, getUrl } from "aws-amplify/storage";
+import {
+  type LogoVariant,
+  type LogoMode,
+  LOGO_IMAGE_CONSTRAINTS,
+} from "@mapyourhealth/backend/shared/landing-logo";
+import { tenantStoragePath } from "@mapyourhealth/backend/shared/tenant";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Upload, X } from "lucide-react";
+import { toast } from "sonner";
+
+interface Props {
+  /** Label shown above the form, e.g. "Global" or "English override". */
+  heading: string;
+  /**
+   * Tenant the upload is scoped to. All uploads land under
+   * `tenants/{tenantId}/landing/logo/*`.
+   */
+  tenantId: string;
+  /**
+   * Current variant, or `null` when this slot is "no override" (per-locale
+   * only — the Global slot is always present).
+   */
+  value: LogoVariant | null;
+  /** Whether the consumer lets this slot be cleared to "no override". */
+  clearable?: boolean;
+  onChange: (next: LogoVariant | null) => void;
+}
+
+export function LogoEditor({
+  heading,
+  tenantId,
+  value,
+  clearable = false,
+  onChange,
+}: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const mode: LogoMode = value?.mode ?? "text";
+  const isDisabled = value === null;
+
+  const updateField = <K extends keyof LogoVariant>(
+    key: K,
+    val: LogoVariant[K],
+  ) => {
+    const base: LogoVariant = value ?? { mode: "text" };
+    onChange({ ...base, [key]: val });
+  };
+
+  const handleFileSelect = async (file: File) => {
+    const err = validateLogoFile(file);
+    if (err) {
+      toast.error(err);
+      return;
+    }
+    try {
+      setUploading(true);
+      const imageUrl = await uploadLogoFile(tenantId, file);
+      const base: LogoVariant = value ?? { mode: "image" };
+      onChange({ ...base, mode: "image", imageUrl });
+      toast.success("Logo uploaded");
+    } catch (e) {
+      console.error("Logo upload failed:", e);
+      toast.error("Logo upload failed");
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className="space-y-4 border rounded-md p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">{heading}</h3>
+        {clearable && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onChange(value === null ? { mode: "text" } : null)}
+          >
+            {value === null ? "Add override" : (
+              <>
+                <X className="h-3 w-3 mr-1" />
+                Clear override
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+
+      {isDisabled ? (
+        <p className="text-sm text-muted-foreground">
+          Using the global logo for this locale.
+        </p>
+      ) : (
+        <>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                checked={mode === "text"}
+                onChange={() => updateField("mode", "text")}
+              />
+              Text
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                checked={mode === "image"}
+                onChange={() => updateField("mode", "image")}
+              />
+              Image
+            </label>
+          </div>
+
+          {mode === "text" ? (
+            <div className="grid grid-cols-1 sm:grid-cols-[1fr_140px] gap-3">
+              <div className="space-y-1.5">
+                <Label>Text</Label>
+                <Input
+                  value={value?.text ?? ""}
+                  onChange={(e) => updateField("text", e.target.value)}
+                  placeholder="MapYourHealth"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Color</Label>
+                <div className="flex gap-2 items-center">
+                  <input
+                    type="color"
+                    value={value?.textColor ?? "#84cc16"}
+                    onChange={(e) => updateField("textColor", e.target.value)}
+                    className="h-9 w-12 border rounded"
+                  />
+                  <Input
+                    value={value?.textColor ?? ""}
+                    onChange={(e) => updateField("textColor", e.target.value)}
+                    placeholder="#84cc16"
+                    className="font-mono text-xs"
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {value?.imageUrl && (
+                <div className="flex items-center gap-3 rounded-md border p-2 bg-muted/30">
+                  <img
+                    src={value.imageUrl}
+                    alt={value.imageAlt ?? ""}
+                    className="h-10 max-w-32 object-contain"
+                  />
+                  <span className="text-xs text-muted-foreground truncate">
+                    {value.imageUrl}
+                  </span>
+                </div>
+              )}
+              <div className="flex gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png"
+                  hidden
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) handleFileSelect(f);
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploading}
+                >
+                  {uploading ? (
+                    <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+                  ) : (
+                    <Upload className="h-3 w-3 mr-2" />
+                  )}
+                  {value?.imageUrl ? "Replace" : "Upload PNG"}
+                </Button>
+                <p className="text-xs text-muted-foreground self-center">
+                  PNG only, ≤ 500 KB, ≤ 1024×1024
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Alt text</Label>
+                <Input
+                  value={value?.imageAlt ?? ""}
+                  onChange={(e) => updateField("imageAlt", e.target.value)}
+                  placeholder="MapYourHealth"
+                />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function validateLogoFile(file: File): string | null {
+  if (
+    !(LOGO_IMAGE_CONSTRAINTS.allowedMimeTypes as readonly string[]).includes(
+      file.type,
+    )
+  ) {
+    return "Only PNG images are allowed.";
+  }
+  if (file.size > LOGO_IMAGE_CONSTRAINTS.maxBytes) {
+    return `Logo is too large (max ${Math.round(
+      LOGO_IMAGE_CONSTRAINTS.maxBytes / 1024,
+    )} KB).`;
+  }
+  return null;
+}
+
+async function uploadLogoFile(tenantId: string, file: File): Promise<string> {
+  // Image-dimension check (browser-only; skipped in SSR).
+  await ensureDimensionsOk(file);
+
+  const ext = file.name.split(".").pop()?.toLowerCase() ?? "png";
+  const path = tenantStoragePath(
+    tenantId,
+    "landing",
+    "logo",
+    `${Date.now()}.${ext}`,
+  );
+  const upload = await uploadData({
+    path,
+    data: file,
+    options: { contentType: file.type },
+  }).result;
+  const { url } = await getUrl({ path: upload.path });
+  // Strip signed query params — storage is public-read.
+  return url.toString().split("?")[0] ?? url.toString();
+}
+
+function ensureDimensionsOk(file: File): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === "undefined") return resolve();
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      if (
+        img.width > LOGO_IMAGE_CONSTRAINTS.maxDimension ||
+        img.height > LOGO_IMAGE_CONSTRAINTS.maxDimension
+      ) {
+        reject(
+          new Error(
+            `Image exceeds ${LOGO_IMAGE_CONSTRAINTS.maxDimension}×${LOGO_IMAGE_CONSTRAINTS.maxDimension}.`,
+          ),
+        );
+      } else {
+        resolve();
+      }
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Could not read image."));
+    };
+    img.src = url;
+  });
+}

--- a/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { generateClient } from "aws-amplify/data";
+import { fetchAuthSession } from "aws-amplify/auth";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import {
+  DEFAULT_LANDING_LOGO,
+  type LandingLogoConfig,
+  type LogoVariant,
+  parseLandingLogo,
+  serializeLandingLogo,
+} from "@mapyourhealth/backend/shared/landing-logo";
+import {
+  SUPPORTED_LOCALES,
+  type Locale,
+} from "@mapyourhealth/backend/shared/landing-page-content";
+import {
+  DEFAULT_TENANT_ID,
+  landingLogoConfigKey,
+} from "@mapyourhealth/backend/shared/tenant";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2, Save } from "lucide-react";
+import { toast } from "sonner";
+import { LogoEditor } from "./logo-editor";
+
+export function LogoSection() {
+  const tenantId = DEFAULT_TENANT_ID;
+  const configKey = landingLogoConfigKey(tenantId);
+  const [config, setConfig] = useState<LandingLogoConfig>(DEFAULT_LANDING_LOGO);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [recordId, setRecordId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const client = generateClient<Schema>({ authMode: "userPool" });
+        const { data } = await client.models.AppConfig.listAppConfigByConfigKey({
+          configKey,
+        });
+        const row = data?.[0];
+        if (row) {
+          setRecordId(row.id);
+          setConfig(parseLandingLogo(row.value));
+        }
+      } catch (err) {
+        console.error("Failed to load logo config:", err);
+        toast.error("Failed to load logo config");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [configKey]);
+
+  const updateGlobal = (next: LogoVariant | null) => {
+    if (next === null) return; // Global can't be cleared.
+    setConfig((prev) => ({ ...prev, global: next }));
+    setDirty(true);
+  };
+
+  const updateLocale = (locale: Locale, next: LogoVariant | null) => {
+    setConfig((prev) => {
+      const locales = { ...(prev.locales ?? {}) };
+      if (next === null) delete locales[locale];
+      else locales[locale] = next;
+      return { ...prev, locales: Object.keys(locales).length ? locales : undefined };
+    });
+    setDirty(true);
+  };
+
+  const save = async () => {
+    try {
+      setSaving(true);
+      const session = await fetchAuthSession();
+      const email =
+        (session.tokens?.idToken?.payload?.email as string | undefined) ??
+        "admin";
+      const client = generateClient<Schema>({ authMode: "userPool" });
+      const value = serializeLandingLogo(config);
+      if (recordId) {
+        const { errors } = await client.models.AppConfig.update({
+          id: recordId,
+          configKey,
+          value,
+          updatedBy: email,
+        });
+        throwIfErrors(errors);
+      } else {
+        const { data, errors } = await client.models.AppConfig.create({
+          configKey,
+          value,
+          updatedBy: email,
+          description: "Landing page logo config (per tenant)",
+        });
+        throwIfErrors(errors);
+        if (data?.id) setRecordId(data.id);
+      }
+      setDirty(false);
+      toast.success("Logo saved");
+    } catch (err) {
+      console.error("Failed to save logo:", err);
+      toast.error("Failed to save logo");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Logo</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div>
+          <CardTitle>Logo</CardTitle>
+          <CardDescription>
+            Shown top-left on the landing page. Pick Text or Image per slot.
+            The global logo is used unless a locale override is set.
+          </CardDescription>
+        </div>
+        <Button onClick={save} disabled={!dirty || saving}>
+          {saving ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Save className="h-4 w-4 mr-2" />
+          )}
+          Save Logo
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <LogoEditor
+          heading="Global"
+          tenantId={tenantId}
+          value={config.global}
+          onChange={updateGlobal}
+        />
+        {SUPPORTED_LOCALES.map((locale) => (
+          <LogoEditor
+            key={locale}
+            heading={`${locale.toUpperCase()} override`}
+            tenantId={tenantId}
+            value={config.locales?.[locale] ?? null}
+            clearable
+            onChange={(next) => updateLocale(locale, next)}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function throwIfErrors(errors: readonly { message: string }[] | undefined) {
+  if (errors?.length) {
+    throw new Error(errors.map((e) => e.message).join("; "));
+  }
+}

--- a/apps/admin/src/app/(admin)/landing-page/page.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/page.tsx
@@ -29,6 +29,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Loader2, RotateCcw, Save } from "lucide-react";
 import { toast } from "sonner";
+import { LogoSection } from "./logo-section";
 
 const BUNDLED: Record<Locale, Record<string, unknown>> = {
   en: enBundled as Record<string, unknown>,
@@ -221,6 +222,8 @@ export default function LandingPageContentPage() {
           blank (or click Reset) to fall back to the bundled default.
         </p>
       </div>
+
+      <LogoSection />
 
       {loading ? (
         <div className="flex items-center justify-center py-20">

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -1,17 +1,38 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import { useLogoVariant } from "@/context/logo-context";
 import { LanguageSelector } from "./language-selector";
 
 export function Navbar() {
+  const { t } = useTranslation();
+  const variant = useLogoVariant();
+  const fallbackText = t("appName");
+
   return (
     <header className="relative z-10">
       <nav className="flex w-full items-center justify-between px-4 py-4 md:px-6">
         <Link
           href="/"
-          className="font-[family-name:var(--font-netflix-bold)] text-2xl text-primary-500 sm:text-3xl"
+          className="font-[family-name:var(--font-netflix-bold)] text-2xl sm:text-3xl inline-flex items-center"
+          style={
+            variant.mode === "text"
+              ? { color: variant.textColor ?? undefined }
+              : undefined
+          }
         >
-          MapYourHealth
+          {variant.mode === "image" && variant.imageUrl ? (
+            <img
+              src={variant.imageUrl}
+              alt={variant.imageAlt ?? fallbackText}
+              className="h-8 sm:h-10 w-auto"
+            />
+          ) : (
+            <span className={variant.textColor ? undefined : "text-primary-500"}>
+              {variant.text?.trim() || fallbackText}
+            </span>
+          )}
         </Link>
         <LanguageSelector />
       </nav>

--- a/apps/web/src/context/logo-context.tsx
+++ b/apps/web/src/context/logo-context.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import {
+  DEFAULT_LANDING_LOGO,
+  type LandingLogoConfig,
+  type LogoVariant,
+  parseLandingLogo,
+  resolveLogoVariant,
+} from "@mapyourhealth/backend/shared/landing-logo";
+import {
+  DEFAULT_TENANT_ID,
+  landingLogoConfigKey,
+  resolveTenantId,
+} from "@mapyourhealth/backend/shared/tenant";
+
+const LogoConfigContext = createContext<LandingLogoConfig>(DEFAULT_LANDING_LOGO);
+
+export function LogoProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<LandingLogoConfig>(DEFAULT_LANDING_LOGO);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const tenantId =
+          resolveTenantId({
+            hostname:
+              typeof window === "undefined" ? undefined : window.location.hostname,
+          }) ?? DEFAULT_TENANT_ID;
+        const client = generateClient<Schema>({ authMode: "iam" });
+        const { data } = await client.models.AppConfig.listAppConfigByConfigKey(
+          { configKey: landingLogoConfigKey(tenantId) },
+        );
+        if (cancelled || !data?.[0]?.value) return;
+        setConfig(parseLandingLogo(data[0].value));
+      } catch (err) {
+        console.warn("[logo] failed to load config:", err);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <LogoConfigContext.Provider value={config}>
+      {children}
+    </LogoConfigContext.Provider>
+  );
+}
+
+/** Returns the resolved logo variant for the active locale. */
+export function useLogoVariant(): LogoVariant {
+  const config = useContext(LogoConfigContext);
+  const { i18n } = useTranslation();
+  return resolveLogoVariant(config, i18n.language);
+}

--- a/apps/web/src/providers/i18n-provider.tsx
+++ b/apps/web/src/providers/i18n-provider.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider, useTranslation } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { RTL_LANGUAGES, type Language } from "@/lib/i18n/resources";
 import { LandingContentLoader } from "@/components/landing-content-loader";
+import { LogoProvider } from "@/context/logo-context";
 
 const STORAGE_KEY = "i18nextLng";
 const SUPPORTED: Language[] = ["en", "fr"];
@@ -66,7 +67,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       <LanguageDetector />
       <DirectionUpdater />
       <LandingContentLoader />
-      {children}
+      <LogoProvider>{children}</LogoProvider>
     </I18nextProvider>
   );
 }

--- a/packages/backend/amplify/storage/resource.ts
+++ b/packages/backend/amplify/storage/resource.ts
@@ -17,5 +17,12 @@ export const storage = defineStorage({
       allow.authenticated.to(['read']),
       allow.guest.to(['read']),
     ],
+    // Tenant-scoped landing-page assets uploaded from the admin CMS.
+    // Readable by the world (used on the public landing page).
+    'tenants/*': [
+      allow.guest.to(['read']),
+      allow.authenticated.to(['read']),
+      allow.groups(['admin']).to(['read', 'write', 'delete']),
+    ],
   }),
 });

--- a/packages/backend/shared/landing-logo.ts
+++ b/packages/backend/shared/landing-logo.ts
@@ -1,0 +1,93 @@
+import type { Locale } from "./landing-page-content";
+
+export type LogoMode = "text" | "image";
+
+export interface LogoVariant {
+  mode: LogoMode;
+  /** Used when mode === "text". Falls back to bundled `appName` if empty. */
+  text?: string;
+  /** Hex or css color for the text logo. */
+  textColor?: string;
+  /** S3 URL (public read) for the image. */
+  imageUrl?: string;
+  /** Alt text for the image. */
+  imageAlt?: string;
+}
+
+export interface LandingLogoConfig {
+  /** Applied when no locale-specific override is set. */
+  global: LogoVariant;
+  /** Optional per-locale overrides. */
+  locales?: Partial<Record<Locale, LogoVariant>>;
+}
+
+export const DEFAULT_LANDING_LOGO: LandingLogoConfig = {
+  global: { mode: "text" },
+};
+
+export function serializeLandingLogo(config: LandingLogoConfig): string {
+  return JSON.stringify(config);
+}
+
+export function parseLandingLogo(raw: unknown): LandingLogoConfig {
+  if (!raw) return DEFAULT_LANDING_LOGO;
+  const source: unknown = typeof raw === "string" ? safeParse(raw) : raw;
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    return DEFAULT_LANDING_LOGO;
+  }
+  const obj = source as Record<string, unknown>;
+  return {
+    global: coerceVariant(obj.global) ?? DEFAULT_LANDING_LOGO.global,
+    locales: coerceLocales(obj.locales),
+  };
+}
+
+/** Resolve which variant to render for a given locale, with fallback chain. */
+export function resolveLogoVariant(
+  config: LandingLogoConfig,
+  locale: string,
+): LogoVariant {
+  return config.locales?.[locale as Locale] ?? config.global;
+}
+
+// --- helpers -------------------------------------------------------------
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function coerceVariant(raw: unknown): LogoVariant | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const v = raw as Record<string, unknown>;
+  const mode: LogoMode = v.mode === "image" ? "image" : "text";
+  return {
+    mode,
+    text: typeof v.text === "string" ? v.text : undefined,
+    textColor: typeof v.textColor === "string" ? v.textColor : undefined,
+    imageUrl: typeof v.imageUrl === "string" ? v.imageUrl : undefined,
+    imageAlt: typeof v.imageAlt === "string" ? v.imageAlt : undefined,
+  };
+}
+
+function coerceLocales(
+  raw: unknown,
+): Partial<Record<Locale, LogoVariant>> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Partial<Record<Locale, LogoVariant>> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const variant = coerceVariant(value);
+    if (variant) out[key as Locale] = variant;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+/** Client-side validation limits. */
+export const LOGO_IMAGE_CONSTRAINTS = {
+  maxBytes: 500 * 1024,
+  maxDimension: 1024,
+  allowedMimeTypes: ["image/png"] as const,
+};

--- a/packages/backend/shared/tenant.ts
+++ b/packages/backend/shared/tenant.ts
@@ -1,0 +1,27 @@
+/**
+ * Tenant resolution. Today the product is single-tenant; every request
+ * belongs to `DEFAULT_TENANT_ID`. Future multi-tenant work will extend
+ * `resolveTenantId` to read subdomain / cookie / header — callers in
+ * admin + web already go through this helper, so they won't change.
+ *
+ * Config and storage keys include the tenantId so today's data is already
+ * partitioned. No migration will be needed when multi-tenant lands.
+ */
+
+export const DEFAULT_TENANT_ID = "default";
+
+export function resolveTenantId(_ctx?: { hostname?: string }): string {
+  // Placeholder for future subdomain / custom-domain → tenant lookup.
+  return DEFAULT_TENANT_ID;
+}
+
+export function landingLogoConfigKey(tenantId: string): string {
+  return `landingLogo:${tenantId}`;
+}
+
+export function tenantStoragePath(
+  tenantId: string,
+  ...segments: string[]
+): string {
+  return ["tenants", tenantId, ...segments].join("/");
+}


### PR DESCRIPTION
## Summary
Adds a CMS-editable logo for the landing page top-left. Admin chooses Text (custom text + color) or Image (uploaded PNG), with optional per-locale overrides. Built multi-tenant-ready — all records and storage paths include a \`tenantId\` that today resolves to the constant \`\"default\"\`; a future subdomain-based \`resolveTenantId\` is the only change needed to partition by tenant.

### Shared helpers (\`packages/backend/shared/\`)
- **\`tenant.ts\`** — \`DEFAULT_TENANT_ID\`, \`resolveTenantId\`, \`landingLogoConfigKey\`, \`tenantStoragePath\`. One place to flip later.
- **\`landing-logo.ts\`** — \`LandingLogoConfig\` types, \`serialize\`/\`parse\`, \`resolveLogoVariant(config, locale)\` walks the locale → global fallback chain, and \`LOGO_IMAGE_CONSTRAINTS\` (PNG, ≤500 KB, ≤1024×1024).

### Storage
New \`tenants/*\` path with admin read/write/delete and public read. No other paths affected.

### Data
**No schema change.** Reuses the existing \`AppConfig\` model; \`configKey\` is \`landingLogo:{tenantId}\`, \`value\` is a JSON string conforming to \`LandingLogoConfig\`.

### Admin UI (\`apps/admin/src/app/(admin)/landing-page/\`)
- \`logo-section.tsx\` owns the AppConfig load/save.
- \`logo-editor.tsx\` is the shared form reused for Global + each locale slot. Per-locale slots can be cleared back to \"use global\".

### Web (\`apps/web\`)
- New \`LogoProvider\` context fetches the config via IAM guest auth on mount.
- \`navbar.tsx\` reads the resolved variant and renders \`<img>\` or styled text (falling back to the bundled \`appName\` translation).

## Test plan
- [ ] Merge into \`staging\`; wait for backend-staging (storage change) and web-staging / admin-staging to redeploy.
- [ ] In admin \`/landing-page\`: set Global → Text with a non-default color. Hit Save Logo. Verify the web landing shows the new text + color.
- [ ] Upload a PNG via Global → Image, save. Verify landing top-left shows the image.
- [ ] Add a FR override (image), save, switch the web to Français → image shows; switch back to English → global shows.
- [ ] Try to upload a JPG, 2 MB PNG, or 2000×2000 PNG — confirm client-side rejection toast.

## Future follow-ups (not in this PR)
- \`resolveTenantId\` reads subdomain / custom-domain → tenant mapping.
- Admin tenant switcher + auth group scoping.
- Backfill existing AppConfig rows with a tenant on the day multi-tenant ships (current rows don't have one; today's single-tenant code ignores it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)