### PR TITLE
ci: gate frontend deploys on backend Amplify job (#265)

### DIFF
--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -54,10 +54,68 @@ jobs:
             echo "admin=false" >> $GITHUB_OUTPUT
           fi
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   admin-deploy:
     name: Deploy Admin Portal
     runs-on: ubuntu-latest
-    needs: detect-changes
+    needs: [detect-changes, wait-for-backend]
     if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -88,7 +88,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -97,8 +97,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -54,10 +54,68 @@ jobs:
             echo "mobile=false" >> $GITHUB_OUTPUT
           fi
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   deploy-mobile:
     name: Deploy Mobile Web
     runs-on: ubuntu-latest
-    needs: detect-changes
+    needs: [detect-changes, wait-for-backend]
     if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -88,7 +88,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -97,8 +97,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -51,7 +51,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -68,7 +68,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -77,8 +77,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -34,10 +34,68 @@ jobs:
           timeoutSeconds: 300
           intervalSeconds: 10
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: wait-for-checks
+    if: github.ref_name == 'main' || github.ref_name == 'staging'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   web-deploy:
     name: Deploy Web Landing Page
     runs-on: ubuntu-latest
-    needs: wait-for-checks
+    needs: [wait-for-checks, wait-for-backend]
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:


### PR DESCRIPTION
## Summary
- Each frontend deploy workflow (web, admin, mobile) now includes a `wait-for-backend` job that polls the backend Amplify app for a job with the same commit SHA and blocks the `aws amplify start-job` call until it reports `SUCCEED`.
- The gate only engages when the push actually touches backend paths (`packages/backend/`, `amplify/`, `amplify.yml`); otherwise it's a no-op so backend-free PRs don't wait.
- `FAILED`/`CANCELLED` aborts the frontend deploy instead of shipping a stale `amplify_outputs.json`. Hard timeout at 30 min.

Fixes #265.

## Why
PR #264 (LandingTheme) shipped with `client.models.LandingTheme === undefined` on web because web's Amplify job started at 17:59 and finished at 18:05 — before the backend job published the new schema at 18:04. Admin won the race; web lost it. Re-running web fixed it. This guarantees serial ordering for any future schema-changing PR.

## Test plan
- [ ] Open a staging PR that modifies only `apps/web/**` (no backend change); confirm `wait-for-backend` runs its detection step and exits immediately (`changed=false`), and the web Amplify job starts without waiting.
- [ ] Open a staging PR that modifies `packages/backend/amplify/data/**` plus a frontend file; confirm the frontend workflow logs "No backend job for <sha> yet" until the backend job finishes, then proceeds. Verify the deployed app sees the new model.
- [ ] Simulate a backend `FAILED` (e.g. push a broken schema to a throwaway branch) and confirm the frontend workflow aborts instead of deploying.
- [ ] Manual `workflow_dispatch` of a frontend workflow still deploys even when there is no matching backend job for the SHA (the `HEAD~1` diff will typically show no backend change, so the gate is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)