### PR TITLE
release: promote staging to main (CMS hardening + deploy-race gate)

### DIFF
--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -54,10 +54,68 @@ jobs:
             echo "admin=false" >> $GITHUB_OUTPUT
           fi
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   admin-deploy:
     name: Deploy Admin Portal
     runs-on: ubuntu-latest
-    needs: detect-changes
+    needs: [detect-changes, wait-for-backend]
     if: (needs.detect-changes.outputs.admin_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -88,7 +88,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -97,8 +97,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -54,10 +54,68 @@ jobs:
             echo "mobile=false" >> $GITHUB_OUTPUT
           fi
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   deploy-mobile:
     name: Deploy Mobile Web
     runs-on: ubuntu-latest
-    needs: detect-changes
+    needs: [detect-changes, wait-for-backend]
     if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -88,7 +88,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -97,8 +97,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -51,7 +51,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             BEFORE="HEAD~1"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml|package\.json|yarn\.lock)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -68,7 +68,7 @@ jobs:
       - name: Wait for backend Amplify job to succeed
         if: steps.backend.outputs.changed == 'true'
         run: |
-          set -euo pipefail
+          set -uo pipefail
           APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
           BRANCH="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
@@ -77,8 +77,21 @@ jobs:
             if [ "$(date +%s)" -ge "$DEADLINE" ]; then
               echo "Timed out waiting for backend deploy of $SHA"; exit 1
             fi
-            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
-              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            JOB=""
+            for attempt in 1 2 3; do
+              if JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+                --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json 2>&1); then
+                break
+              fi
+              echo "list-jobs attempt $attempt failed: $JOB"
+              JOB=""
+              sleep 5
+            done
+            if [ -z "$JOB" ]; then
+              echo "list-jobs failed 3 times; will retry on next poll"
+              sleep 20
+              continue
+            fi
             STATUS=$(echo "$JOB" | jq -r '.status // empty')
             if [ -z "$STATUS" ]; then
               echo "No backend job for $SHA yet; waiting..."

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -34,10 +34,68 @@ jobs:
           timeoutSeconds: 300
           intervalSeconds: 10
 
+  wait-for-backend:
+    name: Wait for Backend Deploy
+    runs-on: ubuntu-latest
+    needs: wait-for-checks
+    if: github.ref_name == 'main' || github.ref_name == 'staging'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if backend changed in this push
+        id: backend
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="HEAD~1"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^(packages/backend/|amplify/|amplify\.yml)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.backend.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Wait for backend Amplify job to succeed
+        if: steps.backend.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while true; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "Timed out waiting for backend deploy of $SHA"; exit 1
+            fi
+            JOB=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 20 \
+              --query "jobSummaries[?commitId=='$SHA'] | [0]" --output json)
+            STATUS=$(echo "$JOB" | jq -r '.status // empty')
+            if [ -z "$STATUS" ]; then
+              echo "No backend job for $SHA yet; waiting..."
+            else
+              echo "Backend job status: $STATUS"
+              case "$STATUS" in
+                SUCCEED) echo "Backend deployed; proceeding."; exit 0 ;;
+                FAILED|CANCELLED) echo "Backend deploy $STATUS; aborting frontend."; exit 1 ;;
+              esac
+            fi
+            sleep 20
+          done
+
   web-deploy:
     name: Deploy Web Landing Page
     runs-on: ubuntu-latest
-    needs: wait-for-checks
+    needs: [wait-for-checks, wait-for-backend]
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:

--- a/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/logo-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { generateClient } from "aws-amplify/data";
 import { fetchAuthSession } from "aws-amplify/auth";
 import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
