### PR TITLE
fix(ci): force Amplify to relink workspace packages each build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -64,6 +64,9 @@ applications:
           commands:
             - corepack enable
             - corepack prepare yarn@4.5.3 --activate
+            # Drop cached internal workspace packages so Yarn relinks them
+            # from the fresh checkout (cache otherwise masks workspace edits).
+            - rm -rf ../../node_modules/@mapyourhealth apps/web/node_modules/@mapyourhealth
             - cd ../.. && yarn install --immutable && cd apps/web
             - npx ampx generate outputs --branch $AWS_BRANCH --app-id d3jl0ykn4qgj9r
         build:
@@ -75,7 +78,6 @@ applications:
           - '**/*'
       cache:
         paths:
-          - node_modules/**/*
           - ../../node_modules/**/*
           - .next/cache/**/*
 
@@ -87,6 +89,9 @@ applications:
           commands:
             - corepack enable
             - corepack prepare yarn@4.5.3 --activate
+            # Drop cached internal workspace packages so Yarn relinks them
+            # from the fresh checkout (cache otherwise masks workspace edits).
+            - rm -rf ../../node_modules/@mapyourhealth apps/admin/node_modules/@mapyourhealth
             # Install from monorepo root, then return to admin dir
             - cd ../.. && yarn install --immutable && cd apps/admin
             # Generate Amplify outputs from backend app (ca-central-1)
@@ -100,6 +105,5 @@ applications:
           - '**/*'
       cache:
         paths:
-          - node_modules/**/*
           - ../../node_modules/**/*
           - .next/cache/**/*


### PR DESCRIPTION
Unblocks PR #266's staging deploy — web + admin builds fail with \`Export NewsletterForm doesn't exist in target module\` because Amplify's cached \`../../node_modules/**/*\` holds a stale copy of \`@mapyourhealth/landing-ui\`, masking the fresh workspace source.

## Fix

- Drop any cached \`@mapyourhealth/*\` directories in both root and app-local node_modules before \`yarn install\` so Yarn is forced to relink from the fresh checkout.
- Remove app-local \`node_modules/**/*\` from the cache path list (deps hoist to root; caching app-local adds volume without benefit).

Applies to \`apps/web\` and \`apps/admin\`. Mobile and backend are left untouched.

## Test plan

- [ ] Merge + watch staging deploys for web + admin succeed.
- [ ] Confirm admin preview at staging renders the extracted Navbar/NewsletterForm (closes the loop from #266).

🤖 Generated with [Claude Code](https://claude.com/claude-code)