### PR TITLE
release: promote staging to main (font + colour parity fix #269)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -52,12 +52,15 @@
   --mh-bg: #000000;
   --mh-card-bg: #1c1c1c;
   --mh-surface-alt: #2e2e2e;
+  --mh-faq-row-bg: #1f2937;
+  --mh-faq-row-bg-hover: #374151;
+  --mh-input-bg: #262626;
+  --mh-input-border: #404040;
   --mh-text: #ffffff;
   --mh-text-muted: #a3a3a3;
-  --mh-font-bold: var(--font-netflix-bold);
-  --mh-font-medium: var(--font-netflix-medium);
-  --mh-font-regular: var(--font-netflix-regular);
-  --mh-font-light: var(--font-netflix-light);
+  /* Font vars cannot live on :root because next/font puts --font-netflix-* on
+     <body>; CSS custom-property substitution resolves at the declaring element.
+     Bound on `body` below so the cascade picks them up. */
 
   --card: #1c1c1c;
   --card-foreground: #ffffff;
@@ -83,5 +86,11 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* Bound here (not :root) so var(--font-netflix-*) resolves on the same
+       element where next/font defined them. */
+    --mh-font-bold: var(--font-netflix-bold);
+    --mh-font-medium: var(--font-netflix-medium);
+    --mh-font-regular: var(--font-netflix-regular);
+    --mh-font-light: var(--font-netflix-light);
   }
 }

