### PR TITLE
fix(landing): restore Netflix fonts + FAQ/input colour parity on www

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -52,12 +52,15 @@
   --mh-bg: #000000;
   --mh-card-bg: #1c1c1c;
   --mh-surface-alt: #2e2e2e;
+  --mh-faq-row-bg: #1f2937;
+  --mh-faq-row-bg-hover: #374151;
+  --mh-input-bg: #262626;
+  --mh-input-border: #404040;
   --mh-text: #ffffff;
   --mh-text-muted: #a3a3a3;
-  --mh-font-bold: var(--font-netflix-bold);
-  --mh-font-medium: var(--font-netflix-medium);
-  --mh-font-regular: var(--font-netflix-regular);
-  --mh-font-light: var(--font-netflix-light);
+  /* Font vars cannot live on :root because next/font puts --font-netflix-* on
+     <body>; CSS custom-property substitution resolves at the declaring element.
+     Bound on `body` below so the cascade picks them up. */
 
   --card: #1c1c1c;
   --card-foreground: #ffffff;
@@ -83,5 +86,11 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* Bound here (not :root) so var(--font-netflix-*) resolves on the same
+       element where next/font defined them. */
+    --mh-font-bold: var(--font-netflix-bold);
+    --mh-font-medium: var(--font-netflix-medium);
+    --mh-font-regular: var(--font-netflix-regular);
+    --mh-font-light: var(--font-netflix-light);
   }
 }