@@ -31,14 +31,30 @@ import { Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import { LogoEditor } from "./logo-editor";
 
-export function LogoSection() {
+type Props = {
+  /** Notified whenever the logo's `dirty` flag flips, so the parent can warn
+      on tab-switch. */
+  onDirtyChange?: (dirty: boolean) => void;
+};
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+export function LogoSection({ onDirtyChange }: Props = {}) {
   const tenantId = DEFAULT_TENANT_ID;
   const configKey = landingLogoConfigKey(tenantId);
   const [config, setConfig] = useState<LandingLogoConfig>(DEFAULT_LANDING_LOGO);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
-  const [recordId, setRecordId] = useState<string | null>(null);
+  // Re-entrancy guard: blocks a second save() call while the first is still
+  // mid-flight. Without it, a fast double-click could fire two creates and
+  // produce duplicate AppConfig rows for the same configKey.
+  const savingRef = useRef(false);
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  onDirtyChangeRef.current = onDirtyChange;
 
   useEffect(() => {
     const load = async () => {
@@ -49,18 +65,21 @@ export function LogoSection() {
         });
         const row = data?.[0];
         if (row) {
-          setRecordId(row.id);
           setConfig(parseLandingLogo(row.value));
         }
       } catch (err) {
         console.error("Failed to load logo config:", err);
-        toast.error("Failed to load logo config");
+        toast.error(`Failed to load logo config: ${errorMessage(err, "unknown error")}`);
       } finally {
         setLoading(false);
       }
     };
     load();
   }, [configKey]);
+
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty);
+  }, [dirty]);
 
   const updateGlobal = (next: LogoVariant | null) => {
     if (next === null) return; // Global can't be cleared.
@@ -79,6 +98,8 @@ export function LogoSection() {
   };
 
   const save = async () => {
+    if (savingRef.current) return; // re-entrancy guard
+    savingRef.current = true;
     try {
       setSaving(true);
       const session = await fetchAuthSession();
@@ -87,30 +108,36 @@ export function LogoSection() {
         "admin";
       const client = generateClient<Schema>({ authMode: "userPool" });
       const value = serializeLandingLogo(config);
-      if (recordId) {
+      // Re-query right before write so we update the live record instead of
+      // racing against stale state and creating a duplicate row.
+      const { data: existing } = await client.models.AppConfig.listAppConfigByConfigKey({
+        configKey,
+      });
+      const row = existing?.[0];
+      if (row) {
         const { errors } = await client.models.AppConfig.update({
-          id: recordId,
+          id: row.id,
           configKey,
           value,
           updatedBy: email,
         });
         throwIfErrors(errors);
       } else {
-        const { data, errors } = await client.models.AppConfig.create({
+        const { errors } = await client.models.AppConfig.create({
           configKey,
           value,
           updatedBy: email,
           description: "Landing page logo config (per tenant)",
         });
         throwIfErrors(errors);
-        if (data?.id) setRecordId(data.id);
       }
       setDirty(false);
       toast.success("Logo saved");
     } catch (err) {
       console.error("Failed to save logo:", err);
-      toast.error("Failed to save logo");
+      toast.error(`Failed to save logo: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   };

--- a/apps/admin/src/app/(admin)/landing-page/page.tsx
+++ b/apps/admin/src/app/(admin)/landing-page/page.tsx
@@ -83,6 +83,14 @@ function throwIfErrors(errors: readonly { message: string }[] | undefined) {
   }
 }
 
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+// Accepts #rgb, #rgba, #rrggbb, #rrggbbaa.
+const THEME_HEX_RE = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 export default function LandingPageContentPage() {
   const [activeTab, setActiveTab] = useState<TabKey>("en");
   const [themePreviewLocale, setThemePreviewLocale] = useState<Locale>("en");
@@ -111,7 +119,17 @@ export default function LandingPageContentPage() {
   );
   const [themeOverrides, setThemeOverrides] = useState<LandingThemeTokens>({});
   const [themeDirty, setThemeDirty] = useState(false);
+  const [themeErrors, setThemeErrors] = useState<Record<string, string>>({});
   const [savingTheme, setSavingTheme] = useState(false);
+
+  // Re-entrancy guards: protect against rapid double-clicks that would
+  // otherwise issue two AppSync mutations and allow the later one to silently
+  // overwrite the first (last-write-wins with no version check).
+  const savingLocaleRef = useRef<Record<Locale, boolean>>({ en: false, fr: false });
+  const savingThemeRef = useRef(false);
+  // Mirror of LogoSection's dirty flag, threaded through a ref so we can
+  // include it in the tab-switch confirmation without prop-drilling state.
+  const logoDirtyRef = useRef(false);
 
   // Debounced mirrors used by the preview to avoid re-rendering on every keystroke.
   const [previewValues, setPreviewValues] = useState(values);
@@ -220,6 +238,8 @@ export default function LandingPageContentPage() {
   };
 
   const handleSave = async (locale: Locale) => {
+    if (savingLocaleRef.current[locale]) return;
+    savingLocaleRef.current[locale] = true;
     try {
       setSaving(locale);
       const next = computeOverrides(values[locale], bundledFlat[locale]);
@@ -259,8 +279,9 @@ export default function LandingPageContentPage() {
       );
     } catch (err) {
       console.error("Failed to save:", err);
-      toast.error("Failed to save changes");
+      toast.error(`Failed to save changes: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingLocaleRef.current[locale] = false;
       setSaving(null);
     }
   };
@@ -268,6 +289,15 @@ export default function LandingPageContentPage() {
   const handleThemeChange = (tokenKey: string, value: string) => {
     setThemeTokens((prev) => ({ ...prev, [tokenKey]: value }));
     setThemeDirty(true);
+    setThemeErrors((prev) => {
+      const next = { ...prev };
+      if (value && !THEME_HEX_RE.test(value)) {
+        next[tokenKey] = "Use a hex colour like #9db835";
+      } else {
+        delete next[tokenKey];
+      }
+      return next;
+    });
   };
 
   const handleResetToken = (tokenKey: string) => {
@@ -275,9 +305,23 @@ export default function LandingPageContentPage() {
     if (!def) return;
     setThemeTokens((prev) => ({ ...prev, [tokenKey]: def.default }));
     setThemeDirty(true);
+    setThemeErrors((prev) => {
+      if (!prev[tokenKey]) return prev;
+      const next = { ...prev };
+      delete next[tokenKey];
+      return next;
+    });
   };
 
+  const themeHasErrors = Object.keys(themeErrors).length > 0;
+
   const handleSaveTheme = async () => {
+    if (savingThemeRef.current) return;
+    if (themeHasErrors) {
+      toast.error("Fix invalid colour values before saving");
+      return;
+    }
+    savingThemeRef.current = true;
     try {
       setSavingTheme(true);
       const next = computeThemeOverrides(themeTokens);
@@ -317,8 +361,9 @@ export default function LandingPageContentPage() {
       );
     } catch (err) {
       console.error("Failed to save theme:", err);
-      toast.error("Failed to save theme");
+      toast.error(`Failed to save theme: ${errorMessage(err, "unknown error")}`);
     } finally {
+      savingThemeRef.current = false;
       setSavingTheme(false);
     }
   };
@@ -345,6 +390,15 @@ export default function LandingPageContentPage() {
         return;
       }
     }
+    if (logoDirtyRef.current) {
+      if (
+        !window.confirm(
+          "You have unsaved logo changes. Switch tab and lose them?",
+        )
+      ) {
+        return;
+      }
+    }
     setActiveTab(next as TabKey);
   };
 
@@ -358,7 +412,11 @@ export default function LandingPageContentPage() {
         </p>
       </div>
 
-      <LogoSection />
+      <LogoSection
+        onDirtyChange={(d) => {
+          logoDirtyRef.current = d;
+        }}
+      />
 
       {loading ? (
         <div className="flex items-center justify-center py-20">
@@ -512,7 +570,7 @@ export default function LandingPageContentPage() {
                     </div>
                     <Button
                       onClick={handleSaveTheme}
-                      disabled={!themeDirty || savingTheme}
+                      disabled={!themeDirty || savingTheme || themeHasErrors}
                     >
                       {savingTheme ? (
                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -568,7 +626,14 @@ export default function LandingPageContentPage() {
                             <input
                               id={`theme-${token.key}`}
                               type="color"
-                              value={value}
+                              // <input type="color"> needs a 6-char hex; fall
+                              // back to the default if the user typed something
+                              // invalid, otherwise the picker quietly resets.
+                              value={
+                                THEME_HEX_RE.test(value) && value.length === 7
+                                  ? value
+                                  : token.default
+                              }
                               onChange={(e) =>
                                 handleThemeChange(token.key, e.target.value)
                               }
@@ -580,8 +645,14 @@ export default function LandingPageContentPage() {
                                 handleThemeChange(token.key, e.target.value)
                               }
                               className="font-mono"
+                              aria-invalid={Boolean(themeErrors[token.key])}
                             />
                           </div>
+                          {themeErrors[token.key] && (
+                            <p className="text-xs text-destructive">
+                              {themeErrors[token.key]}
+                            </p>
+                          )}
                         </div>
                       );
                     })}


### PR DESCRIPTION
## Summary
Promotes two staging-only changes to production:

- **#271** — admin landing-page CMS hardening: concurrent-save lock, logo create/update race fix, theme hex validation, tab-switch-with-dirty-logo confirmation, real error messages in toasts.
- **#272** — CI gate so frontend Amplify deploys wait for the backend Amplify job of the same commit SHA to succeed before starting (fixes #265).

## Test plan
- [ ] After merge, confirm all four frontend Amplify apps (backend / admin / web / mobile-web) deploy successfully on the promotion commit.
- [ ] Load https://www.mapyourhealth.info/ (EN + FR) → renders correctly, no console errors. (Pre-merge baseline already confirmed clean.)
- [ ] Load https://admin.mapyourhealth.info/ → landing-page editor loads, theme section + logo section mount without errors.
- [ ] In admin, type an invalid hex into a theme token → inline error appears, "Save theme" disabled.
- [ ] Double-click "Save EN" → only one AppSync mutation fires.
- [ ] Next PR that touches both `packages/backend/amplify/data/` and a frontend confirms `wait-for-backend` job runs and gates the frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)