### PR TITLE
fix(admin): harden landing-page CMS against double-saves + bad theme hex

### DIFF
--- a/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { generateClient } from "aws-amplify/data";
 import { fetchAuthSession } from "aws-amplify/auth";
 import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
@@ -31,14 +31,30 @@ import { Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import { LogoEditor } from "./logo-editor";
 
-export function LogoSection() {
+type Props = {
+  /** Notified whenever the logo's `dirty` flag flips, so the parent can warn
+      on tab-switch. */
+  onDirtyChange?: (dirty: boolean) => void;
+};
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+export function LogoSection({ onDirtyChange }: Props = {}) {
   const tenantId = DEFAULT_TENANT_ID;
   const configKey = landingLogoConfigKey(tenantId);
   const [config, setConfig] = useState<LandingLogoConfig>(DEFAULT_LANDING_LOGO);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
-  const [recordId, setRecordId] = useState<string | null>(null);
+  // Re-entrancy guard: blocks a second save() call while the first is still
+  // mid-flight. Without it, a fast double-click could fire two creates and
+  // produce duplicate AppConfig rows for the same configKey.
+  const savingRef = useRef(false);
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  onDirtyChangeRef.current = onDirtyChange;
 
   useEffect(() => {
     const load = async () => {
@@ -49,18 +65,21 @@ export function LogoSection() {
         });
         const row = data?.[0];
         if (row) {
-          setRecordId(row.id);
           setConfig(parseLandingLogo(row.value));
         }
       } catch (err) {
         console.error("Failed to load logo config:", err);
-        toast.error("Failed to load logo config");
+        toast.error(`Failed to load logo config: ${errorMessage(err, "unknown error")}`);
       } finally {
         setLoading(false);
       }
     };
     load();
   }, [configKey]);
+
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty);
+  }, [dirty]);
 
   const updateGlobal = (next: LogoVariant | null) => {
     if (next === null) return; // Global can't be cleared.
@@ -79,6 +98,8 @@ export function LogoSection() {
   };
 
   const save = async () => {
+    if (savingRef.current) return; // re-entrancy guard
+    savingRef.current = true;
     try {
       setSaving(true);
       const session = await fetchAuthSession();
@@ -87,30 +108,36 @@ export function LogoSection() {
         "admin";
       const client = generateClient<Schema>({ authMode: "userPool" });
       const value = serializeLandingLogo(config);
-      if (recordId) {
+      // Re-query right before write so we update the live record instead of
+      // racing against stale state and creating a duplicate row.
+      const { data: existing } = await client.models.AppConfig.listAppConfigByConfigKey({
+        configKey,
+      });
+      const row = existing?.[0];
+      if (row) {
         const { errors } = await client.models.AppConfig.update({
-          id: recordId,
+          id: row.id,
           configKey,
           value,
           updatedBy: email,
         });
         throwIfErrors(errors);
       } else {
-        const { data, errors } = await client.models.AppConfig.create({
+        const { errors } = await client.models.AppConfig.create({
           configKey,
           value,
           updatedBy: email,
           description: "Landing page logo config (per tenant)",
         });
         throwIfErrors(errors);
-        if (data?.id) setRecordId(data.id);
       }
       setDirty(false);
       toast.success("Logo saved");
     } catch (err) {
       console.error("Failed to save logo:", err);
-      toast.error("Failed to save logo");
+      toast.error(`Failed to save logo: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   };

--- a/apps/admin/src/app/(admin)/landing-page/page.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/page.tsx
@@ -83,6 +83,14 @@ function throwIfErrors(errors: readonly { message: string }[] | undefined) {
   }
 }
 
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+// Accepts #rgb, #rgba, #rrggbb, #rrggbbaa.
+const THEME_HEX_RE = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 export default function LandingPageContentPage() {
   const [activeTab, setActiveTab] = useState<TabKey>("en");
   const [themePreviewLocale, setThemePreviewLocale] = useState<Locale>("en");
@@ -111,7 +119,17 @@ export default function LandingPageContentPage() {
   );
   const [themeOverrides, setThemeOverrides] = useState<LandingThemeTokens>({});
   const [themeDirty, setThemeDirty] = useState(false);
+  const [themeErrors, setThemeErrors] = useState<Record<string, string>>({});
   const [savingTheme, setSavingTheme] = useState(false);
+
+  // Re-entrancy guards: protect against rapid double-clicks that would
+  // otherwise issue two AppSync mutations and allow the later one to silently
+  // overwrite the first (last-write-wins with no version check).
+  const savingLocaleRef = useRef<Record<Locale, boolean>>({ en: false, fr: false });
+  const savingThemeRef = useRef(false);
+  // Mirror of LogoSection's dirty flag, threaded through a ref so we can
+  // include it in the tab-switch confirmation without prop-drilling state.
+  const logoDirtyRef = useRef(false);
 
   // Debounced mirrors used by the preview to avoid re-rendering on every keystroke.
   const [previewValues, setPreviewValues] = useState(values);
@@ -220,6 +238,8 @@ export default function LandingPageContentPage() {
   };
 
   const handleSave = async (locale: Locale) => {
+    if (savingLocaleRef.current[locale]) return;
+    savingLocaleRef.current[locale] = true;
     try {
       setSaving(locale);
       const next = computeOverrides(values[locale], bundledFlat[locale]);
@@ -259,8 +279,9 @@ export default function LandingPageContentPage() {
       );
     } catch (err) {
       console.error("Failed to save:", err);
-      toast.error("Failed to save changes");
+      toast.error(`Failed to save changes: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingLocaleRef.current[locale] = false;
       setSaving(null);
     }
   };
@@ -268,6 +289,15 @@ export default function LandingPageContentPage() {
   const handleThemeChange = (tokenKey: string, value: string) => {
     setThemeTokens((prev) => ({ ...prev, [tokenKey]: value }));
     setThemeDirty(true);
+    setThemeErrors((prev) => {
+      const next = { ...prev };
+      if (value && !THEME_HEX_RE.test(value)) {
+        next[tokenKey] = "Use a hex colour like #9db835";
+      } else {
+        delete next[tokenKey];
+      }
+      return next;
+    });
   };
 
   const handleResetToken = (tokenKey: string) => {
@@ -275,9 +305,23 @@ export default function LandingPageContentPage() {
     if (!def) return;
     setThemeTokens((prev) => ({ ...prev, [tokenKey]: def.default }));
     setThemeDirty(true);
+    setThemeErrors((prev) => {
+      if (!prev[tokenKey]) return prev;
+      const next = { ...prev };
+      delete next[tokenKey];
+      return next;
+    });
   };
 
+  const themeHasErrors = Object.keys(themeErrors).length > 0;
+
   const handleSaveTheme = async () => {
+    if (savingThemeRef.current) return;
+    if (themeHasErrors) {
+      toast.error("Fix invalid colour values before saving");
+      return;
+    }
+    savingThemeRef.current = true;
     try {
       setSavingTheme(true);
       const next = computeThemeOverrides(themeTokens);
@@ -317,8 +361,9 @@ export default function LandingPageContentPage() {
       );
     } catch (err) {
       console.error("Failed to save theme:", err);
-      toast.error("Failed to save theme");
+      toast.error(`Failed to save theme: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingThemeRef.current = false;
       setSavingTheme(false);
     }
   };
@@ -345,6 +390,15 @@ export default function LandingPageContentPage() {
         return;
       }
     }
+    if (logoDirtyRef.current) {
+      if (
+        !window.confirm(
+          "You have unsaved logo changes. Switch tab and lose them?",
+        )
+      ) {
+        return;
+      }
+    }
     setActiveTab(next as TabKey);
   };
 
@@ -358,7 +412,11 @@ export default function LandingPageContentPage() {
         </p>
       </div>
 
-      <LogoSection />
+      <LogoSection
+        onDirtyChange={(d) => {
+          logoDirtyRef.current = d;
+        }}
+      />
 
       {loading ? (
         <div className="flex items-center justify-center py-20">
@@ -512,7 +570,7 @@ export default function LandingPageContentPage() {
                     </div>
                     <Button
                       onClick={handleSaveTheme}
-                      disabled={!themeDirty || savingTheme}
+                      disabled={!themeDirty || savingTheme || themeHasErrors}
                     >
                       {savingTheme ? (
                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -568,7 +626,14 @@ export default function LandingPageContentPage() {
                             <input
                               id={`theme-${token.key}`}
                               type="color"
-                              value={value}
+                              // <input type="color"> needs a 6-char hex; fall
+                              // back to the default if the user typed something
+                              // invalid, otherwise the picker quietly resets.
+                              value={
+                                THEME_HEX_RE.test(value) && value.length === 7
+                                  ? value
+                                  : token.default
+                              }
                               onChange={(e) =>
                                 handleThemeChange(token.key, e.target.value)
                               }
@@ -580,8 +645,14 @@ export default function LandingPageContentPage() {
                                 handleThemeChange(token.key, e.target.value)
                               }
                               className="font-mono"
+                              aria-invalid={Boolean(themeErrors[token.key])}
                             />
                           </div>
+                          {themeErrors[token.key] && (
+                            <p className="text-xs text-destructive">
+                              {themeErrors[token.key]}
+                            </p>
+                          )}
                         </div>
                       );
                     })}


### PR DESCRIPTION
Defensive fixes for the four user-visible CMS issues most likely to bite Rayane in production. Found via a code review of \`apps/admin/src/app/(admin)/landing-page/\`.

## Fixes

### 1. Concurrent-save lock (high)

Both \`handleSave\` (per locale), \`handleSaveTheme\`, and the logo \`save()\` now use a \`useRef\` guard that bails early if a previous call is still in flight.

The \`disabled\` prop on the buttons already provided a UI guard, but a fast double-click before React commits the \`saving\` state could still fire two AppSync mutations and let the second silently overwrite the first (no optimistic locking, no version field).

### 2. Logo create/update race (high)

\`logo-section.tsx\` previously relied on a \`recordId\` state set inside \`save()\`. If two saves happened in quick succession, the second could see \`recordId === null\` and call \`AppConfig.create\` again — producing **two AppConfig rows with the same \`configKey\`**, with non-deterministic read behaviour on the web side.

Now each save re-queries \`AppConfig.listAppConfigByConfigKey\` right before writing and decides create-vs-update from the live data.

### 3. Theme hex validation (medium)

Each theme colour text input is validated against \`/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i\`. Invalid values render an inline error and disable the "Save theme" button. The \`<input type="color">\` falls back to the bundled default when the text input is invalid (the native picker silently resets otherwise).

### 4. Tab-switch confirms unsaved logo edits (medium)

\`LogoSection\` exposes an \`onDirtyChange\` callback that the page wires to a ref. \`handleTabChange\` now also confirms when the logo is dirty, matching the existing behaviour for content + theme dirty flags.

### 5. Real error messages in toasts (low — bonus)

All four save handlers + the logo loader surface \`err.message\` in the toast (e.g. \`"Failed to save changes: NotAuthorizedException"\`) instead of the generic string. Gives Rayane something actionable when an auth token expires mid-edit.

## What's NOT in this PR (deferred from the review)

- **Empty-string overrides** (the \`computeOverrides\` filter) — needs a UX decision: do we want to allow Rayane to *hide* a field by clearing it? Open as a separate question.
- **S3 logo orphan cleanup** — would need either a TTL on the S3 prefix or a cleanup hook on save failure. Not urgent; storage cost is trivial.
- **Logo image alt-text required** — accessibility-only, not data loss.
- **Preview lies about logo override fallback** — admin preview hardcodes text logo. Needs a small refactor.
- **CDN propagation lag** — out of scope for an editor fix.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src\` clean (only pre-existing warnings on unrelated files)
- [ ] Staging admin: type an invalid hex (\`not-a-color\`) into a theme token → see inline error, "Save theme" disabled, attempting Save anyway shows toast.
- [ ] Staging admin: edit logo, switch to English/Theme without saving → confirmation prompt fires.
- [ ] Staging admin: click "Save EN" twice rapidly → only one save fires (verify via Network tab or backend table).
- [ ] Staging admin: simulate failed save (e.g. revoke admin group temporarily) → toast shows the AppSync error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)