### PR TITLE
feat(landing): make Try Web Beta button environment-aware

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
+const APP_URLS: Record<string, string> = {
+  staging: "https://staging.d2z5ddqhlc1q5.amplifyapp.com",
+  main: "https://app.mapyourhealth.info",
+};
+
+const branch = process.env.AWS_BRANCH ?? "main";
+const appUrl = APP_URLS[branch] ?? APP_URLS.main;
+
 const nextConfig: NextConfig = {
   transpilePackages: ["@mapyourhealth/landing-ui"],
+  env: {
+    NEXT_PUBLIC_APP_URL: appUrl,
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/components/newsletter-form.tsx
+++ b/apps/web/src/components/newsletter-form.tsx
@@ -9,7 +9,7 @@ import {
 import type { SubscribeArgs, SubscribeResult } from "@mapyourhealth/landing-ui";
 import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
 
-const APP_URL = "https://app.mapyourhealth.info";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.mapyourhealth.info";
 
 export function NewsletterForm() {
   const { t, i18n } = useTranslation();


### PR DESCRIPTION
## Summary

- The "Try Web Beta" button on the landing page is hardcoded to `https://app.mapyourhealth.info`, so on staging (`https://staging.dv0j563gt073v.amplifyapp.com/`) it sends testers to the production mobile web build instead of the staging build that pairs with the staging backend.
- Derive `NEXT_PUBLIC_APP_URL` at build time from Amplify's auto-injected `AWS_BRANCH` in `apps/web/next.config.ts`, then read it from `process.env.NEXT_PUBLIC_APP_URL` in `newsletter-form.tsx` with the production URL as a fallback for local dev.
- Mapping: `AWS_BRANCH=staging` → `https://staging.d2z5ddqhlc1q5.amplifyapp.com`; anything else (including `main` and unset/local dev) → `https://app.mapyourhealth.info`.

Why this approach: Amplify already injects `AWS_BRANCH` (we use it elsewhere in `amplify.yml` to pick the backend env), so no AWS console env-var setup is needed and the mapping stays in code/PR review. Build-time injection avoids hydration mismatch.

OG/SEO metadata in `apps/web/src/app/layout.tsx` is intentionally left pinned to the canonical production domain — we don't want staging URLs ranking in search.

## Test plan

- [ ] Type check + lint pass: `cd apps/web && npx tsc --noEmit && npm run lint` (verified locally)
- [ ] After merge, `web-deploy.yml` deploys staging
- [ ] Open `https://staging.dv0j563gt073v.amplifyapp.com/`, click both "Try Web Beta" CTAs (post-success state and "Already know" link), verify each opens `https://staging.d2z5ddqhlc1q5.amplifyapp.com/`
- [ ] After staging→main promotion, verify on `https://www.mapyourhealth.info/` that the button still opens `https://app.mapyourhealth.info/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)