--- a/packages/landing-ui/src/FaqSection.tsx
+++ b/packages/landing-ui/src/FaqSection.tsx
@@ -8,6 +8,42 @@ type Props = {
   content?: LandingContent;
 };
 
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
 export function FaqSection({ content }: Props) {
   const t = createT(content);
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -26,37 +62,48 @@ export function FaqSection({ content }: Props) {
         {t("home.faqTitle")}
       </h2>
       <div className="flex flex-col">
-        {faqItems.map((item, index) => (
-          <div
-            key={index}
-            className="overflow-hidden border-b-2"
-            style={{ backgroundColor: "var(--mh-surface-alt)", borderColor: "var(--mh-surface-alt)" }}
-          >
-            <button
-              onClick={() => setOpenIndex(openIndex === index ? null : index)}
-              className="flex w-full items-center justify-between p-2 text-left transition-colors"
-              style={{ backgroundColor: "var(--mh-card-bg)", color: "var(--mh-text)" }}
-            >
-              <span className="text-2xl">{item.question}</span>
-              <span
-                aria-hidden
-                className="inline-flex size-8 shrink-0 items-center justify-center text-3xl leading-none"
-              >
-                {openIndex === index ? "\u00d7" : "+"}
-              </span>
-            </button>
+        {faqItems.map((item, index) => {
+          const isOpen = openIndex === index;
+          return (
             <div
-              className="grid transition-all duration-300 ease-in-out"
-              style={{ gridTemplateRows: openIndex === index ? "1fr" : "0fr" }}
+              key={index}
+              className="overflow-hidden border-b-2"
+              style={{
+                backgroundColor: "var(--mh-surface-alt)",
+                borderColor: "var(--mh-surface-alt)",
+              }}
             >
-              <div className="overflow-hidden">
-                <p className="p-2 text-lg whitespace-pre-line" style={{ color: "var(--mh-text)" }}>
-                  {item.answer}
-                </p>
+              <button
+                onClick={() => setOpenIndex(isOpen ? null : index)}
+                className="flex w-full items-center justify-between p-2 text-left transition-colors hover:bg-[var(--mh-faq-row-bg-hover)]"
+                style={{
+                  backgroundColor: "var(--mh-faq-row-bg)",
+                  color: "var(--mh-text)",
+                }}
+              >
+                <span className="text-2xl">{item.question}</span>
+                {isOpen ? (
+                  <CloseIcon className="size-8 shrink-0" />
+                ) : (
+                  <PlusIcon className="size-8 shrink-0" />
+                )}
+              </button>
+              <div
+                className="grid transition-all duration-300 ease-in-out"
+                style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
+              >
+                <div className="overflow-hidden">
+                  <p
+                    className="p-2 text-lg whitespace-pre-line"
+                    style={{ color: "var(--mh-text)" }}
+                  >
+                    {item.answer}
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/packages/landing-ui/src/NewsletterForm.tsx
+++ b/packages/landing-ui/src/NewsletterForm.tsx
@@ -169,10 +169,12 @@ export function NewsletterForm({
   };
 
   const inputStyle = {
-    backgroundColor: "var(--mh-surface-alt)",
-    borderColor: "var(--mh-surface-alt)",
+    backgroundColor: "var(--mh-input-bg)",
+    borderColor: "var(--mh-input-border)",
     color: "var(--mh-text)",
   };
+  const inputClass =
+    "h-11 rounded-md border px-3 placeholder:text-[var(--mh-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--mh-accent)]";
 
   return (
     <div className="mt-4 flex flex-1 flex-col items-center xs:mt-12">
@@ -263,7 +265,7 @@ export function NewsletterForm({
                   placeholder={t("home.enterEmail")}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="h-11 rounded-md border px-3 focus:outline-none"
+                  className={inputClass}
                   style={inputStyle}
                 />
                 {errorMessage && (
@@ -280,7 +282,7 @@ export function NewsletterForm({
                 value={country}
                 onChange={(e) => setCountry(e.target.value)}
                 data-testid="newsletter-country"
-                className="h-11 w-[200px] rounded-md border px-2 focus:outline-none"
+                className="h-11 w-[200px] rounded-md border px-2 focus:outline-none focus:ring-2 focus:ring-[var(--mh-accent)]"
                 style={inputStyle}
               >
                 <option value="">{t("home.selectCountry")}</option>
@@ -296,7 +298,7 @@ export function NewsletterForm({
                 placeholder={t("home.zipCode")}
                 value={zipCode}
                 onChange={(e) => setZipCode(e.target.value)}
-                className="h-11 rounded-md border px-3 focus:outline-none"
+                className={inputClass}
                 style={inputStyle}
               />
             </div>

--- a/packages/landing-ui/src/styles.css
+++ b/packages/landing-ui/src/styles.css
@@ -2,6 +2,10 @@
  * Default CSS variables for @mapyourhealth/landing-ui.
  * Consumers can override any of these at any scope (e.g. :root for global,
  * or on a container to scope to a preview pane).
+ *
+ * Font variables are intentionally NOT defined here. Consumers (apps/web) bind
+ * them on `body` so they resolve where next/font's `--font-*` vars are scoped;
+ * the admin preview leaves them unset and inherits the host's fonts.
  */
 :where(:root) {
   --mh-accent: #9db835;
@@ -10,10 +14,10 @@
   --mh-bg: #000000;
   --mh-card-bg: #1c1c1c;
   --mh-surface-alt: #2e2e2e;
+  --mh-faq-row-bg: #1f2937;
+  --mh-faq-row-bg-hover: #374151;
+  --mh-input-bg: #262626;
+  --mh-input-border: #404040;
   --mh-text: #ffffff;
   --mh-text-muted: #a3a3a3;
-  --mh-font-bold: inherit;
-  --mh-font-medium: inherit;
-  --mh-font-regular: inherit;
-  --mh-font-light: inherit;
 }


### PR DESCRIPTION
Promotes #269 — restores Netflix fonts and FAQ/input colour parity on www that the prior promotion (#268) regressed.

## What lands

- #269 — fix(landing): restore Netflix fonts + FAQ/input colour parity

## Why

After #268 went to main, www showed four regressions vs the prior bundle:

1. Netflix fonts replaced by browser default sans (CSS var resolution scope bug — \`--mh-font-*\` was bound at \`:root\` but \`--font-netflix-*\` is scoped to \`<body>\`).
2. FAQ row background drifted from #1f2937 → #1c1c1c.
3. NewsletterForm input bg/border collapsed onto one token; border nearly invisible.
4. FAQ +/× swapped to Unicode glyphs.

#269 fixes all four. Verified on staging:
- DevTools confirms \`h1FontFamily = "netflixSansBold"\`, \`faqBtnBg = rgb(31,41,55)\` (#1f2937), \`inputBg = rgb(38,38,38)\` (#262626), \`inputBorder = rgb(64,64,64)\` (#404040).
- Visual screenshots side-by-side with the prod baseline: hero, FAQ-collapsed, FAQ-open all match in styling. (Text content on staging hero differs because staging has a CMS override; prod has no overrides so it'll show bundled copy with the restored styling.)

## Visible impact on production

Reverses all four regressions from #268. Brand identity (Netflix Sans), FAQ row blue tint, NewsletterForm input borders, and lucide-style FAQ toggle icons all return.

## Test plan

- [ ] Watch main deploys (web + admin paths only — no backend/admin schema changes; admin path won't trigger since this PR is web-only changes).
- [ ] Visual diff www.mapyourhealth.info against \`landing-promo-before/\` baseline → expect identical styling on hero, FAQ, footer, NewsletterForm.
- [ ] Newsletter subscription still works end-to-end.

## Rollback

\`git revert\` the merge commit. No data, no schema, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)