--- a/packages/landing-ui/src/FaqSection.tsx
+++ b/packages/landing-ui/src/FaqSection.tsx
@@ -8,6 +8,42 @@ type Props = {
   content?: LandingContent;
 };
 
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
 export function FaqSection({ content }: Props) {
   const t = createT(content);
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -26,37 +62,48 @@ export function FaqSection({ content }: Props) {
         {t("home.faqTitle")}
       </h2>
       <div className="flex flex-col">
-        {faqItems.map((item, index) => (
-          <div
-            key={index}
-            className="overflow-hidden border-b-2"
-            style={{ backgroundColor: "var(--mh-surface-alt)", borderColor: "var(--mh-surface-alt)" }}
-          >
-            <button
-              onClick={() => setOpenIndex(openIndex === index ? null : index)}
-              className="flex w-full items-center justify-between p-2 text-left transition-colors"
-              style={{ backgroundColor: "var(--mh-card-bg)", color: "var(--mh-text)" }}
-            >
-              <span className="text-2xl">{item.question}</span>
-              <span
-                aria-hidden
-                className="inline-flex size-8 shrink-0 items-center justify-center text-3xl leading-none"
-              >
-                {openIndex === index ? "\u00d7" : "+"}
-              </span>
-            </button>
+        {faqItems.map((item, index) => {
+          const isOpen = openIndex === index;
+          return (
             <div
-              className="grid transition-all duration-300 ease-in-out"
-              style={{ gridTemplateRows: openIndex === index ? "1fr" : "0fr" }}
+              key={index}
+              className="overflow-hidden border-b-2"
+              style={{
+                backgroundColor: "var(--mh-surface-alt)",
+                borderColor: "var(--mh-surface-alt)",
+              }}
             >
-              <div className="overflow-hidden">
-                <p className="p-2 text-lg whitespace-pre-line" style={{ color: "var(--mh-text)" }}>
-                  {item.answer}
-                </p>
+              <button
+                onClick={() => setOpenIndex(isOpen ? null : index)}
+                className="flex w-full items-center justify-between p-2 text-left transition-colors hover:bg-[var(--mh-faq-row-bg-hover)]"
+                style={{
+                  backgroundColor: "var(--mh-faq-row-bg)",
+                  color: "var(--mh-text)",
+                }}
+              >
+                <span className="text-2xl">{item.question}</span>
+                {isOpen ? (
+                  <CloseIcon className="size-8 shrink-0" />
+                ) : (
+                  <PlusIcon className="size-8 shrink-0" />
+                )}
+              </button>
+              <div
+                className="grid transition-all duration-300 ease-in-out"
+                style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
+              >
+                <div className="overflow-hidden">
+                  <p
+                    className="p-2 text-lg whitespace-pre-line"
+                    style={{ color: "var(--mh-text)" }}
+                  >
+                    {item.answer}
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/packages/landing-ui/src/NewsletterForm.tsx
+++ b/packages/landing-ui/src/NewsletterForm.tsx
@@ -169,10 +169,12 @@ export function NewsletterForm({
   };
 
   const inputStyle = {
-    backgroundColor: "var(--mh-surface-alt)",
-    borderColor: "var(--mh-surface-alt)",
+    backgroundColor: "var(--mh-input-bg)",
+    borderColor: "var(--mh-input-border)",
     color: "var(--mh-text)",
   };
+  const inputClass =
+    "h-11 rounded-md border px-3 placeholder:text-[var(--mh-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--mh-accent)]";
 
   return (
     <div className="mt-4 flex flex-1 flex-col items-center xs:mt-12">
@@ -263,7 +265,7 @@ export function NewsletterForm({
                   placeholder={t("home.enterEmail")}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="h-11 rounded-md border px-3 focus:outline-none"
+                  className={inputClass}
                   style={inputStyle}
                 />
                 {errorMessage && (
@@ -280,7 +282,7 @@ export function NewsletterForm({
                 value={country}
                 onChange={(e) => setCountry(e.target.value)}
                 data-testid="newsletter-country"
-                className="h-11 w-[200px] rounded-md border px-2 focus:outline-none"
+                className="h-11 w-[200px] rounded-md border px-2 focus:outline-none focus:ring-2 focus:ring-[var(--mh-accent)]"
                 style={inputStyle}
               >
                 <option value="">{t("home.selectCountry")}</option>
@@ -296,7 +298,7 @@ export function NewsletterForm({
                 placeholder={t("home.zipCode")}
                 value={zipCode}
                 onChange={(e) => setZipCode(e.target.value)}
-                className="h-11 rounded-md border px-3 focus:outline-none"
+                className={inputClass}
                 style={inputStyle}
               />
             </div>

--- a/packages/landing-ui/src/styles.css
+++ b/packages/landing-ui/src/styles.css
@@ -2,6 +2,10 @@
  * Default CSS variables for @mapyourhealth/landing-ui.
  * Consumers can override any of these at any scope (e.g. :root for global,
  * or on a container to scope to a preview pane).
+ *
+ * Font variables are intentionally NOT defined here. Consumers (apps/web) bind
+ * them on `body` so they resolve where next/font's `--font-*` vars are scoped;
+ * the admin preview leaves them unset and inherits the host's fonts.
  */
 :where(:root) {
   --mh-accent: #9db835;
@@ -10,10 +14,10 @@
   --mh-bg: #000000;
   --mh-card-bg: #1c1c1c;
   --mh-surface-alt: #2e2e2e;
+  --mh-faq-row-bg: #1f2937;
+  --mh-faq-row-bg-hover: #374151;
+  --mh-input-bg: #262626;
+  --mh-input-border: #404040;
   --mh-text: #ffffff;
   --mh-text-muted: #a3a3a3;
-  --mh-font-bold: inherit;
-  --mh-font-medium: inherit;
-  --mh-font-regular: inherit;
-  --mh-font-light: inherit;
 }


### PR DESCRIPTION
After #268 promoted to main, www.mapyourhealth.info had **four visible regressions** vs prod baseline (caught via post-merge screenshot diff). Fixing them on staging first, then promoting.

## Regressions

1. **Fonts:** Netflix Bold/Medium/Regular/Light replaced by browser default sans. CSS custom-property substitution evaluates at the declaring element, and \`:root\` doesn't see \`--font-netflix-*\` (next/font scopes those to \`<body>\`).
2. **FAQ row background:** old \`bg-gray-800\` (#1f2937, blue tint) → \`--mh-card-bg\` (#1c1c1c, neutral). Two tokens were collapsed into one.
3. **NewsletterForm input fields:** old \`bg-neutral-800\` (#262626) + \`border-neutral-700\` (#404040) → both \`--mh-surface-alt\` (#2e2e2e). Border nearly invisible; placeholder + focus ring lost.
4. **FAQ +/× glyphs:** Unicode chars vs lucide SVG (already flagged in #268 — fixed here for parity).

## Fixes

- **Move \`--mh-font-*\` bindings from \`:root\` to \`body\`** in \`apps/web/src/app/globals.css\`. Now resolves correctly because next/font's \`--font-netflix-*\` are scoped to \`<body>\`.
- **Add dedicated tokens** in \`packages/landing-ui/src/styles.css\`:
  - \`--mh-faq-row-bg: #1f2937\`, \`--mh-faq-row-bg-hover: #374151\`
  - \`--mh-input-bg: #262626\`, \`--mh-input-border: #404040\`
- **\`FaqSection\`** uses the new tokens and inline SVG icons matching lucide.
- **\`NewsletterForm\`** uses the new input tokens and re-adds \`placeholder:text-[var(--mh-text-muted)]\` + \`focus:ring-2 focus:ring-[var(--mh-accent)]\` on the inputs/select.

\`THEME_TOKENS\` is **not extended** with the new tokens — they exist only to restore production parity, not as editorial knobs.

## Test plan

- [x] \`npx tsc --noEmit\` — landing-ui, web, admin all clean
- [x] \`npx jest\` — 32 tests pass (newsletter-form, newsletter-form-wrapper, landing-ui)
- [x] \`npx eslint src\` — clean
- [ ] Wait for staging Amplify deploys
- [ ] Capture \`staging.dv0j563gt073v.amplifyapp.com\` screenshots → \`landing-promo-staging-fix-after/\`
- [ ] Diff against \`landing-promo-before/\` (the prod baseline) → expect visual parity
- [ ] If green, open promotion PR \`staging\` → \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)