### PR TITLE
feat: location hierarchy cascade for sub-locations (#123)

### DIFF
--- a/apps/admin/e2e/admin/cascade-import-validation.spec.ts
+++ b/apps/admin/e2e/admin/cascade-import-validation.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from "@playwright/test";
+import { testUrls, adminCredentials } from "../fixtures/test-data";
+
+/**
+ * E2E-123: Location-hierarchy cascade — admin import validation
+ *
+ * Verifies the admin import page accepts the new state- and country-
+ * scoped CSV rows introduced by PR #278:
+ *   - city + state + country → city-scoped (legacy behavior)
+ *   - state + country (no city) → state-scoped (new)
+ *   - country only (no city/state) → country-scoped (new)
+ *   - city without state → still rejected as ambiguous
+ *
+ * The page-level validation runs entirely client-side, so this spec
+ * doesn't need a seeded backend — it parses the uploaded CSV and
+ * surfaces row-level errors in the preview table. The Import button
+ * isn't clicked: actually inserting rows would touch DynamoDB and
+ * isn't the validation we're verifying here.
+ *
+ * Requires admin credentials via env vars:
+ *   - ADMIN_TEST_EMAIL
+ *   - ADMIN_TEST_PASSWORD
+ */
+
+const hasRealCredentials =
+  process.env.ADMIN_TEST_EMAIL && process.env.ADMIN_TEST_PASSWORD;
+
+// Build a tiny in-memory CSV with one valid row of each scope plus
+// one deliberately-broken row.
+function buildCascadeCsv(): { name: string; mimeType: string; buffer: Buffer } {
+  const csv = [
+    "city,state,country,contaminantId,value,source",
+    // City-scoped (legacy)
+    "Beverly Hills,CA,US,nitrate,8500,EPA",
+    // State-scoped — no city, just state + country
+    ",QC,CA,radon,3.0,Health Canada",
+    // Country-scoped — no city, no state, just country
+    ",,CA,radon,2.5,Federal Average",
+    // Invalid: city without state must still be rejected as ambiguous
+    "Springfield,,US,lead,4.2,Local Lab",
+  ].join("\n");
+  return {
+    name: "cascade-test.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(csv, "utf-8"),
+  };
+}
+
+test.describe("E2E-123: Cascade import validation (#123)", () => {
+  test.skip(
+    !hasRealCredentials,
+    "Skipping - requires ADMIN_TEST_EMAIL and ADMIN_TEST_PASSWORD env vars",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${testUrls.admin}/login`);
+    await page.fill("input#email", adminCredentials.email);
+    await page.fill("input#password", adminCredentials.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await page.waitForURL(`${testUrls.admin}/`, { timeout: 30000 });
+    await page.goto(`${testUrls.admin}/import`);
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("CSV format hint advertises the new optional city/state semantics", async ({
+    page,
+  }) => {
+    // Water Quality tab is the default; the hint should mention that
+    // city + state can be left blank for state-/country-level rows.
+    await page.getByRole("tab", { name: /water quality/i }).click();
+
+    // The import page renders the field hints joined with commas inside
+    // CardDescription. Use a regex on the visible text rather than
+    // exact match so a copy tweak doesn't break the test.
+    await expect(
+      page.getByText(/city.*optional.*leave blank.*state.*country.*level/i),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/state.*optional if city blank/i),
+    ).toBeVisible();
+    await expect(page.getByText(/country.*required/i)).toBeVisible();
+  });
+
+  test("CSV example shows state- and country-scoped rows in the Air Pollution template", async ({
+    page,
+  }) => {
+    // The Air template is where the cascade rows are most useful
+    // (radon is the canonical multi-scope contaminant) — confirm the
+    // example actually demonstrates the new cascade form rather than
+    // just describing it.
+    await page.getByRole("tab", { name: /air pollution/i }).click();
+
+    // The example block contains a state-scoped row ",QC,CA,radon,..."
+    // and a country-scoped row ",,CA,radon,...". Use a forgiving
+    // substring match because <pre> whitespace varies.
+    const examplePre = page.locator("pre", {
+      hasText: /radon/i,
+    });
+    await expect(examplePre.first()).toContainText(",QC,CA,radon");
+    await expect(examplePre.first()).toContainText(",,CA,radon");
+  });
+
+  test("uploading a CSV with mixed scopes accepts state/country rows and rejects city-without-state", async ({
+    page,
+  }) => {
+    await page.getByRole("tab", { name: /water quality/i }).click();
+
+    const fileInput = page.locator('input[type="file"]');
+    const csv = buildCascadeCsv();
+    await fileInput.setInputFiles({
+      name: csv.name,
+      mimeType: csv.mimeType,
+      buffer: csv.buffer,
+    });
+
+    // The preview table should render. Wait for it to appear instead
+    // of hard-coding a delay — the file parser is async.
+    await expect(page.getByText(/Preview/)).toBeVisible({ timeout: 10000 });
+
+    // Three of the four rows are valid (city, state, country scopes);
+    // one is invalid (city without state).
+    await expect(page.getByText(/3 valid/i)).toBeVisible();
+    await expect(page.getByText(/1 invalid/i)).toBeVisible();
+
+    // The invalid row's error column should specifically call out the
+    // city-without-state rule we kept after relaxing the schema.
+    await expect(
+      page.getByText(/state is required when city is provided/i),
+    ).toBeVisible();
+  });
+
+  test("Silent import toggle is present in the preview header", async ({
+    page,
+  }) => {
+    // Bulk imports flagged as silent must NOT trigger notification fan-
+    // out, especially now that state/country-scoped rows can blast
+    // every subscriber in a country.
+    await page.getByRole("tab", { name: /water quality/i }).click();
+
+    const fileInput = page.locator('input[type="file"]');
+    const csv = buildCascadeCsv();
+    await fileInput.setInputFiles({
+      name: csv.name,
+      mimeType: csv.mimeType,
+      buffer: csv.buffer,
+    });
+
+    await expect(page.getByText(/Preview/)).toBeVisible({ timeout: 10000 });
+
+    // The toggle is rendered as a labelled switch — assert by label
+    // text and the implicit role.
+    await expect(page.getByLabel(/silent import/i)).toBeVisible();
+  });
+});

--- a/apps/admin/src/app/(admin)/import/page.tsx
+++ b/apps/admin/src/app/(admin)/import/page.tsx
@@ -87,9 +87,9 @@ Beverly Hills,CA,US,nitrate,8500,EPA
 Beverly Hills,CA,US,lead,4.2,Local Lab
 New York,NY,US,arsenic,3.1,EPA`,
     fields: [
-      "city",
-      "state",
-      "country",
+      "city (optional — leave blank for state/country-level row)",
+      "state (optional if city blank — leave blank for country-level row)",
+      "country (required)",
       "contaminantId",
       "value",
       "source (optional)",
@@ -98,12 +98,12 @@ New York,NY,US,arsenic,3.1,EPA`,
   air: {
     example: `city,state,country,contaminantId,value,source
 Beverly Hills,CA,US,radon,2.8,EPA
-New York,NY,US,radon,1.5,State Survey
-Montreal,QC,CA,radon,3.2,Health Canada`,
+,QC,CA,radon,3.0,Health Canada
+,,CA,radon,2.5,Federal Average`,
     fields: [
-      "city",
-      "state",
-      "country",
+      "city (optional — leave blank for state/country-level row)",
+      "state (optional if city blank — leave blank for country-level row)",
+      "country (required)",
       "contaminantId (e.g., radon)",
       "value (pCi/L)",
       "source (optional)",
@@ -165,16 +165,17 @@ export default function ImportPage() {
   ): ImportRow => {
     const errors: string[] = [];
 
-    if (!row.city || row.city.length < 1) {
-      errors.push("City is required");
-    }
-
-    if (!row.state || row.state.length < 1) {
-      errors.push("State is required");
-    }
-
+    // Location hierarchy (#123): country is the only required location level.
+    // - city + state + country → city-scoped record
+    // - state + country (no city) → state-scoped (cascades to every city)
+    // - country only (no city/state) → country-scoped (cascades to every city)
+    // City-without-state is rejected as ambiguous.
     if (!row.country || row.country.length < 1) {
       errors.push("Country is required");
+    }
+
+    if (row.city && row.city.length > 0 && (!row.state || row.state.length < 1)) {
+      errors.push("State is required when city is provided");
     }
 
     if (!row.contaminantId) {
@@ -445,9 +446,11 @@ export default function ImportPage() {
 
       for (const row of validRows) {
         try {
+          // Location hierarchy (#123): pass null for omitted city/state so
+          // the row is anchored at the appropriate cascade level.
           await client.models.LocationMeasurement.create({
-            city: row.city,
-            state: row.state,
+            city: row.city || null,
+            state: row.state || null,
             country: row.country,
             contaminantId: row.contaminantId,
             value: row.value,
@@ -459,8 +462,13 @@ export default function ImportPage() {
           result.success++;
         } catch (error) {
           result.failed++;
+          const scopeLabel = row.city
+            ? `${row.city}, ${row.state}`
+            : row.state
+              ? `${row.state}, ${row.country}`
+              : row.country;
           result.errors.push(
-            `${row.city}, ${row.state}/${row.contaminantId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+            `${scopeLabel}/${row.contaminantId}: ${error instanceof Error ? error.message : "Unknown error"}`,
           );
         }
       }

--- a/apps/admin/src/app/(admin)/observations/page.tsx
+++ b/apps/admin/src/app/(admin)/observations/page.tsx
@@ -148,8 +148,9 @@ export default function ObservationsPage() {
   const openEditDialog = (observation: LocationObservation) => {
     setEditingObservation(observation);
     setFormData({
-      city: observation.city,
-      state: observation.state,
+      // city/state may be null on state-/country-anchored records (#123).
+      city: observation.city ?? "",
+      state: observation.state ?? "",
       country: observation.country,
       county: observation.county || "",
       propertyId: observation.propertyId,
@@ -172,14 +173,15 @@ export default function ObservationsPage() {
   };
 
   const handleSave = async () => {
-    if (
-      !formData.city ||
-      !formData.state ||
-      !formData.country ||
-      !formData.propertyId ||
-      !formData.observedAt
-    ) {
-      toast.error("Please fill in all required fields");
+    // Location hierarchy (#123): country is the only required location level.
+    // Allow city- (city + state + country), state- (state + country), or
+    // country-scoped (country only) records. Reject city without state.
+    if (!formData.country || !formData.propertyId || !formData.observedAt) {
+      toast.error("Country, property, and observed-at are required");
+      return;
+    }
+    if (formData.city && !formData.state) {
+      toast.error("State is required when city is provided");
       return;
     }
 
@@ -188,8 +190,10 @@ export default function ObservationsPage() {
       const client = generateClient<Schema>();
 
       const observationData = {
-        city: formData.city,
-        state: formData.state,
+        // Pass null for omitted city/state so the row is anchored at the
+        // appropriate cascade level.
+        city: formData.city || null,
+        state: formData.state || null,
         country: formData.country,
         county: formData.county || null,
         propertyId: formData.propertyId,
@@ -266,13 +270,16 @@ export default function ObservationsPage() {
     ? getProperty(formData.propertyId)
     : null;
 
-  // Get unique countries and states for filters
+  // Get unique countries and states for filters. With cascade scope (#123),
+  // state may be null on country-anchored records — drop those from the
+  // state filter rather than crashing.
   const countries = [...new Set(observations.map((o) => o.country))].sort();
   const states = [
     ...new Set(
       observations
         .filter((o) => filterCountry === "all" || o.country === filterCountry)
         .map((o) => o.state)
+        .filter((s): s is string => Boolean(s))
     ),
   ].sort();
 
@@ -341,13 +348,22 @@ export default function ObservationsPage() {
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
-              {/* Location */}
+              {/* Location hierarchy (#123): country is required; city + state
+                  are optional. Leaving city blank → state-scoped record;
+                  leaving city + state blank → country-scoped. */}
+              <p className="text-xs text-muted-foreground">
+                Tip: leave <strong>city</strong> blank for a state-level
+                observation, or leave both <strong>city</strong> and
+                <strong> state</strong> blank for a country-level observation.
+                The mobile app will cascade city → state → country
+                automatically.
+              </p>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="city">City *</Label>
+                  <Label htmlFor="city">City</Label>
                   <Input
                     id="city"
-                    placeholder="e.g., Montreal"
+                    placeholder="e.g., Montreal (blank = state/country-level)"
                     value={formData.city}
                     onChange={(e) =>
                       setFormData({ ...formData, city: e.target.value })
@@ -369,10 +385,10 @@ export default function ObservationsPage() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="state">State/Province *</Label>
+                  <Label htmlFor="state">State/Province</Label>
                   <Input
                     id="state"
-                    placeholder="e.g., QC"
+                    placeholder="e.g., QC (blank = country-level)"
                     value={formData.state}
                     onChange={(e) =>
                       setFormData({ ...formData, state: e.target.value })

--- a/apps/admin/src/app/(admin)/observations/page.tsx
+++ b/apps/admin/src/app/(admin)/observations/page.tsx
@@ -241,9 +241,14 @@ export default function ObservationsPage() {
     const propertyName =
       properties.find((p) => p.propertyId === observation.propertyId)?.name ||
       observation.propertyId;
+    // Cascade scope (#123): city/state may be null on state-/country-anchored records.
+    const locationLabel =
+      [observation.city, observation.state, observation.country]
+        .filter(Boolean)
+        .join(", ") || "this location";
     if (
       !confirm(
-        `Are you sure you want to delete the "${propertyName}" observation for ${observation.city}, ${observation.state}?`
+        `Are you sure you want to delete the "${propertyName}" observation for ${locationLabel}?`
       )
     ) {
       return;
@@ -709,13 +714,23 @@ export default function ObservationsPage() {
               <TableBody>
                 {filteredObservations.map((observation) => {
                   const property = getProperty(observation.propertyId);
+                  // Cascade scope (#123): city/state may be null. Show the
+                  // most-specific populated level on the primary line and
+                  // the rest of the location chain on the secondary line.
+                  const primary =
+                    observation.city || observation.state || observation.country;
+                  const secondary = observation.city
+                    ? [observation.state, observation.country].filter(Boolean).join(", ")
+                    : observation.state
+                      ? observation.country ?? ""
+                      : "";
                   return (
                     <TableRow key={observation.id}>
                       <TableCell>
-                        <div className="font-medium">{observation.city}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {observation.state}, {observation.country}
-                        </div>
+                        <div className="font-medium">{primary}</div>
+                        {secondary && (
+                          <div className="text-sm text-muted-foreground">{secondary}</div>
+                        )}
                       </TableCell>
                       <TableCell>
                         {property ? (

--- a/apps/admin/src/app/(admin)/page.tsx
+++ b/apps/admin/src/app/(admin)/page.tsx
@@ -63,12 +63,15 @@ export default function AdminDashboard() {
         // Count contaminants
         const contaminants = contaminantsResult.data?.length || 0;
 
-        // Count unique cities with data
+        // Count unique cities with data. Cascade scope (#123) means
+        // city/state may be null on state-/country-anchored records — skip
+        // those so the count reflects actual distinct city locations
+        // rather than collapsing every null row into one bogus bucket.
         const uniqueCities = new Set(
-          measurementsResult.data?.map((m) => {
-            const measurement = m as LocationMeasurementWithLocation;
-            return `${measurement.city}|${measurement.state}`;
-          }) || [],
+          measurementsResult.data
+            ?.map((m) => m as LocationMeasurementWithLocation)
+            .filter((m) => m.city && m.state)
+            .map((m) => `${m.city}|${m.state}`) || [],
         );
         const locationsWithData = uniqueCities.size;
 

--- a/apps/admin/src/app/(admin)/pollution-sources/page.tsx
+++ b/apps/admin/src/app/(admin)/pollution-sources/page.tsx
@@ -401,7 +401,11 @@ export default function PollutionSourcesPage() {
                           {source.name}
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {source.city}, {source.state}
+                          {/* Cascade scope (#123): city/state may be null
+                              on state-/country-anchored records. */}
+                          {[source.city, source.state, source.country]
+                            .filter(Boolean)
+                            .join(", ") || "—"}
                         </div>
                         <div className="flex items-center gap-2 mt-1">
                           <Badge

--- a/apps/admin/src/app/(admin)/pollution-sources/page.tsx
+++ b/apps/admin/src/app/(admin)/pollution-sources/page.tsx
@@ -174,15 +174,23 @@ export default function PollutionSourcesPage() {
         
         toast.success("Pollution source updated successfully");
       } else {
-        // Create new source
+        // Create new source. Location hierarchy (#123): country is required;
+        // city/state are optional and determine the cascade scope of the
+        // record (city-, state-, or country-scoped).
+        if (!sourceData.country) {
+          throw new Error("Country is required for pollution sources");
+        }
+        if (sourceData.city && !sourceData.state) {
+          throw new Error("State is required when city is provided");
+        }
         const result = await client.models.PollutionSource.create({
           name: sourceData.name || "Unnamed Source",
           latitude: sourceData.latitude || 0,
           longitude: sourceData.longitude || 0,
           impactRadius: sourceData.impactRadius || 500,
-          city: sourceData.city || "",
-          state: sourceData.state || "",
-          country: sourceData.country || "",
+          city: sourceData.city || null,
+          state: sourceData.state || null,
+          country: sourceData.country,
           sourceId: `PS_${Date.now()}`,
           sourceType: sourceData.sourceType,
           address: sourceData.address,

--- a/apps/admin/src/app/(admin)/zip-codes/[zipCode]/page.tsx
+++ b/apps/admin/src/app/(admin)/zip-codes/[zipCode]/page.tsx
@@ -211,10 +211,22 @@ export default function LocationDetailPage({
       const value = parseFloat(formData.value);
       const now = new Date().toISOString();
 
+      // Inherit state/country from any existing measurement for this city,
+      // or from the row being edited. Schema (#123) requires `country`, so
+      // surface a clear error if neither is available rather than failing
+      // opaquely on create.
+      const reference = editingMeasurement ?? measurements[0];
+      if (!reference?.country) {
+        toast.error(
+          "Cannot infer country for this city — add a measurement via the import page first.",
+        );
+        setIsSaving(false);
+        return;
+      }
       const measurementData = {
         city: cityName,
-        state: "",
-        country: "",
+        state: reference.state ?? null,
+        country: reference.country,
         contaminantId: formData.contaminantId,
         value,
         measuredAt: now,

--- a/apps/admin/src/components/pollution-sources/PollutionSourceMap.tsx
+++ b/apps/admin/src/components/pollution-sources/PollutionSourceMap.tsx
@@ -70,8 +70,10 @@ const sourceFormSchema = z.object({
   longitude: z.number().min(-180).max(180),
   impactRadius: z.number().min(1, "Radius must be at least 1 meter").max(50000, "Radius cannot exceed 50km"),
   address: z.string().optional(),
-  city: z.string().min(1, "City is required"),
-  state: z.string().min(1, "State/Province is required"),
+  // Location hierarchy (#123): country is required; city/state are optional
+  // and define the cascade scope. City without state is rejected as ambiguous.
+  city: z.string().optional(),
+  state: z.string().optional(),
   country: z.string().min(1, "Country is required"),
   jurisdictionCode: z.string().min(1, "Jurisdiction is required"),
   primaryContaminants: z.array(z.string()).min(0),
@@ -79,7 +81,10 @@ const sourceFormSchema = z.object({
   status: z.enum(["active", "monitored", "remediated", "closed"]),
   description: z.string().optional(),
   notes: z.string().optional(),
-});
+}).refine(
+  (data) => !(data.city && !data.state),
+  { message: "State is required when city is provided", path: ["state"] },
+);
 
 type FormData = z.infer<typeof sourceFormSchema>;
 
@@ -431,13 +436,21 @@ export default function PollutionSourceMap({
                   />
                 </div>
 
+                {/* Location hierarchy (#123): country is required; city/state
+                    are optional and set the cascade scope of this source. */}
+                <p className="text-xs text-muted-foreground">
+                  Tip: leave city blank for a state-wide source, or both city
+                  and state blank for a country-wide source. The mobile app
+                  will surface higher-scope sources to every city in the same
+                  state/country that lacks its own data.
+                </p>
                 <div className="grid grid-cols-3 gap-3">
                   <div>
-                    <Label htmlFor="city">City *</Label>
+                    <Label htmlFor="city">City</Label>
                     <Input
                       id="city"
                       {...register("city")}
-                      placeholder="Montreal"
+                      placeholder="Montreal (optional)"
                     />
                     {errors.city && (
                       <p className="text-sm text-red-500 mt-1">{errors.city.message}</p>
@@ -445,11 +458,11 @@ export default function PollutionSourceMap({
                   </div>
 
                   <div>
-                    <Label htmlFor="state">State/Province *</Label>
+                    <Label htmlFor="state">State/Province</Label>
                     <Input
                       id="state"
                       {...register("state")}
-                      placeholder="QC"
+                      placeholder="QC (optional)"
                     />
                     {errors.state && (
                       <p className="text-sm text-red-500 mt-1">{errors.state.message}</p>

--- a/apps/mobile/.maestro/flows/E2E-123-location-hierarchy-cascade.yaml
+++ b/apps/mobile/.maestro/flows/E2E-123-location-hierarchy-cascade.yaml
@@ -1,0 +1,147 @@
+# flow: E2E-123 Location Hierarchy Cascade (#123)
+# intent:
+#   Verify the city → state → country cascade end-to-end:
+#   1. Search a Quebec city that has no city-specific data
+#      (Sorel-Tracy is documented in PR #278 as a state-fallback target).
+#   2. Confirm the Dashboard surfaces inherited data instead of the
+#      no-data empty state.
+#   3. Confirm the LocationScopeBadge renders provenance ("Showing QC
+#      data" or similar) so the user knows the data is inherited.
+#   4. Drill into the Health Observations screen and confirm the
+#      legacy `state-fallback-banner` testID still resolves there.
+#
+# Pre-requisites (staging):
+#   - LocationMeasurement rows seeded with `state: "QC", country: "CA",
+#     city: null` for at least one contaminant.
+#   - LocationObservation rows seeded with `state: "QC", country: "CA",
+#     city: null` for at least one observed property.
+#
+# When this flow runs against a backend that has not been seeded with
+# state-anchored rows, the assertions on the badge / banner are
+# expected to fail — the dashboard would correctly show the "no data"
+# empty state instead. That's the verification we want.
+
+appId: ${MAESTRO_APP_ID}
+onFlowStart:
+  - runFlow: ../shared/_OnFlowStart.yaml
+---
+
+# ========================================
+# Part 1: Search a no-data Quebec city
+# ========================================
+- assertVisible:
+    text: "Search city or location..."
+    label: "Search bar visible at app start"
+
+- tapOn:
+    text: "Search city or.*"
+    label: "Tap on search bar"
+
+- inputText: "Sorel-Tracy"
+
+# Wait for Google Places autocomplete suggestions
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- tapOn:
+    text: ".*Sorel-Tracy.*QC.*"
+    index: 0
+    label: "Select Sorel-Tracy from autocomplete"
+
+# Allow the dashboard to fetch and resolve the cascade
+- waitForAnimationToEnd:
+    timeout: 8000
+
+- extendedWaitUntil:
+    visible: "Sorel-Tracy"
+    timeout: 10000
+
+# ========================================
+# Part 2: Confirm cascade resolved (badge present)
+# ========================================
+# Cascade resolved → provenance badge is rendered.
+# Accept either label form (state name or generic fallback).
+- assertVisible:
+    id: "location-scope-badge"
+    optional: false
+    label: "Cascade-scope badge is rendered for state-level fallback"
+
+# Belt-and-suspenders text assertion — fails only if the badge is
+# rendered for some non-cascade reason. Both QC and "Showing"
+# substrings tolerate copy variations.
+- assertVisible:
+    text: "Showing.*QC.*"
+    label: "Badge label mentions the resolved scope (QC)"
+    optional: true
+
+# ========================================
+# Part 3: Cascade should hide the no-data empty state
+# ========================================
+# The dashboard should NOT be in its empty / "Find out how safe..."
+# state because the cascade resolved. If this assertion fires it
+# means the inherited data path didn't kick in.
+- assertNotVisible:
+    text: "Find out how safe your location is"
+    label: "Dashboard renders inherited data, not the guest empty state"
+
+- assertNotVisible:
+    text: "Search above to get safety insights"
+    optional: true
+    label: "No-data hint is not shown when cascade resolved"
+
+# ========================================
+# Part 4: Verify legacy testID survives on the observations screen
+# ========================================
+# The LocationScopeBadge in LocationObservationsScreen carries the
+# legacy `state-fallback-banner` testID specifically when scope is
+# state. This is a regression test for I4 — the prior wrapper-with-
+# conditional-testID would always have rendered an empty wrapper here
+# even for city-scope data.
+- runFlow:
+    when:
+      visible: "Health Observations"
+    commands:
+      - tapOn:
+          text: "Health Observations"
+          label: "Open Health Observations from the dashboard"
+      - waitForAnimationToEnd:
+          timeout: 5000
+      - assertVisible:
+          id: "state-fallback-banner"
+          label: "Legacy state-fallback-banner testID resolves on observations screen"
+      - back
+      - waitForAnimationToEnd:
+          timeout: 2000
+
+# ========================================
+# Part 5: Sanity — searching a city WITH data should NOT show a badge
+# ========================================
+# Beverly Hills (US-CA) has city-specific data; the badge must not
+# render for the common case so we don't clutter the UI.
+- tapOn:
+    text: "Sorel-Tracy.*"
+    label: "Tap search bar again"
+
+- inputText: "Beverly Hills"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- tapOn:
+    text: ".*Beverly Hills.*CA.*"
+    index: 0
+    label: "Select Beverly Hills from autocomplete"
+
+- waitForAnimationToEnd:
+    timeout: 8000
+
+- extendedWaitUntil:
+    visible: "Beverly Hills"
+    timeout: 10000
+
+# Badge should NOT render for city-scope data (this is the
+# behaviour LocationScopeBadge implements: returns null for
+# `scope === "city"`).
+- assertNotVisible:
+    id: "location-scope-badge"
+    label: "No cascade badge for city-specific data (regression check)"

--- a/apps/mobile/app/components/LocationScopeBadge.test.tsx
+++ b/apps/mobile/app/components/LocationScopeBadge.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for LocationScopeBadge
+ *
+ * Verifies the cascade-scope badge (#123) renders only for non-city scopes,
+ * exposes an accessible label, and falls back to a generic label when the
+ * caller doesn't supply state/country names.
+ *
+ * The component normally pulls in `@/theme/context`, which transitively
+ * imports `@expo-google-fonts/space-grotesk` (a known broken-in-jest
+ * dependency in this monorepo). We mock `useAppTheme` directly so the
+ * test exercises only the badge logic, not the theme loader.
+ */
+
+import { render } from "@testing-library/react-native"
+
+jest.mock("@/theme/context", () => ({
+  useAppTheme: () => ({
+    theme: {
+      colors: {
+        accentBlueBg: "#E0F2FE",
+        tint: "#0284C7",
+      },
+    },
+    // Ignite's `useAppTheme` returns a `themed()` helper used by Text;
+    // pass styles through unchanged so render doesn't blow up.
+    themed: (style: unknown) => style,
+  }),
+}))
+
+// eslint-disable-next-line import/first
+import { LocationScopeBadge } from "./LocationScopeBadge"
+
+describe("LocationScopeBadge", () => {
+  it("renders nothing for city scope (no badge clutter for the common case)", () => {
+    const { queryByTestId } = render(<LocationScopeBadge scope="city" state="QC" country="CA" />)
+    expect(queryByTestId("location-scope-badge")).toBeNull()
+  })
+
+  it("renders nothing when no cascade resolved (scope=none)", () => {
+    const { queryByTestId } = render(<LocationScopeBadge scope="none" state="QC" country="CA" />)
+    expect(queryByTestId("location-scope-badge")).toBeNull()
+  })
+
+  it("renders the state label for state-scope fallback", () => {
+    const { getByTestId, getByText } = render(
+      <LocationScopeBadge scope="state" state="QC" country="CA" />,
+    )
+    expect(getByTestId("location-scope-badge")).toBeTruthy()
+    expect(getByText("Showing QC data")).toBeTruthy()
+  })
+
+  it("renders the country label for country-scope fallback", () => {
+    const { getByTestId, getByText } = render(
+      <LocationScopeBadge scope="country" state="QC" country="CA" />,
+    )
+    expect(getByTestId("location-scope-badge")).toBeTruthy()
+    expect(getByText("Showing CA data")).toBeTruthy()
+  })
+
+  it("falls back to a generic label when state name is missing for state scope", () => {
+    const { getByText } = render(<LocationScopeBadge scope="state" />)
+    expect(getByText("Showing state-level data")).toBeTruthy()
+  })
+
+  it("falls back to a generic label when country name is missing for country scope", () => {
+    const { getByText } = render(<LocationScopeBadge scope="country" />)
+    expect(getByText("Showing country-level data")).toBeTruthy()
+  })
+
+  it("exposes an accessibility label that screen readers will announce", () => {
+    const { getByLabelText } = render(<LocationScopeBadge scope="state" state="QC" country="CA" />)
+    expect(getByLabelText("Showing QC data")).toBeTruthy()
+  })
+})

--- a/apps/mobile/app/components/LocationScopeBadge.tsx
+++ b/apps/mobile/app/components/LocationScopeBadge.tsx
@@ -1,0 +1,76 @@
+/**
+ * LocationScopeBadge — small inline pill that surfaces the source level of
+ * cascaded data (#123). Renders nothing for "city" and "none" scopes so the
+ * common case (city-specific data) stays uncluttered.
+ *
+ * Used by every screen that consumes a cascading hook — DashboardScreen,
+ * CategoryDetailScreen, PollutionSourcesScreen, LocationObservationsScreen.
+ */
+
+import { FC } from "react"
+import { View, ViewStyle, TextStyle } from "react-native"
+import { MaterialCommunityIcons } from "@expo/vector-icons"
+
+import { Text } from "@/components/Text"
+import { describeScope, type LocationScope } from "@/lib/locationFallback"
+import { useAppTheme } from "@/theme/context"
+
+interface LocationScopeBadgeProps {
+  scope: LocationScope
+  state?: string
+  country?: string
+  /** Optional style override (e.g. margins). */
+  style?: ViewStyle
+}
+
+export const LocationScopeBadge: FC<LocationScopeBadgeProps> = ({
+  scope,
+  state,
+  country,
+  style,
+}) => {
+  const { theme } = useAppTheme()
+  const label = describeScope(scope, { state, country })
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <View
+      // eslint-disable-next-line react-native/no-inline-styles
+      style={[
+        $container,
+        { backgroundColor: theme.colors.accentBlueBg, borderColor: theme.colors.tint },
+        style,
+      ]}
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      testID="location-scope-badge"
+    >
+      <MaterialCommunityIcons
+        name="map-marker-radius-outline"
+        size={14}
+        color={theme.colors.tint}
+      />
+      {/* eslint-disable-next-line react-native/no-inline-styles */}
+      <Text style={[$label, { color: theme.colors.tint }]}>{label}</Text>
+    </View>
+  )
+}
+
+const $container: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  alignSelf: "flex-start",
+  paddingHorizontal: 10,
+  paddingVertical: 4,
+  borderRadius: 12,
+  borderWidth: 1,
+  gap: 6,
+}
+
+const $label: TextStyle = {
+  fontSize: 12,
+  fontWeight: "600",
+}

--- a/apps/mobile/app/components/LocationScopeBadge.tsx
+++ b/apps/mobile/app/components/LocationScopeBadge.tsx
@@ -21,6 +21,13 @@ interface LocationScopeBadgeProps {
   country?: string
   /** Optional style override (e.g. margins). */
   style?: ViewStyle
+  /**
+   * Optional testID override. Defaults to "location-scope-badge". Screens
+   * pass scope-specific values (e.g. "state-fallback-banner",
+   * "country-fallback-banner") so E2E selectors can distinguish provenance
+   * without inspecting copy.
+   */
+  testID?: string
 }
 
 export const LocationScopeBadge: FC<LocationScopeBadgeProps> = ({
@@ -28,6 +35,7 @@ export const LocationScopeBadge: FC<LocationScopeBadgeProps> = ({
   state,
   country,
   style,
+  testID = "location-scope-badge",
 }) => {
   const { theme } = useAppTheme()
   const label = describeScope(scope, { state, country })
@@ -46,7 +54,7 @@ export const LocationScopeBadge: FC<LocationScopeBadgeProps> = ({
       ]}
       accessibilityRole="text"
       accessibilityLabel={label}
-      testID="location-scope-badge"
+      testID={testID}
     >
       <MaterialCommunityIcons
         name="map-marker-radius-outline"

--- a/apps/mobile/app/hooks/useLocationData.test.ts
+++ b/apps/mobile/app/hooks/useLocationData.test.ts
@@ -12,9 +12,13 @@ import { renderHook, waitFor } from "@testing-library/react-native"
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockGetLocationMeasurements = jest.fn()
+const mockGetLocationMeasurementsByState = jest.fn()
+const mockGetLocationMeasurementsByCountry = jest.fn()
 
 jest.mock("../services/amplify/data", () => ({
   getLocationMeasurements: (...args) => mockGetLocationMeasurements(...args),
+  getLocationMeasurementsByState: (...args) => mockGetLocationMeasurementsByState(...args),
+  getLocationMeasurementsByCountry: (...args) => mockGetLocationMeasurementsByCountry(...args),
 }))
 
 const mockGetThreshold = jest.fn()
@@ -118,6 +122,10 @@ describe("useLocationData", () => {
     jest.clearAllMocks()
     mockIsOffline = false
     mockLoad.mockReturnValue(null)
+    // Default cascading fetchers to empty so legacy tests that only mock
+    // the city fetcher don't accidentally match the wrong scope.
+    mockGetLocationMeasurementsByState.mockResolvedValue([])
+    mockGetLocationMeasurementsByCountry.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -367,6 +375,109 @@ describe("useLocationData", () => {
 
       expect(result.current.cityData).toBeNull()
       expect(result.current.isMockData).toBe(false)
+    })
+  })
+
+  // ── Cascade through location hierarchy (#123) ──────────────────────────────
+
+  describe("cascade fallback (#123)", () => {
+    const stateRecord = {
+      city: null,
+      state: "QC",
+      country: "CA",
+      contaminantId: "chlorite",
+      value: 750,
+      measuredAt: "2026-04-01T00:00:00Z",
+    }
+    const countryRecord = {
+      city: null,
+      state: null,
+      country: "CA",
+      contaminantId: "chlorite",
+      value: 600,
+      measuredAt: "2026-04-01T00:00:00Z",
+    }
+
+    it("returns city scope when city-level data exists", async () => {
+      mockGetLocationMeasurements.mockResolvedValue([montrealMeasurement])
+      mockGetJurisdictionForLocation.mockReturnValue({ code: "CA-QC" })
+      mockGetThreshold.mockReturnValue(caQcThreshold)
+
+      const { result } = renderHook(() => useLocationData("Montreal", "QC", "CA"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.cityData).not.toBeNull())
+      expect(result.current.scope).toBe("city")
+      expect(mockGetLocationMeasurementsByState).not.toHaveBeenCalled()
+      expect(mockGetLocationMeasurementsByCountry).not.toHaveBeenCalled()
+    })
+
+    it("falls back to state when city has no records", async () => {
+      mockGetLocationMeasurements.mockResolvedValue([])
+      mockGetLocationMeasurementsByState.mockResolvedValue([stateRecord])
+      mockGetJurisdictionForLocation.mockReturnValue({ code: "CA-QC" })
+      mockGetThreshold.mockReturnValue(caQcThreshold)
+
+      const { result } = renderHook(() => useLocationData("Sorel-Tracy", "QC", "CA"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.cityData).not.toBeNull())
+      expect(result.current.scope).toBe("state")
+      // The user's input city/state/country wins over the record's null fields.
+      expect(result.current.cityData!.city).toBe("Sorel-Tracy")
+      expect(result.current.cityData!.state).toBe("QC")
+      expect(result.current.cityData!.country).toBe("CA")
+      // Jurisdiction lookup uses the user's location, not the record's.
+      expect(mockGetJurisdictionForLocation).toHaveBeenCalledWith("QC", "CA")
+      expect(mockGetLocationMeasurementsByCountry).not.toHaveBeenCalled()
+    })
+
+    it("falls back to country when city and state are both empty", async () => {
+      mockGetLocationMeasurements.mockResolvedValue([])
+      mockGetLocationMeasurementsByState.mockResolvedValue([])
+      mockGetLocationMeasurementsByCountry.mockResolvedValue([countryRecord])
+      mockGetJurisdictionForLocation.mockReturnValue({ code: "CA" })
+      mockGetThreshold.mockReturnValue(caQcThreshold)
+
+      const { result } = renderHook(() => useLocationData("Sorel-Tracy", "QC", "CA"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.cityData).not.toBeNull())
+      expect(result.current.scope).toBe("country")
+      expect(result.current.cityData!.city).toBe("Sorel-Tracy")
+      expect(result.current.cityData!.country).toBe("CA")
+    })
+
+    it('reports scope "none" when every level is empty', async () => {
+      mockGetLocationMeasurements.mockResolvedValue([])
+      mockGetLocationMeasurementsByState.mockResolvedValue([])
+      mockGetLocationMeasurementsByCountry.mockResolvedValue([])
+
+      const { result } = renderHook(() => useLocationData("UnknownCity", "QC", "CA"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.cityData).toBeNull()
+      expect(result.current.scope).toBe("none")
+    })
+
+    it("does not cascade when caller omits state/country (backward compat)", async () => {
+      mockGetLocationMeasurements.mockResolvedValue([])
+      mockGetLocationMeasurementsByState.mockResolvedValue([stateRecord])
+
+      const { result } = renderHook(() => useLocationData("Sorel-Tracy"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      // No state/country supplied → state-level fetcher must not run.
+      expect(mockGetLocationMeasurementsByState).not.toHaveBeenCalled()
+      expect(result.current.cityData).toBeNull()
+      expect(result.current.scope).toBe("none")
     })
   })
 })

--- a/apps/mobile/app/hooks/useLocationData.test.ts
+++ b/apps/mobile/app/hooks/useLocationData.test.ts
@@ -305,8 +305,11 @@ describe("useLocationData", () => {
         expect(result.current.cityData).not.toBeNull()
       })
 
+      // Cache key now includes state/country (#123, I1) so same-named
+      // cities in different states don't alias each other in the cache.
+      // Legacy single-arg form (city only) appears as `_Montreal||`.
       expect(mockSave).toHaveBeenCalledWith(
-        "location_stats_Montreal",
+        "location_stats_Montreal||",
         expect.objectContaining({
           data: expect.objectContaining({ cityName: "Montreal" }),
           cachedAt: expect.any(Number),

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -11,8 +11,14 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useContaminants } from "@/context/ContaminantsContext"
 import { type CityData, type CityStat, type StatStatus, StatCategory } from "@/data/types/safety"
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
+import { fetchWithLocationFallback, type LocationScope } from "@/lib/locationFallback"
 import { queryKeys } from "@/lib/queryKeys"
-import { getLocationMeasurements, AmplifyLocationMeasurement } from "@/services/amplify/data"
+import {
+  getLocationMeasurements,
+  getLocationMeasurementsByCountry,
+  getLocationMeasurementsByState,
+  AmplifyLocationMeasurement,
+} from "@/services/amplify/data"
 import { load, save, remove } from "@/utils/storage"
 
 /** Cache key prefix for location stats */
@@ -25,6 +31,8 @@ const CACHE_DURATION_MS = 24 * 60 * 60 * 1000
 interface CachedLocationData {
   data: CityData
   cachedAt: number
+  /** Scope this data resolved at, for provenance display after rehydration. */
+  scope?: LocationScope
 }
 
 interface UseLocationDataResult {
@@ -42,6 +50,12 @@ interface UseLocationDataResult {
   lastUpdated: number | null
   /** Whether the device is offline */
   isOffline: boolean
+  /**
+   * Which level of the location hierarchy resolved the data (#123).
+   * "city" = city-specific record exists; "state"/"country" = inherited;
+   * "none" = no data at any level.
+   */
+  scope: LocationScope
   /** Refresh data from the backend */
   refresh: () => Promise<void>
 }
@@ -64,11 +78,11 @@ function getCachedData(city: string): CachedLocationData | null {
 }
 
 /**
- * Save city data to MMKV cache with timestamp.
+ * Save city data to MMKV cache with timestamp + cascade scope.
  */
-function setCachedData(city: string, data: CityData): void {
+function setCachedData(city: string, data: CityData, scope: LocationScope): void {
   const cacheKey = `${CACHE_KEY_PREFIX}${city}`
-  save(cacheKey, { data, cachedAt: Date.now() })
+  save(cacheKey, { data, cachedAt: Date.now(), scope })
 }
 
 /**
@@ -79,9 +93,18 @@ export function clearCachedLocationData(city: string): void {
 }
 
 /**
- * Hook to fetch city safety data with caching support
+ * Hook to fetch city safety data with caching support.
+ *
+ * Cascades through the location hierarchy (#123): if no city-specific
+ * measurements exist, falls back to state-level, then country-level.
+ * `state` and `country` are optional for backward compatibility but
+ * required to actually cascade past the city level.
  */
-export function useLocationData(city: string): UseLocationDataResult {
+export function useLocationData(
+  city: string,
+  state: string = "",
+  country: string = "",
+): UseLocationDataResult {
   const {
     contaminants,
     getThreshold,
@@ -126,13 +149,15 @@ export function useLocationData(city: string): UseLocationDataResult {
   )
 
   /**
-   * Core query function that fetches measurements and builds CityData
+   * Core query function that fetches measurements (with location-hierarchy
+   * cascading per #123) and builds CityData.
    */
   const queryFn = useCallback(async (): Promise<{
     cityData: CityData | null
     isMockData: boolean
     isCachedData: boolean
     lastUpdated: number | null
+    scope: LocationScope
     warning: string | null
   }> => {
     if (!city) {
@@ -141,6 +166,7 @@ export function useLocationData(city: string): UseLocationDataResult {
         isMockData: false,
         isCachedData: false,
         lastUpdated: null,
+        scope: "none",
         warning: null,
       }
     }
@@ -154,30 +180,51 @@ export function useLocationData(city: string): UseLocationDataResult {
           isMockData: false,
           isCachedData: true,
           lastUpdated: cached.cachedAt,
+          scope: cached.scope ?? "city",
           warning: null,
         }
       }
       throw new Error("You're offline and no cached data is available")
     }
 
-    // Online: fetch from API
-    const measurements = await getLocationMeasurements(city)
+    // Online: cascade city → state → country via the shared util.
+    const { data: measurements, scope } = await fetchWithLocationFallback(
+      { city, state, country },
+      {
+        byCity: getLocationMeasurements,
+        byState: getLocationMeasurementsByState,
+        byCountry: getLocationMeasurementsByCountry,
+      },
+    )
 
     if (measurements.length > 0) {
-      // Extract state/country from API response (measurements have full location data)
+      // Prefer the caller's state/country (drives cascading + jurisdiction).
+      // For city-scope hits without a caller-provided state/country (legacy
+      // call sites + tests), fall back to the record's own state/country so
+      // jurisdiction resolution still works. State-/country-scope rows may
+      // have null city/state on the record, so the caller's input is the
+      // only reliable source there.
       const firstMeasurement = measurements[0]
-      const cityName = firstMeasurement.city ?? city
-      const state = firstMeasurement.state ?? ""
-      const country = firstMeasurement.country ?? ""
-      const jurisdictionCode = getJurisdictionForLocation(state, country)?.code || "WHO"
+      const effectiveState = state || firstMeasurement.state || ""
+      const effectiveCountry = country || firstMeasurement.country || ""
+      const cityName = scope === "city" ? (firstMeasurement.city ?? city) : city
+      const jurisdictionCode =
+        getJurisdictionForLocation(effectiveState, effectiveCountry)?.code || "WHO"
       const stats = measurements.map((m) => mapMeasurementToLegacyStat(m, jurisdictionCode))
-      const newData: CityData = { city, cityName, state, country, stats }
-      setCachedData(city, newData)
+      const newData: CityData = {
+        city,
+        cityName,
+        state: effectiveState,
+        country: effectiveCountry,
+        stats,
+      }
+      setCachedData(city, newData, scope)
       return {
         cityData: newData,
         isMockData: false,
         isCachedData: false,
         lastUpdated: Date.now(),
+        scope,
         warning: null,
       }
     }
@@ -190,6 +237,7 @@ export function useLocationData(city: string): UseLocationDataResult {
         isMockData: false,
         isCachedData: true,
         lastUpdated: cached.cachedAt,
+        scope: cached.scope ?? "none",
         warning: null,
       }
     }
@@ -199,9 +247,10 @@ export function useLocationData(city: string): UseLocationDataResult {
       isMockData: false,
       isCachedData: false,
       lastUpdated: null,
+      scope: "none",
       warning: null,
     }
-  }, [city, isOffline, mapMeasurementToLegacyStat, getJurisdictionForLocation])
+  }, [city, state, country, isOffline, mapMeasurementToLegacyStat, getJurisdictionForLocation])
 
   const query = useQuery({
     queryKey: queryKeys.measurements.byLocation(city),
@@ -218,6 +267,7 @@ export function useLocationData(city: string): UseLocationDataResult {
           isMockData: false,
           isCachedData: true,
           lastUpdated: cached.cachedAt,
+          scope: cached.scope ?? "city",
           warning: null,
         }
       }
@@ -229,8 +279,12 @@ export function useLocationData(city: string): UseLocationDataResult {
   const result = query.data
 
   const refresh = useCallback(async () => {
-    await qc.invalidateQueries({ queryKey: queryKeys.measurements.byLocation(city) })
-  }, [qc, city])
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: queryKeys.measurements.byLocation(city) }),
+      qc.invalidateQueries({ queryKey: queryKeys.measurements.byState(state) }),
+      qc.invalidateQueries({ queryKey: queryKeys.measurements.byCountry(country) }),
+    ])
+  }, [qc, city, state, country])
 
   // Determine error: use query error or warning from the result
   const error = query.error?.message ?? result?.warning ?? null
@@ -243,6 +297,7 @@ export function useLocationData(city: string): UseLocationDataResult {
     isCachedData: result?.isCachedData ?? false,
     lastUpdated: result?.lastUpdated ?? null,
     isOffline,
+    scope: result?.scope ?? "none",
     refresh,
   }
 }

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -301,13 +301,12 @@ export function useLocationData(
 
   const result = query.data
 
+  // Invalidate every measurements query so sibling cities sharing the
+  // same state/country cascade source also refetch (#123). The per-city
+  // byLocation key alone wouldn't reach them.
   const refresh = useCallback(async () => {
-    await Promise.all([
-      qc.invalidateQueries({ queryKey: queryKeys.measurements.byLocation(city, state, country) }),
-      qc.invalidateQueries({ queryKey: queryKeys.measurements.byState(state) }),
-      qc.invalidateQueries({ queryKey: queryKeys.measurements.byCountry(country) }),
-    ])
-  }, [qc, city, state, country])
+    await qc.invalidateQueries({ queryKey: queryKeys.measurements.all })
+  }, [qc])
 
   // Determine error: use query error or warning from the result
   const error = query.error?.message ?? result?.warning ?? null

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -61,10 +61,20 @@ interface UseLocationDataResult {
 }
 
 /**
+ * Build the MMKV cache key. Includes state/country alongside city
+ * because the cascading hook resolves data based on all three (#123) —
+ * keying on city alone would alias same-named cities in different
+ * states, or serve a stale result when state/country change.
+ */
+function locationCacheKey(city: string, state: string, country: string): string {
+  return `${CACHE_KEY_PREFIX}${city}|${state}|${country}`
+}
+
+/**
  * Get cached data for a city from MMKV storage.
  */
-function getCachedData(city: string): CachedLocationData | null {
-  const cacheKey = `${CACHE_KEY_PREFIX}${city}`
+function getCachedData(city: string, state: string, country: string): CachedLocationData | null {
+  const cacheKey = locationCacheKey(city, state, country)
   const cached = load<CachedLocationData>(cacheKey)
 
   if (!cached) return null
@@ -80,15 +90,28 @@ function getCachedData(city: string): CachedLocationData | null {
 /**
  * Save city data to MMKV cache with timestamp + cascade scope.
  */
-function setCachedData(city: string, data: CityData, scope: LocationScope): void {
-  const cacheKey = `${CACHE_KEY_PREFIX}${city}`
-  save(cacheKey, { data, cachedAt: Date.now(), scope })
+function setCachedData(
+  city: string,
+  state: string,
+  country: string,
+  data: CityData,
+  scope: LocationScope,
+): void {
+  save(locationCacheKey(city, state, country), { data, cachedAt: Date.now(), scope })
 }
 
 /**
- * Clear cached data for a specific city.
+ * Clear cached data for a specific city. Accepts the legacy single-arg
+ * form (clears every state/country variant for that city) or the full
+ * triple. The single-arg form is retained for callers that don't yet
+ * thread state/country through.
  */
-export function clearCachedLocationData(city: string): void {
+export function clearCachedLocationData(city: string, state?: string, country?: string): void {
+  if (state !== undefined && country !== undefined) {
+    remove(locationCacheKey(city, state, country))
+    return
+  }
+  // No state/country supplied — fall back to the legacy bare-city key.
   remove(`${CACHE_KEY_PREFIX}${city}`)
 }
 
@@ -173,7 +196,7 @@ export function useLocationData(
 
     // If offline, use MMKV cache
     if (isOffline) {
-      const cached = getCachedData(city)
+      const cached = getCachedData(city, state, country)
       if (cached) {
         return {
           cityData: cached.data,
@@ -218,7 +241,7 @@ export function useLocationData(
         country: effectiveCountry,
         stats,
       }
-      setCachedData(city, newData, scope)
+      setCachedData(city, state, country, newData, scope)
       return {
         cityData: newData,
         isMockData: false,
@@ -230,7 +253,7 @@ export function useLocationData(
     }
 
     // No data from backend - keep cache as fallback for offline use
-    const cached = getCachedData(city)
+    const cached = getCachedData(city, state, country)
     if (cached) {
       return {
         cityData: cached.data,
@@ -253,14 +276,14 @@ export function useLocationData(
   }, [city, state, country, isOffline, mapMeasurementToLegacyStat, getJurisdictionForLocation])
 
   const query = useQuery({
-    queryKey: queryKeys.measurements.byLocation(city),
+    queryKey: queryKeys.measurements.byLocation(city, state, country),
     queryFn,
     enabled: !!city && !defsLoading,
     staleTime: 5 * 60 * 1000,
     // Use MMKV cached data as initialData if available
     initialData: () => {
       if (!city) return undefined
-      const cached = getCachedData(city)
+      const cached = getCachedData(city, state, country)
       if (cached) {
         return {
           cityData: cached.data,
@@ -280,7 +303,7 @@ export function useLocationData(
 
   const refresh = useCallback(async () => {
     await Promise.all([
-      qc.invalidateQueries({ queryKey: queryKeys.measurements.byLocation(city) }),
+      qc.invalidateQueries({ queryKey: queryKeys.measurements.byLocation(city, state, country) }),
       qc.invalidateQueries({ queryKey: queryKeys.measurements.byState(state) }),
       qc.invalidateQueries({ queryKey: queryKeys.measurements.byCountry(country) }),
     ])

--- a/apps/mobile/app/hooks/useLocationObservations.test.ts
+++ b/apps/mobile/app/hooks/useLocationObservations.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for useLocationObservations hook
+ *
+ * Covers the location-hierarchy cascade (#123): city → state → country
+ * fallback, scope flag, dedup of higher-scope fan-out by propertyId, and
+ * backward-compat for the deprecated `isStateLevelFallback` field.
+ */
+
+import { createElement } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react-native"
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetLocationObservations = jest.fn()
+const mockGetLocationObservationsByState = jest.fn()
+const mockGetLocationObservationsByCountry = jest.fn()
+const mockGetObservedProperties = jest.fn()
+const mockGetPropertyThresholdsForJurisdiction = jest.fn()
+
+jest.mock("../services/amplify/data", () => ({
+  getLocationObservations: (...args: unknown[]) => mockGetLocationObservations(...args),
+  getLocationObservationsByState: (...args: unknown[]) =>
+    mockGetLocationObservationsByState(...args),
+  getLocationObservationsByCountry: (...args: unknown[]) =>
+    mockGetLocationObservationsByCountry(...args),
+  getObservedProperties: (...args: unknown[]) => mockGetObservedProperties(...args),
+  getPropertyThresholdsForJurisdiction: (...args: unknown[]) =>
+    mockGetPropertyThresholdsForJurisdiction(...args),
+}))
+
+jest.mock("./useNetworkStatus", () => ({
+  useNetworkStatus: () => ({
+    isOffline: false,
+    isReady: true,
+  }),
+}))
+
+// `calculateObservationStatus` is a pure helper; mock it to a deterministic
+// value so the test focuses on the cascade/scope plumbing rather than the
+// status-derivation logic (covered elsewhere).
+jest.mock("../data/types/safety", () => {
+  const actual = jest.requireActual("../data/types/safety")
+  return {
+    ...actual,
+    calculateObservationStatus: jest.fn(() => "safe"),
+  }
+})
+
+// eslint-disable-next-line import/first
+import { useLocationObservations } from "./useLocationObservations"
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const radonProperty = {
+  propertyId: "radon",
+  name: "Radon",
+  category: "radiation",
+  observationType: "numeric",
+  unit: "Bq/m³",
+  higherIsBad: true,
+}
+
+const lymeProperty = {
+  propertyId: "lyme",
+  name: "Lyme",
+  category: "disease",
+  observationType: "endemic",
+  higherIsBad: true,
+}
+
+const cityRadon = {
+  city: "Sorel-Tracy",
+  state: "QC",
+  country: "CA",
+  propertyId: "radon",
+  numericValue: 120,
+  observedAt: "2026-04-01T00:00:00Z",
+}
+
+const stateRadon = {
+  // state-anchored record — null city
+  city: null,
+  state: "QC",
+  country: "CA",
+  propertyId: "radon",
+  numericValue: 200,
+  observedAt: "2026-04-01T00:00:00Z",
+}
+
+const stateLyme = {
+  city: null,
+  state: "QC",
+  country: "CA",
+  propertyId: "lyme",
+  endemicValue: true,
+  observedAt: "2026-04-01T00:00:00Z",
+}
+
+const countryRadon = {
+  city: null,
+  state: null,
+  country: "CA",
+  propertyId: "radon",
+  numericValue: 90,
+  observedAt: "2026-04-01T00:00:00Z",
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let queryClient: QueryClient
+
+function createWrapper() {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+const baseParams = {
+  city: "Sorel-Tracy",
+  state: "QC",
+  country: "CA",
+  jurisdictionCode: "CA-QC",
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useLocationObservations cascade fallback (#123)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetObservedProperties.mockResolvedValue([radonProperty, lymeProperty])
+    mockGetPropertyThresholdsForJurisdiction.mockResolvedValue([])
+    // Default cascading fetchers to empty so individual tests opt in to
+    // the scope they want to exercise.
+    mockGetLocationObservations.mockResolvedValue([])
+    mockGetLocationObservationsByState.mockResolvedValue([])
+    mockGetLocationObservationsByCountry.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  it("reports city scope when city-level data exists and skips state/country fetchers", async () => {
+    mockGetLocationObservations.mockResolvedValue([cityRadon])
+
+    const { result } = renderHook(() => useLocationObservations(baseParams), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.observations.length).toBeGreaterThan(0))
+
+    expect(result.current.scope).toBe("city")
+    expect(result.current.isStateLevelFallback).toBe(false)
+    expect(result.current.observations).toHaveLength(1)
+    expect(mockGetLocationObservationsByState).not.toHaveBeenCalled()
+    expect(mockGetLocationObservationsByCountry).not.toHaveBeenCalled()
+  })
+
+  it("falls back to state and reports scope=state when city has no data", async () => {
+    mockGetLocationObservationsByState.mockResolvedValue([stateRadon])
+
+    const { result } = renderHook(() => useLocationObservations(baseParams), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.observations.length).toBeGreaterThan(0))
+
+    expect(result.current.scope).toBe("state")
+    expect(result.current.isStateLevelFallback).toBe(true) // legacy field still works
+    expect(mockGetLocationObservationsByState).toHaveBeenCalledWith("QC")
+    expect(mockGetLocationObservationsByCountry).not.toHaveBeenCalled()
+  })
+
+  it("falls back to country when city and state are both empty", async () => {
+    mockGetLocationObservationsByCountry.mockResolvedValue([countryRadon])
+
+    const { result } = renderHook(() => useLocationObservations(baseParams), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.observations.length).toBeGreaterThan(0))
+
+    expect(result.current.scope).toBe("country")
+    expect(result.current.isStateLevelFallback).toBe(false)
+    expect(mockGetLocationObservationsByCountry).toHaveBeenCalledWith("CA")
+  })
+
+  it('reports scope "none" when every level is empty', async () => {
+    const { result } = renderHook(() => useLocationObservations(baseParams), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.scope).toBe("none")
+    expect(result.current.isStateLevelFallback).toBe(false)
+    expect(result.current.observations).toEqual([])
+  })
+
+  it("dedupes by propertyId for state-scope fan-out (multiple cities reporting same property)", async () => {
+    // Two state-scope rows for the SAME property — the cascade dedup
+    // should collapse them so only one card surfaces per property.
+    const stateRadonAlt = { ...stateRadon, numericValue: 250 }
+    mockGetLocationObservationsByState.mockResolvedValue([stateRadon, stateRadonAlt, stateLyme])
+
+    const { result } = renderHook(() => useLocationObservations(baseParams), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.observations.length).toBeGreaterThan(0))
+
+    expect(result.current.scope).toBe("state")
+    // Two unique properties (radon + lyme), one card each.
+    const propertyIds = result.current.observations.map((o) => o.propertyId).sort()
+    expect(propertyIds).toEqual(["lyme", "radon"])
+  })
+
+  it("does not cascade when state is empty (hook is gated on city + state)", async () => {
+    mockGetLocationObservations.mockResolvedValue([cityRadon])
+
+    const { result } = renderHook(() => useLocationObservations({ ...baseParams, state: "" }), {
+      wrapper: createWrapper(),
+    })
+
+    // Hook is disabled when state is empty; no fetcher should run.
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(mockGetLocationObservations).not.toHaveBeenCalled()
+    expect(mockGetLocationObservationsByState).not.toHaveBeenCalled()
+    expect(mockGetLocationObservationsByCountry).not.toHaveBeenCalled()
+    expect(result.current.scope).toBe("none")
+  })
+})

--- a/apps/mobile/app/hooks/useLocationObservations.test.ts
+++ b/apps/mobile/app/hooks/useLocationObservations.test.ts
@@ -219,14 +219,32 @@ describe("useLocationObservations cascade fallback (#123)", () => {
     expect(propertyIds).toEqual(["lyme", "radon"])
   })
 
-  it("does not cascade when state is empty (hook is gated on city + state)", async () => {
-    mockGetLocationObservations.mockResolvedValue([cityRadon])
+  it("still resolves when state is empty: city → country (state level skipped)", async () => {
+    // I2 fix: the hook is enabled whenever any cascade level has a value,
+    // so a missing state must NOT silently disable the country fallback.
+    // The shared util skips the state level internally.
+    mockGetLocationObservations.mockResolvedValue([])
+    mockGetLocationObservationsByCountry.mockResolvedValue([countryRadon])
 
     const { result } = renderHook(() => useLocationObservations({ ...baseParams, state: "" }), {
       wrapper: createWrapper(),
     })
 
-    // Hook is disabled when state is empty; no fetcher should run.
+    await waitFor(() => expect(result.current.observations.length).toBeGreaterThan(0))
+    // City fetcher ran (city is set), state fetcher was skipped (state empty),
+    // country fetcher ran on the empty city result and resolved the cascade.
+    expect(mockGetLocationObservations).toHaveBeenCalledWith("Sorel-Tracy")
+    expect(mockGetLocationObservationsByState).not.toHaveBeenCalled()
+    expect(mockGetLocationObservationsByCountry).toHaveBeenCalledWith("CA")
+    expect(result.current.scope).toBe("country")
+  })
+
+  it("hook is fully disabled only when city, state, AND country are all empty", async () => {
+    const { result } = renderHook(
+      () => useLocationObservations({ ...baseParams, city: "", state: "", country: "" }),
+      { wrapper: createWrapper() },
+    )
+
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(mockGetLocationObservations).not.toHaveBeenCalled()
     expect(mockGetLocationObservationsByState).not.toHaveBeenCalled()

--- a/apps/mobile/app/hooks/useLocationObservations.ts
+++ b/apps/mobile/app/hooks/useLocationObservations.ts
@@ -204,7 +204,10 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
   const { isOffline } = useNetworkStatus()
   const qc = useQueryClient()
 
-  // Fetch observations cascading city → state → country.
+  // Fetch observations cascading city → state → country (#123).
+  // Enabled whenever any cascade level has a value — `country` alone is a
+  // legitimate input. The shared util internally skips levels with empty
+  // input, so requiring all three would gate out the country-only path.
   const observationsQuery = useQuery({
     queryKey: queryKeys.observations.byCity(city),
     queryFn: async () =>
@@ -216,7 +219,7 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
           byCountry: getLocationObservationsByCountry,
         },
       ),
-    enabled: !!city && !!state,
+    enabled: !!(city || state || country),
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
 

--- a/apps/mobile/app/hooks/useLocationObservations.ts
+++ b/apps/mobile/app/hooks/useLocationObservations.ts
@@ -14,9 +14,11 @@ import {
   calculateObservationStatus,
 } from "@/data/types/safety"
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
+import { fetchWithLocationFallback, type LocationScope } from "@/lib/locationFallback"
 import { queryKeys } from "@/lib/queryKeys"
 import {
   getLocationObservations,
+  getLocationObservationsByCountry,
   getLocationObservationsByState,
   getObservedProperties,
   getPropertyThresholdsForJurisdiction,
@@ -42,7 +44,15 @@ interface UseLocationObservationsResult {
   worstStatus: "danger" | "warning" | "safe"
   /** Count of danger/warning observations */
   alertCount: number
-  /** Whether data is from state-level fallback (not city-specific) */
+  /**
+   * Which level of the location hierarchy resolved the data (#123).
+   * "city" = city-specific record exists; "state"/"country" = inherited.
+   */
+  scope: LocationScope
+  /**
+   * @deprecated Prefer `scope === "state"`. Retained for callers that
+   * haven't migrated to the unified scope flag.
+   */
   isStateLevelFallback: boolean
 }
 
@@ -50,6 +60,8 @@ interface LocationParams {
   city: string
   state: string
   jurisdictionCode: string
+  /** Country anchor for country-level cascade fallback (#123). Optional for backward compat. */
+  country?: string
 }
 
 /**
@@ -73,8 +85,9 @@ function mapAmplifyObservation(obs: AmplifyLocationObservation): {
   notes?: string
 } {
   return {
-    city: obs.city,
-    state: obs.state,
+    // city/state may be null on state-/country-anchored records (#123).
+    city: obs.city ?? "",
+    state: obs.state ?? "",
     country: obs.country,
     county: obs.county ?? undefined,
     propertyId: obs.propertyId,
@@ -180,24 +193,29 @@ function deduplicateByWorstStatus(observations: ObservationWithStatus[]): Observ
 }
 
 /**
- * Hook to fetch and process location observations
+ * Hook to fetch and process location observations.
+ *
+ * Cascades city → state → country (#123) via the shared
+ * `fetchWithLocationFallback` util and exposes the resolved `scope` so
+ * callers can render provenance.
  */
 export function useLocationObservations(params: LocationParams): UseLocationObservationsResult {
-  const { city, state, jurisdictionCode } = params
+  const { city, state, jurisdictionCode, country = "" } = params
   const { isOffline } = useNetworkStatus()
   const qc = useQueryClient()
 
-  // Fetch observations for the city (fallback to state if no city data)
+  // Fetch observations cascading city → state → country.
   const observationsQuery = useQuery({
     queryKey: queryKeys.observations.byCity(city),
-    queryFn: async () => {
-      const cityObs = await getLocationObservations(city)
-      if (cityObs.length > 0) return { data: cityObs, isStateFallback: false }
-
-      // Fallback to state-level observations (dedup happens in useMemo after status calc)
-      const stateObs = await getLocationObservationsByState(state)
-      return { data: stateObs, isStateFallback: stateObs.length > 0 }
-    },
+    queryFn: async () =>
+      fetchWithLocationFallback(
+        { city, state, country },
+        {
+          byCity: getLocationObservations,
+          byState: getLocationObservationsByState,
+          byCountry: getLocationObservationsByCountry,
+        },
+      ),
     enabled: !!city && !!state,
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
@@ -251,8 +269,10 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
       })
       .filter((obs): obs is ObservationWithStatus => obs !== null)
 
-    // Deduplicate state-level fallback data by propertyId, keeping worst status
-    if (observationsQuery.data.isStateFallback) {
+    // Deduplicate fallback data (state or country scope) by propertyId,
+    // keeping worst status. City-scoped data is one row per property by
+    // construction so dedup is unnecessary.
+    if (observationsQuery.data.scope === "state" || observationsQuery.data.scope === "country") {
       return deduplicateByWorstStatus(enriched)
     }
 
@@ -279,19 +299,22 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
     return observations.filter((obs) => obs.status === "danger" || obs.status === "warning").length
   }, [observations])
 
-  // Refresh function - invalidate both city and state queries since we may have fallen back to state data
+  // Refresh function — invalidate every cascade level since the fallback
+  // may have resolved at any of them.
   const refresh = useCallback(async () => {
     await Promise.all([
       qc.invalidateQueries({ queryKey: queryKeys.observations.byCity(city) }),
       qc.invalidateQueries({ queryKey: queryKeys.observations.byState(state) }),
+      qc.invalidateQueries({ queryKey: queryKeys.observations.byCountry(country) }),
       qc.invalidateQueries({ queryKey: queryKeys.observedProperties.list() }),
       qc.invalidateQueries({
         queryKey: queryKeys.propertyThresholds.byJurisdiction(jurisdictionCode),
       }),
     ])
-  }, [qc, city, state, jurisdictionCode])
+  }, [qc, city, state, country, jurisdictionCode])
 
-  const isStateLevelFallback = observationsQuery.data?.isStateFallback ?? false
+  const scope = observationsQuery.data?.scope ?? "none"
+  const isStateLevelFallback = scope === "state"
 
   // Combine loading states
   const isLoading =
@@ -313,6 +336,7 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
     getByCategory,
     worstStatus,
     alertCount,
+    scope,
     isStateLevelFallback,
   }
 }

--- a/apps/mobile/app/hooks/useLocationObservations.ts
+++ b/apps/mobile/app/hooks/useLocationObservations.ts
@@ -208,8 +208,11 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
   // Enabled whenever any cascade level has a value — `country` alone is a
   // legitimate input. The shared util internally skips levels with empty
   // input, so requiring all three would gate out the country-only path.
+  // Key carries all three inputs because the cascade resolves on (city,
+  // state, country) — a city-only key aliases distinct (state, country)
+  // pairs once `city === ""` (state-/country-only cascade).
   const observationsQuery = useQuery({
-    queryKey: queryKeys.observations.byCity(city),
+    queryKey: queryKeys.observations.byLocation(city, state, country),
     queryFn: async () =>
       fetchWithLocationFallback(
         { city, state, country },
@@ -302,19 +305,18 @@ export function useLocationObservations(params: LocationParams): UseLocationObse
     return observations.filter((obs) => obs.status === "danger" || obs.status === "warning").length
   }, [observations])
 
-  // Refresh function — invalidate every cascade level since the fallback
-  // may have resolved at any of them.
+  // Refresh function — invalidate every observations query so sibling
+  // cities under the same state/country cascade source also refetch
+  // (#123), plus the supporting property/threshold caches.
   const refresh = useCallback(async () => {
     await Promise.all([
-      qc.invalidateQueries({ queryKey: queryKeys.observations.byCity(city) }),
-      qc.invalidateQueries({ queryKey: queryKeys.observations.byState(state) }),
-      qc.invalidateQueries({ queryKey: queryKeys.observations.byCountry(country) }),
+      qc.invalidateQueries({ queryKey: queryKeys.observations.all }),
       qc.invalidateQueries({ queryKey: queryKeys.observedProperties.list() }),
       qc.invalidateQueries({
         queryKey: queryKeys.propertyThresholds.byJurisdiction(jurisdictionCode),
       }),
     ])
-  }, [qc, city, state, country, jurisdictionCode])
+  }, [qc, jurisdictionCode])
 
   const scope = observationsQuery.data?.scope ?? "none"
   const isStateLevelFallback = scope === "state"

--- a/apps/mobile/app/hooks/usePollutionSources.test.ts
+++ b/apps/mobile/app/hooks/usePollutionSources.test.ts
@@ -13,10 +13,12 @@ import { renderHook, waitFor } from "@testing-library/react-native"
 
 const mockGetPollutionSourcesByCity = jest.fn()
 const mockGetPollutionSourcesByState = jest.fn()
+const mockGetPollutionSourcesByCountry = jest.fn()
 
 jest.mock("../services/amplify/data", () => ({
   getPollutionSourcesByCity: (...args: unknown[]) => mockGetPollutionSourcesByCity(...args),
   getPollutionSourcesByState: (...args: unknown[]) => mockGetPollutionSourcesByState(...args),
+  getPollutionSourcesByCountry: (...args: unknown[]) => mockGetPollutionSourcesByCountry(...args),
 }))
 
 let mockIsOffline = false
@@ -82,6 +84,7 @@ describe("usePollutionSources", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockIsOffline = false
+    mockGetPollutionSourcesByCountry.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -212,6 +215,81 @@ describe("usePollutionSources", () => {
       )
 
       expect(result.current.isOffline).toBe(true)
+    })
+  })
+
+  // ── Cascade through location hierarchy (#123) ──────────────────────────────
+
+  describe("cascade fallback (#123)", () => {
+    const countrySource = {
+      id: "src-3",
+      name: "National Industrial Site",
+      sourceType: "industrial",
+      city: null,
+      state: null,
+      country: "CA",
+      latitude: 50,
+      longitude: -100,
+      impactRadius: 10000,
+      severity: "high",
+      status: "active",
+    }
+
+    it("reports city scope when city has data", async () => {
+      mockGetPollutionSourcesByCity.mockResolvedValue([citySource])
+
+      const { result } = renderHook(
+        () => usePollutionSources({ city: "Sorel-Tracy", state: "QC", country: "CA" }),
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(() => expect(result.current.sources).toHaveLength(1))
+      expect(result.current.scope).toBe("city")
+    })
+
+    it("reports state scope when falling back to state", async () => {
+      mockGetPollutionSourcesByCity.mockResolvedValue([])
+      mockGetPollutionSourcesByState.mockResolvedValue([stateSource])
+
+      const { result } = renderHook(
+        () => usePollutionSources({ city: "Sorel-Tracy", state: "QC", country: "CA" }),
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(() => expect(result.current.sources).toHaveLength(1))
+      expect(result.current.scope).toBe("state")
+      // Country fetcher must not run when state had data.
+      expect(mockGetPollutionSourcesByCountry).not.toHaveBeenCalled()
+    })
+
+    it("falls back to country when state is also empty", async () => {
+      mockGetPollutionSourcesByCity.mockResolvedValue([])
+      mockGetPollutionSourcesByState.mockResolvedValue([])
+      mockGetPollutionSourcesByCountry.mockResolvedValue([countrySource])
+
+      const { result } = renderHook(
+        () => usePollutionSources({ city: "Sorel-Tracy", state: "QC", country: "CA" }),
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(() => expect(result.current.sources).toHaveLength(1))
+      expect(result.current.scope).toBe("country")
+      expect(mockGetPollutionSourcesByCountry).toHaveBeenCalledWith("CA")
+    })
+
+    it('reports scope "none" when every level is empty', async () => {
+      mockGetPollutionSourcesByCity.mockResolvedValue([])
+      mockGetPollutionSourcesByState.mockResolvedValue([])
+      mockGetPollutionSourcesByCountry.mockResolvedValue([])
+
+      const { result } = renderHook(
+        () => usePollutionSources({ city: "Sorel-Tracy", state: "QC", country: "CA" }),
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.sources).toEqual([])
+      expect(result.current.scope).toBe("none")
     })
   })
 })

--- a/apps/mobile/app/hooks/usePollutionSources.test.ts
+++ b/apps/mobile/app/hooks/usePollutionSources.test.ts
@@ -147,22 +147,30 @@ describe("usePollutionSources", () => {
   })
 
   describe("disabled state", () => {
-    it("returns empty sources when city is empty", () => {
-      const { result } = renderHook(() => usePollutionSources({ city: "", state: "QC" }), {
-        wrapper: createWrapper(),
-      })
-
-      expect(result.current.sources).toEqual([])
-      expect(mockGetPollutionSourcesByCity).not.toHaveBeenCalled()
-    })
-
-    it("returns empty sources when state is empty", () => {
+    it("city-only input still runs the city fetcher (I2: country-only path must remain reachable)", async () => {
+      // I2 fix: the hook is enabled whenever any cascade level has a value.
+      // Previously it required city + state, which silently disabled the
+      // country fallback even though that's the cascade's whole purpose.
+      mockGetPollutionSourcesByCity.mockResolvedValue([])
       const { result } = renderHook(() => usePollutionSources({ city: "Sorel-Tracy", state: "" }), {
         wrapper: createWrapper(),
       })
 
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(mockGetPollutionSourcesByCity).toHaveBeenCalledWith("Sorel-Tracy")
+      expect(result.current.sources).toEqual([])
+    })
+
+    it("hook is disabled only when city, state, AND country are all empty", () => {
+      const { result } = renderHook(
+        () => usePollutionSources({ city: "", state: "", country: "" }),
+        { wrapper: createWrapper() },
+      )
+
       expect(result.current.sources).toEqual([])
       expect(mockGetPollutionSourcesByCity).not.toHaveBeenCalled()
+      expect(mockGetPollutionSourcesByState).not.toHaveBeenCalled()
+      expect(mockGetPollutionSourcesByCountry).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/mobile/app/hooks/usePollutionSources.ts
+++ b/apps/mobile/app/hooks/usePollutionSources.ts
@@ -52,6 +52,9 @@ export function usePollutionSources(params: LocationParams): UsePollutionSources
   const { isOffline } = useNetworkStatus()
   const qc = useQueryClient()
 
+  // Cascade city → state → country (#123). Enabled whenever any cascade
+  // level has a value so the country-only path remains reachable; the
+  // shared util internally skips levels with empty input.
   const sourcesQuery = useQuery({
     queryKey: queryKeys.pollutionSources.byCity(city),
     queryFn: async () =>
@@ -63,7 +66,7 @@ export function usePollutionSources(params: LocationParams): UsePollutionSources
           byCountry: getPollutionSourcesByCountry,
         },
       ),
-    enabled: !!city && !!state,
+    enabled: !!(city || state || country),
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
 

--- a/apps/mobile/app/hooks/usePollutionSources.ts
+++ b/apps/mobile/app/hooks/usePollutionSources.ts
@@ -55,8 +55,11 @@ export function usePollutionSources(params: LocationParams): UsePollutionSources
   // Cascade city → state → country (#123). Enabled whenever any cascade
   // level has a value so the country-only path remains reachable; the
   // shared util internally skips levels with empty input.
+  // Key carries all three inputs because the cascade resolves on (city,
+  // state, country) — a city-only key aliases distinct (state, country)
+  // pairs once `city === ""` (state-/country-only cascade).
   const sourcesQuery = useQuery({
-    queryKey: queryKeys.pollutionSources.byCity(city),
+    queryKey: queryKeys.pollutionSources.byLocation(city, state, country),
     queryFn: async () =>
       fetchWithLocationFallback(
         { city, state, country },
@@ -70,13 +73,11 @@ export function usePollutionSources(params: LocationParams): UsePollutionSources
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
 
+  // Invalidate every pollution-sources query so sibling cities sharing
+  // the same state/country cascade source also refetch (#123).
   const refresh = useCallback(async () => {
-    await Promise.all([
-      qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byCity(city) }),
-      qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byState(state) }),
-      qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byCountry(country) }),
-    ])
-  }, [qc, city, state, country])
+    await qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.all })
+  }, [qc])
 
   return {
     sources: sourcesQuery.data?.data ?? [],

--- a/apps/mobile/app/hooks/usePollutionSources.ts
+++ b/apps/mobile/app/hooks/usePollutionSources.ts
@@ -1,16 +1,19 @@
 /**
  * usePollutionSources Hook
  *
- * Fetches pollution sources for a location (by city, with state fallback).
+ * Fetches pollution sources for a location, cascading city → state → country
+ * per #123 via the shared `fetchWithLocationFallback` util.
  */
 
 import { useCallback } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
+import { fetchWithLocationFallback, type LocationScope } from "@/lib/locationFallback"
 import { queryKeys } from "@/lib/queryKeys"
 import {
   getPollutionSourcesByCity,
+  getPollutionSourcesByCountry,
   getPollutionSourcesByState,
   type AmplifyPollutionSource,
 } from "@/services/amplify/data"
@@ -24,6 +27,8 @@ interface UsePollutionSourcesResult {
   error: string | null
   /** Whether offline */
   isOffline: boolean
+  /** Which level of the location hierarchy resolved the data (#123). */
+  scope: LocationScope
   /** Refresh data */
   refresh: () => Promise<void>
 }
@@ -31,26 +36,33 @@ interface UsePollutionSourcesResult {
 interface LocationParams {
   city: string
   state: string
+  /** Country anchor for country-level cascade fallback (#123). Optional for backward compat. */
+  country?: string
 }
 
 /**
- * Hook to fetch pollution sources for a location
+ * Hook to fetch pollution sources for a location.
+ *
+ * Cascades city → state → country (#123). Returns a `scope` flag so the
+ * caller can render provenance ("Showing QC data") rather than letting the
+ * user think a city has its own row when in fact data was inherited.
  */
 export function usePollutionSources(params: LocationParams): UsePollutionSourcesResult {
-  const { city, state } = params
+  const { city, state, country = "" } = params
   const { isOffline } = useNetworkStatus()
   const qc = useQueryClient()
 
   const sourcesQuery = useQuery({
     queryKey: queryKeys.pollutionSources.byCity(city),
-    queryFn: async () => {
-      const citySources = await getPollutionSourcesByCity(city)
-      if (citySources.length > 0) return citySources
-
-      // Fallback to state-level sources
-      const stateSources = await getPollutionSourcesByState(state)
-      return stateSources
-    },
+    queryFn: async () =>
+      fetchWithLocationFallback(
+        { city, state, country },
+        {
+          byCity: getPollutionSourcesByCity,
+          byState: getPollutionSourcesByState,
+          byCountry: getPollutionSourcesByCountry,
+        },
+      ),
     enabled: !!city && !!state,
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
@@ -59,14 +71,16 @@ export function usePollutionSources(params: LocationParams): UsePollutionSources
     await Promise.all([
       qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byCity(city) }),
       qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byState(state) }),
+      qc.invalidateQueries({ queryKey: queryKeys.pollutionSources.byCountry(country) }),
     ])
-  }, [qc, city, state])
+  }, [qc, city, state, country])
 
   return {
-    sources: sourcesQuery.data ?? [],
+    sources: sourcesQuery.data?.data ?? [],
     isLoading: sourcesQuery.isLoading,
     error: sourcesQuery.error?.message ?? null,
     isOffline,
+    scope: sourcesQuery.data?.scope ?? "none",
     refresh,
   }
 }

--- a/apps/mobile/app/lib/locationFallback.test.ts
+++ b/apps/mobile/app/lib/locationFallback.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the location-hierarchy cascading fallback util (#123).
+ */
+
+import { describeScope, fetchWithLocationFallback } from "./locationFallback"
+
+describe("fetchWithLocationFallback", () => {
+  const location = { city: "Sorel-Tracy", state: "QC", country: "CA" }
+
+  it("returns city-scope data when the city fetcher resolves non-empty", async () => {
+    const result = await fetchWithLocationFallback(location, {
+      byCity: async () => [{ id: "city-row" }],
+      byState: async () => [{ id: "state-row" }],
+      byCountry: async () => [{ id: "country-row" }],
+    })
+    expect(result).toEqual({ data: [{ id: "city-row" }], scope: "city" })
+  })
+
+  it("falls back to state when the city fetcher returns empty", async () => {
+    const result = await fetchWithLocationFallback(location, {
+      byCity: async () => [],
+      byState: async () => [{ id: "state-row" }],
+      byCountry: async () => [{ id: "country-row" }],
+    })
+    expect(result).toEqual({ data: [{ id: "state-row" }], scope: "state" })
+  })
+
+  it("falls back to country when both city and state are empty", async () => {
+    const result = await fetchWithLocationFallback(location, {
+      byCity: async () => [],
+      byState: async () => [],
+      byCountry: async () => [{ id: "country-row" }],
+    })
+    expect(result).toEqual({ data: [{ id: "country-row" }], scope: "country" })
+  })
+
+  it('returns scope "none" when every level is empty', async () => {
+    const result = await fetchWithLocationFallback(location, {
+      byCity: async () => [],
+      byState: async () => [],
+      byCountry: async () => [],
+    })
+    expect(result).toEqual({ data: [], scope: "none" })
+  })
+
+  it("skips scopes whose location field is empty", async () => {
+    const byCity = jest.fn(async () => [])
+    const byState = jest.fn(async () => [])
+    const byCountry = jest.fn(async () => [{ id: "country-row" }])
+    const result = await fetchWithLocationFallback(
+      { city: "", state: "", country: "CA" },
+      { byCity, byState, byCountry },
+    )
+    expect(byCity).not.toHaveBeenCalled()
+    expect(byState).not.toHaveBeenCalled()
+    expect(byCountry).toHaveBeenCalledWith("CA")
+    expect(result.scope).toBe("country")
+  })
+
+  it("skips scopes whose fetcher is omitted entirely", async () => {
+    const result = await fetchWithLocationFallback(location, {
+      byCountry: async () => [{ id: "country-row" }],
+    })
+    expect(result).toEqual({ data: [{ id: "country-row" }], scope: "country" })
+  })
+
+  it("does not call lower-precedence fetchers once a level returns data", async () => {
+    const byCity = jest.fn(async () => [{ id: "city-row" }])
+    const byState = jest.fn(async () => [{ id: "state-row" }])
+    const byCountry = jest.fn(async () => [{ id: "country-row" }])
+    await fetchWithLocationFallback(location, { byCity, byState, byCountry })
+    expect(byCity).toHaveBeenCalledTimes(1)
+    expect(byState).not.toHaveBeenCalled()
+    expect(byCountry).not.toHaveBeenCalled()
+  })
+
+  it("propagates a fetcher error rather than swallowing it", async () => {
+    await expect(
+      fetchWithLocationFallback(location, {
+        byCity: async () => {
+          throw new Error("network down")
+        },
+        byState: async () => [{ id: "state-row" }],
+      }),
+    ).rejects.toThrow("network down")
+  })
+})
+
+describe("describeScope", () => {
+  it("returns null for city scope (no badge needed)", () => {
+    expect(describeScope("city", { state: "QC", country: "CA" })).toBeNull()
+  })
+
+  it("returns the state label for state scope", () => {
+    expect(describeScope("state", { state: "QC", country: "CA" })).toBe("Showing QC data")
+  })
+
+  it("returns the country label for country scope", () => {
+    expect(describeScope("country", { state: "QC", country: "CA" })).toBe("Showing CA data")
+  })
+
+  it("returns null for none scope", () => {
+    expect(describeScope("none", { state: "QC", country: "CA" })).toBeNull()
+  })
+
+  it("falls back to a generic label when state/country missing", () => {
+    expect(describeScope("state", {})).toBe("Showing state-level data")
+    expect(describeScope("country", {})).toBe("Showing country-level data")
+  })
+})

--- a/apps/mobile/app/lib/locationFallback.ts
+++ b/apps/mobile/app/lib/locationFallback.ts
@@ -1,0 +1,95 @@
+/**
+ * Location-hierarchy cascading fallback (#123).
+ *
+ * Resolves data city → state → country, returning the first non-empty result
+ * along with a `scope` label so callers can render provenance ("Showing
+ * Quebec province data" rather than pretending Sorel-Tracy has its own row).
+ *
+ * Used by every location-scoped hook that supports cascading:
+ *   - useLocationData (LocationMeasurement)
+ *   - usePollutionSources (PollutionSource)
+ *   - useLocationObservations (LocationObservation)
+ *
+ * Convention: a fetcher returning [] means "no data at this scope"; the
+ * util walks down to the next level. A fetcher rejecting bubbles up — we
+ * do not silently swallow errors mid-cascade.
+ */
+
+/** Which level of the hierarchy resolved the data. */
+export type LocationScope = "city" | "state" | "country" | "none"
+
+export interface LocationFallbackResult<T> {
+  /** Records returned from whichever scope had data. */
+  data: T[]
+  /** Where the data came from. "none" when every scope was empty. */
+  scope: LocationScope
+}
+
+export interface LocationFallbackInput {
+  city: string
+  state: string
+  country: string
+}
+
+export interface LocationFallbackFetchers<T> {
+  /** Optional city-scope fetcher. Skipped when omitted or city is empty. */
+  byCity?: (city: string) => Promise<T[]>
+  /** Optional state-scope fetcher. Skipped when omitted or state is empty. */
+  byState?: (state: string) => Promise<T[]>
+  /** Optional country-scope fetcher. Skipped when omitted or country is empty. */
+  byCountry?: (country: string) => Promise<T[]>
+}
+
+/**
+ * Cascade through the location hierarchy until a fetcher returns non-empty.
+ *
+ * Returns `scope: "none"` and `data: []` when every level is empty (or every
+ * level is skipped because the input/fetcher is missing). Errors are not
+ * swallowed — a thrown fetcher aborts the cascade.
+ */
+export async function fetchWithLocationFallback<T>(
+  location: LocationFallbackInput,
+  fetchers: LocationFallbackFetchers<T>,
+): Promise<LocationFallbackResult<T>> {
+  const { city, state, country } = location
+
+  if (city && fetchers.byCity) {
+    const cityData = await fetchers.byCity(city)
+    if (cityData.length > 0) {
+      return { data: cityData, scope: "city" }
+    }
+  }
+
+  if (state && fetchers.byState) {
+    const stateData = await fetchers.byState(state)
+    if (stateData.length > 0) {
+      return { data: stateData, scope: "state" }
+    }
+  }
+
+  if (country && fetchers.byCountry) {
+    const countryData = await fetchers.byCountry(country)
+    if (countryData.length > 0) {
+      return { data: countryData, scope: "country" }
+    }
+  }
+
+  return { data: [], scope: "none" }
+}
+
+/** Human-readable label for a scope. Used by provenance UI. */
+export function describeScope(
+  scope: LocationScope,
+  location: { state?: string; country?: string },
+): string | null {
+  switch (scope) {
+    case "city":
+      return null // Default — no badge needed.
+    case "state":
+      return location.state ? `Showing ${location.state} data` : "Showing state-level data"
+    case "country":
+      return location.country ? `Showing ${location.country} data` : "Showing country-level data"
+    case "none":
+      return null
+  }
+}

--- a/apps/mobile/app/lib/queryKeys.test.ts
+++ b/apps/mobile/app/lib/queryKeys.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression tests for the cascade-aware query keys (#123).
+ *
+ * Originally `usePollutionSources` and `useLocationObservations` keyed
+ * React Query by `byCity(city)` only. Once the cascade was added, two
+ * distinct (state, country) inputs with `city === ""` (the state-/country-
+ * only cascade case) collapsed onto the same cache slot, serving stale
+ * data from the previous query. The fix introduces `byLocation(city,
+ * state, country)`; this file pins the contract so a future refactor
+ * can't quietly regress.
+ */
+
+import { queryKeys } from "./queryKeys"
+
+describe("queryKeys.byLocation cascade keys (#123)", () => {
+  it.each([
+    ["measurements", queryKeys.measurements.byLocation],
+    ["observations", queryKeys.observations.byLocation],
+    ["pollutionSources", queryKeys.pollutionSources.byLocation],
+  ] as const)(
+    "%s: distinct (state, country) inputs with empty city produce distinct keys",
+    (_label, byLocation) => {
+      const qcKey = JSON.stringify(byLocation("", "QC", "CA"))
+      const onKey = JSON.stringify(byLocation("", "ON", "CA"))
+      const usKey = JSON.stringify(byLocation("", "", "US"))
+      const caCountryKey = JSON.stringify(byLocation("", "", "CA"))
+
+      expect(qcKey).not.toBe(onKey)
+      expect(qcKey).not.toBe(usKey)
+      expect(qcKey).not.toBe(caCountryKey)
+      expect(onKey).not.toBe(caCountryKey)
+      expect(usKey).not.toBe(caCountryKey)
+    },
+  )
+
+  it.each([
+    ["measurements", queryKeys.measurements.byLocation],
+    ["observations", queryKeys.observations.byLocation],
+    ["pollutionSources", queryKeys.pollutionSources.byLocation],
+  ] as const)(
+    "%s: same-named city in different states produces distinct keys",
+    (_label, byLocation) => {
+      // Same city name, different state → must not alias.
+      const springfieldIL = JSON.stringify(byLocation("Springfield", "IL", "US"))
+      const springfieldMA = JSON.stringify(byLocation("Springfield", "MA", "US"))
+      expect(springfieldIL).not.toBe(springfieldMA)
+    },
+  )
+})

--- a/apps/mobile/app/lib/queryKeys.ts
+++ b/apps/mobile/app/lib/queryKeys.ts
@@ -34,6 +34,8 @@ export const queryKeys = {
     byLocation: (city: string) => [...queryKeys.measurements.all, "location", city] as const,
     byCity: (city: string, state: string) =>
       [...queryKeys.measurements.all, "city", city, state] as const,
+    byState: (state: string) => [...queryKeys.measurements.all, "state", state] as const,
+    byCountry: (country: string) => [...queryKeys.measurements.all, "country", country] as const,
     multiLocation: (cities: string[]) =>
       [...queryKeys.measurements.all, "multi", ...cities.sort()] as const,
   },
@@ -84,5 +86,7 @@ export const queryKeys = {
     all: ["pollutionSources"] as const,
     byCity: (city: string) => [...queryKeys.pollutionSources.all, "city", city] as const,
     byState: (state: string) => [...queryKeys.pollutionSources.all, "state", state] as const,
+    byCountry: (country: string) =>
+      [...queryKeys.pollutionSources.all, "country", country] as const,
   },
 } as const

--- a/apps/mobile/app/lib/queryKeys.ts
+++ b/apps/mobile/app/lib/queryKeys.ts
@@ -31,7 +31,15 @@ export const queryKeys = {
   // ── Measurements / Location data ──
   measurements: {
     all: ["measurements"] as const,
-    byLocation: (city: string) => [...queryKeys.measurements.all, "location", city] as const,
+    /**
+     * Cascade-aware location key. Includes state/country because the
+     * cascading hook resolves data based on all three (#123) — keying on
+     * city alone would serve a stale result when the same-named city in
+     * a different state was previously queried, or when state/country
+     * change without the city changing.
+     */
+    byLocation: (city: string, state: string, country: string) =>
+      [...queryKeys.measurements.all, "location", city, state, country] as const,
     byCity: (city: string, state: string) =>
       [...queryKeys.measurements.all, "city", city, state] as const,
     byState: (state: string) => [...queryKeys.measurements.all, "state", state] as const,

--- a/apps/mobile/app/lib/queryKeys.ts
+++ b/apps/mobile/app/lib/queryKeys.ts
@@ -69,6 +69,13 @@ export const queryKeys = {
   // ── O&M Observations ──
   observations: {
     all: ["observations"] as const,
+    /**
+     * Cascade-aware location key (#123). City alone aliases distinct
+     * (state, country) inputs once `city === ""` (state-/country-only
+     * cascade), so the key must carry all three.
+     */
+    byLocation: (city: string, state: string, country: string) =>
+      [...queryKeys.observations.all, "location", city, state, country] as const,
     byCity: (city: string) => [...queryKeys.observations.all, "city", city] as const,
     byState: (state: string) => [...queryKeys.observations.all, "state", state] as const,
     byCountry: (country: string) => [...queryKeys.observations.all, "country", country] as const,
@@ -92,6 +99,13 @@ export const queryKeys = {
   // ── Pollution Sources ──
   pollutionSources: {
     all: ["pollutionSources"] as const,
+    /**
+     * Cascade-aware location key (#123). City alone aliases distinct
+     * (state, country) inputs once `city === ""` (state-/country-only
+     * cascade), so the key must carry all three.
+     */
+    byLocation: (city: string, state: string, country: string) =>
+      [...queryKeys.pollutionSources.all, "location", city, state, country] as const,
     byCity: (city: string) => [...queryKeys.pollutionSources.all, "city", city] as const,
     byState: (state: string) => [...queryKeys.pollutionSources.all, "state", state] as const,
     byCountry: (country: string) =>

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -19,6 +19,7 @@ import { ContaminantTable, ContaminantTableRow } from "@/components/ContaminantT
 import { ExpandableCard } from "@/components/ExpandableCard"
 import { Header } from "@/components/Header"
 import { LinkedText } from "@/components/LinkedText"
+import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { Screen } from "@/components/Screen"
 import { CATEGORY_DISPLAY_NAMES } from "@/components/StatCategoryCard"
 import { StatItem } from "@/components/StatItem"
@@ -55,9 +56,19 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
   const { getWHOThreshold, getThreshold, getJurisdictionForLocation } = useContaminants()
   const { getCategoryName, getCategoryColor } = useCategories()
 
-  // Fetch data for the passed city from Amplify (with caching and offline support)
-  const { cityData, isLoading, error, isMockData, isCachedData, lastUpdated, isOffline, refresh } =
-    useLocationData(city)
+  // Fetch data for the passed city from Amplify (with caching, offline support,
+  // and city → state → country cascading per #123).
+  const {
+    cityData,
+    isLoading,
+    error,
+    isMockData,
+    isCachedData,
+    lastUpdated,
+    isOffline,
+    scope,
+    refresh,
+  } = useLocationData(city, state, country)
 
   // State for pull-to-refresh
   const [isRefreshing, setIsRefreshing] = useState(false)
@@ -459,6 +470,14 @@ View details: ${shareUrl}`
           </View>
           <Text style={$categoryName}>{categoryName}</Text>
         </View>
+
+        {/* Cascade-scope provenance (#123): only renders for state/country fallback. */}
+        <LocationScopeBadge
+          scope={scope}
+          state={state}
+          country={country}
+          style={{ marginHorizontal: 16, marginBottom: 8 }}
+        />
 
         {/* Category Description */}
         <View style={$descriptionContainer}>

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -806,10 +806,16 @@ View details: ${shareUrl}`
         />
       </View>
 
-      {/* Location Header */}
+      {/* Location Header. Tolerates missing city/state for country-only
+          cascade inputs (#123) — joining ", " when both are blank would
+          render a stray comma. */}
       <LocationHeader
         locationName={
-          currentLocation ? `${currentLocation.city}, ${currentLocation.state}` : "Unknown"
+          currentLocation
+            ? [currentLocation.city, currentLocation.state].filter(Boolean).join(", ") ||
+              currentLocation.country ||
+              "Unknown"
+            : "Unknown"
         }
         secondaryText={currentLocation?.country === "CA" ? "Canada" : "United States"}
       />

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -21,6 +21,7 @@ import {
   SubCategoryStatusResult,
 } from "@/components/ExpandableCategoryCard"
 import { LocationHeader } from "@/components/LocationHeader"
+import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { NavHeader } from "@/components/NavHeader"
 import { PlacesSearchBar } from "@/components/PlacesSearchBar"
 import { ProfileMenu } from "@/components/ProfileMenu"
@@ -129,8 +130,13 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     return null
   }, [route.params?.city, route.params?.state, route.params?.country, route.params?.address])
 
-  // Fetch data for current location from Amplify (with caching and offline support)
-  const locationData = useLocationData(currentLocation?.city || "")
+  // Fetch data for current location from Amplify (with caching, offline support,
+  // and city → state → country cascading per #123).
+  const locationData = useLocationData(
+    currentLocation?.city || "",
+    currentLocation?.state || "",
+    currentLocation?.country || "",
+  )
 
   const {
     cityData,
@@ -140,6 +146,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     isCachedData = false,
     lastUpdated = null,
     isOffline,
+    scope,
     refresh,
   } = locationData
 
@@ -717,8 +724,9 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
-        {/* Pollution Sources Card */}
-        {renderPollutionSourcesCard()}
+        {/* Pollution Sources Card — gated on a real location to avoid landing on
+            an empty PollutionSourcesScreen when no city/state is set. */}
+        {currentLocation && renderPollutionSourcesCard()}
         <View style={$emptyStateContainer}>
           <MaterialCommunityIcons
             name="map-marker-question"
@@ -804,6 +812,15 @@ View details: ${shareUrl}`
           currentLocation ? `${currentLocation.city}, ${currentLocation.state}` : "Unknown"
         }
         secondaryText={currentLocation?.country === "CA" ? "Canada" : "United States"}
+      />
+
+      {/* Cascade-scope provenance: only renders for state/country fallback (#123) */}
+      <LocationScopeBadge
+        scope={scope}
+        state={currentLocation?.state}
+        country={currentLocation?.country}
+        // eslint-disable-next-line react-native/no-inline-styles
+        style={{ marginHorizontal: 16, marginBottom: 8 }}
       />
 
       {/* Searched Address Banner - shown when user searched for a specific address */}

--- a/apps/mobile/app/screens/LocationObservationsScreen.tsx
+++ b/apps/mobile/app/screens/LocationObservationsScreen.tsx
@@ -104,22 +104,13 @@ export const LocationObservationsScreen: FC<LocationObservationsScreenProps> =
       route.params.jurisdictionCode ?? getJurisdictionForLocation(state, country)?.code ?? "WHO"
     const { theme } = useAppTheme()
 
-    const {
-      observations,
-      isLoading,
-      error,
-      isOffline,
-      refresh,
-      worstStatus,
-      alertCount,
-      scope,
-      isStateLevelFallback,
-    } = useLocationObservations({
-      city,
-      state,
-      country,
-      jurisdictionCode,
-    })
+    const { observations, isLoading, error, isOffline, refresh, worstStatus, alertCount, scope } =
+      useLocationObservations({
+        city,
+        state,
+        country,
+        jurisdictionCode,
+      })
 
     const [isRefreshing, setIsRefreshing] = useState(false)
 
@@ -273,16 +264,24 @@ export const LocationObservationsScreen: FC<LocationObservationsScreenProps> =
 
           {/* Cascade-scope provenance (#123): renders for state and country
               fallback. Replaces the prior state-only banner so country-level
-              records are surfaced too. testID retained for E2E continuity. */}
-          <View testID={isStateLevelFallback ? "state-fallback-banner" : undefined}>
-            <LocationScopeBadge
-              scope={scope}
-              state={state}
-              country={country}
-              // eslint-disable-next-line react-native/no-inline-styles
-              style={{ marginHorizontal: 16, marginBottom: 12 }}
-            />
-          </View>
+              records are surfaced too. The badge carries a scope-specific
+              testID so E2E selectors can distinguish provenance — and so the
+              legacy `state-fallback-banner` testID still resolves only when
+              state-scope data is actually displayed (no orphan wrapper). */}
+          <LocationScopeBadge
+            scope={scope}
+            state={state}
+            country={country}
+            testID={
+              scope === "state"
+                ? "state-fallback-banner"
+                : scope === "country"
+                  ? "country-fallback-banner"
+                  : undefined
+            }
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={{ marginHorizontal: 16, marginBottom: 12 }}
+          />
 
           {/* Offline Banner */}
           {isOffline && (

--- a/apps/mobile/app/screens/LocationObservationsScreen.tsx
+++ b/apps/mobile/app/screens/LocationObservationsScreen.tsx
@@ -21,6 +21,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons"
 import { EmptyState } from "@/components/EmptyState"
 import { ExpandableCard } from "@/components/ExpandableCard"
 import { Header } from "@/components/Header"
+import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { ObservationCard } from "@/components/ObservationCard"
 import { Screen } from "@/components/Screen"
 import { StatusIndicator } from "@/components/StatusIndicator"
@@ -111,10 +112,12 @@ export const LocationObservationsScreen: FC<LocationObservationsScreenProps> =
       refresh,
       worstStatus,
       alertCount,
+      scope,
       isStateLevelFallback,
     } = useLocationObservations({
       city,
       state,
+      country,
       jurisdictionCode,
     })
 
@@ -268,22 +271,18 @@ export const LocationObservationsScreen: FC<LocationObservationsScreenProps> =
             </View>
           </View>
 
-          {/* State-level fallback banner */}
-          {isStateLevelFallback && (
-            <View
-              style={[styles.stateFallbackBanner, { backgroundColor: theme.colors.accentBlueBg }]}
-              testID="state-fallback-banner"
-            >
-              <MaterialCommunityIcons
-                name="information-outline"
-                size={16}
-                color={theme.colors.tint}
-              />
-              <Text style={[styles.stateFallbackText, { color: theme.colors.tint }]}>
-                Based on {state} provincial data
-              </Text>
-            </View>
-          )}
+          {/* Cascade-scope provenance (#123): renders for state and country
+              fallback. Replaces the prior state-only banner so country-level
+              records are surfaced too. testID retained for E2E continuity. */}
+          <View testID={isStateLevelFallback ? "state-fallback-banner" : undefined}>
+            <LocationScopeBadge
+              scope={scope}
+              state={state}
+              country={country}
+              // eslint-disable-next-line react-native/no-inline-styles
+              style={{ marginHorizontal: 16, marginBottom: 12 }}
+            />
+          </View>
 
           {/* Offline Banner */}
           {isOffline && (
@@ -450,22 +449,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
   } as TextStyle,
-  stateFallbackBanner: {
-    alignItems: "center",
-    borderRadius: 6,
-    flexDirection: "row",
-    gap: 8,
-    justifyContent: "center",
-    marginHorizontal: 16,
-    marginTop: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  } as ViewStyle,
-  stateFallbackText: {
-    flex: 1,
-    fontSize: 12,
-    textAlign: "center",
-  } as TextStyle,
+  // stateFallbackBanner / stateFallbackText removed: replaced by the unified
+  // LocationScopeBadge component (#123), which also covers country fallback.
   summaryCard: {
     alignItems: "center",
     borderLeftWidth: 4,

--- a/apps/mobile/app/screens/PollutionSourcesScreen.tsx
+++ b/apps/mobile/app/screens/PollutionSourcesScreen.tsx
@@ -21,6 +21,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons"
 
 import { EmptyState } from "@/components/EmptyState"
 import { Header } from "@/components/Header"
+import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import { usePollutionSources } from "@/hooks/usePollutionSources"
@@ -150,10 +151,14 @@ function SourceCard({
 export const PollutionSourcesScreen: FC<PollutionSourcesScreenProps> =
   function PollutionSourcesScreen(props) {
     const { navigation, route } = props
-    const { city, state } = route.params
+    const { city, state, country } = route.params
     const { theme } = useAppTheme()
 
-    const { sources, isLoading, error, refresh } = usePollutionSources({ city, state })
+    const { sources, isLoading, error, scope, refresh } = usePollutionSources({
+      city,
+      state,
+      country,
+    })
     const [isRefreshing, setIsRefreshing] = useState(false)
 
     const onRefresh = useCallback(async () => {
@@ -253,6 +258,13 @@ export const PollutionSourcesScreen: FC<PollutionSourcesScreenProps> =
           <Text style={[styles.$subtitle, { color: theme.colors.textDim }]}>
             {sources.length} source{sources.length !== 1 ? "s" : ""} near {city}
           </Text>
+          <LocationScopeBadge
+            scope={scope}
+            state={state}
+            country={country}
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={{ marginBottom: 12 }}
+          />
           {sources.map((source) => (
             <SourceCard key={source.id} source={source} theme={theme} />
           ))}

--- a/apps/mobile/app/screens/StatTrendScreen.tsx
+++ b/apps/mobile/app/screens/StatTrendScreen.tsx
@@ -90,8 +90,9 @@ export function StatTrendScreen() {
 
   const { statId, city, state, country } = route.params
 
-  // Fetch data for this location (uses React Query caching — likely already cached from CategoryDetail)
-  const { cityData, isLoading } = useLocationData(city)
+  // Fetch data for this location (uses React Query caching — likely already cached from CategoryDetail).
+  // Cascades city → state → country per #123.
+  const { cityData, isLoading } = useLocationData(city, state, country)
 
   // Look up the contaminant definition
   const definition = contaminantMap.get(statId)

--- a/apps/mobile/app/services/amplify/data.ts
+++ b/apps/mobile/app/services/amplify/data.ts
@@ -414,6 +414,25 @@ export async function getLocationMeasurementsByState(
 }
 
 /**
+ * Fetch measurements for a specific country (#123 cascade fallback)
+ */
+export async function getLocationMeasurementsByCountry(
+  country: string,
+): Promise<AmplifyLocationMeasurement[]> {
+  const client = await getPublicClient()
+  const { data, errors } = await client.models.LocationMeasurement.listLocationMeasurementByCountry(
+    {
+      country,
+    },
+  )
+  if (errors) {
+    console.error("Error fetching location measurements by country:", errors)
+    throw new Error("Failed to fetch location measurements by country")
+  }
+  return data
+}
+
+/**
  * Fetch measurements for a specific contaminant across all locations
  */
 export async function getMeasurementsByContaminant(
@@ -801,6 +820,23 @@ export async function getPollutionSourcesByState(state: string): Promise<Amplify
   if (errors) {
     console.error("Error fetching pollution sources by state:", errors)
     throw new Error("Failed to fetch pollution sources by state")
+  }
+  return data
+}
+
+/**
+ * Fetch pollution sources for a specific country (#123 cascade fallback)
+ */
+export async function getPollutionSourcesByCountry(
+  country: string,
+): Promise<AmplifyPollutionSource[]> {
+  const client = await getPublicClient()
+  const { data, errors } = await client.models.PollutionSource.listPollutionSourceByCountry({
+    country,
+  })
+  if (errors) {
+    console.error("Error fetching pollution sources by country:", errors)
+    throw new Error("Failed to fetch pollution sources by country")
   }
   return data
 }

--- a/apps/mobile/app/services/amplify/data.ts
+++ b/apps/mobile/app/services/amplify/data.ts
@@ -51,6 +51,57 @@ function getPrivateClient() {
 }
 
 // =============================================================================
+// Pagination helper (#123)
+// =============================================================================
+
+/** Page size for cascade fetchers — Amplify upper bound per call. */
+const CASCADE_PAGE_LIMIT = 1000
+
+/**
+ * Safety cap to bound runaway pagination on the mobile client. A country
+ * with more than this many records in the GSI almost certainly indicates
+ * a data-modeling problem, not a legitimate request.
+ */
+const CASCADE_MAX_PAGES = 20
+
+interface AmplifyListResponse<T> {
+  data: T[] | null | undefined
+  errors?: unknown
+  nextToken?: string | null
+}
+
+/**
+ * Page through an Amplify GSI list call until exhausted (or the safety cap
+ * is hit). Used by the cascade fetchers (#123) so a country with hundreds
+ * of measurements doesn't silently truncate at Amplify's 100-row default.
+ */
+async function paginateList<T>(
+  label: string,
+  fetchPage: (nextToken: string | undefined) => Promise<AmplifyListResponse<T>>,
+): Promise<T[]> {
+  const out: T[] = []
+  let token: string | undefined
+  let pages = 0
+  do {
+    const { data, errors, nextToken } = await fetchPage(token)
+    if (errors) {
+      console.error(`Error fetching ${label}:`, errors)
+      throw new Error(`Failed to fetch ${label}`)
+    }
+    if (data) out.push(...data)
+    token = nextToken ?? undefined
+    pages += 1
+    if (pages >= CASCADE_MAX_PAGES && token) {
+      console.warn(
+        `paginateList(${label}) hit the ${CASCADE_MAX_PAGES}-page safety cap with results still pending`,
+      )
+      break
+    }
+  } while (token)
+  return out
+}
+
+// =============================================================================
 // New Model Types
 // =============================================================================
 
@@ -397,39 +448,37 @@ export async function getLocationMeasurements(city: string): Promise<AmplifyLoca
 }
 
 /**
- * Fetch measurements for a specific state
+ * Fetch measurements for a specific state — paginated so country/state
+ * cascade fetches don't silently truncate at Amplify's 100-row default (#123).
  */
 export async function getLocationMeasurementsByState(
   state: string,
 ): Promise<AmplifyLocationMeasurement[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.LocationMeasurement.listLocationMeasurementByState({
-    state,
-  })
-  if (errors) {
-    console.error("Error fetching location measurements by state:", errors)
-    throw new Error("Failed to fetch location measurements by state")
-  }
-  return data
+  return paginateList("location measurements by state", (nextToken) =>
+    client.models.LocationMeasurement.listLocationMeasurementByState({
+      state,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
 }
 
 /**
- * Fetch measurements for a specific country (#123 cascade fallback)
+ * Fetch measurements for a specific country (#123 cascade fallback) —
+ * paginated, see getLocationMeasurementsByState.
  */
 export async function getLocationMeasurementsByCountry(
   country: string,
 ): Promise<AmplifyLocationMeasurement[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.LocationMeasurement.listLocationMeasurementByCountry(
-    {
+  return paginateList("location measurements by country", (nextToken) =>
+    client.models.LocationMeasurement.listLocationMeasurementByCountry({
       country,
-    },
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
   )
-  if (errors) {
-    console.error("Error fetching location measurements by country:", errors)
-    throw new Error("Failed to fetch location measurements by country")
-  }
-  return data
 }
 
 /**
@@ -718,20 +767,20 @@ export async function getLocationObservations(city: string): Promise<AmplifyLoca
 }
 
 /**
- * Fetch observations for a specific state/province
+ * Fetch observations for a specific state/province — paginated so
+ * country/state cascade fetches don't silently truncate (#123).
  */
 export async function getLocationObservationsByState(
   state: string,
 ): Promise<AmplifyLocationObservation[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.LocationObservation.listLocationObservationByState({
-    state,
-  })
-  if (errors) {
-    console.error("Error fetching location observations by state:", errors)
-    throw new Error("Failed to fetch location observations by state")
-  }
-  return data
+  return paginateList("location observations by state", (nextToken) =>
+    client.models.LocationObservation.listLocationObservationByState({
+      state,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
 }
 
 /**
@@ -753,22 +802,20 @@ export async function getObservationsByProperty(
 }
 
 /**
- * Fetch observations for a specific country
+ * Fetch observations for a specific country — paginated, see
+ * getLocationObservationsByState (#123).
  */
 export async function getLocationObservationsByCountry(
   country: string,
 ): Promise<AmplifyLocationObservation[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.LocationObservation.listLocationObservationByCountry(
-    {
+  return paginateList("location observations by country", (nextToken) =>
+    client.models.LocationObservation.listLocationObservationByCountry({
       country,
-    },
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
   )
-  if (errors) {
-    console.error("Error fetching location observations by country:", errors)
-    throw new Error("Failed to fetch location observations by country")
-  }
-  return data
 }
 
 // =============================================================================
@@ -810,35 +857,35 @@ export async function getPollutionSourcesByCity(city: string): Promise<AmplifyPo
 }
 
 /**
- * Fetch pollution sources for a specific state/province
+ * Fetch pollution sources for a specific state/province — paginated so
+ * country/state cascade fetches don't silently truncate (#123).
  */
 export async function getPollutionSourcesByState(state: string): Promise<AmplifyPollutionSource[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.PollutionSource.listPollutionSourceByState({
-    state,
-  })
-  if (errors) {
-    console.error("Error fetching pollution sources by state:", errors)
-    throw new Error("Failed to fetch pollution sources by state")
-  }
-  return data
+  return paginateList("pollution sources by state", (nextToken) =>
+    client.models.PollutionSource.listPollutionSourceByState({
+      state,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
 }
 
 /**
  * Fetch pollution sources for a specific country (#123 cascade fallback)
+ * — paginated, see getPollutionSourcesByState.
  */
 export async function getPollutionSourcesByCountry(
   country: string,
 ): Promise<AmplifyPollutionSource[]> {
   const client = await getPublicClient()
-  const { data, errors } = await client.models.PollutionSource.listPollutionSourceByCountry({
-    country,
-  })
-  if (errors) {
-    console.error("Error fetching pollution sources by country:", errors)
-    throw new Error("Failed to fetch pollution sources by country")
-  }
-  return data
+  return paginateList("pollution sources by country", (nextToken) =>
+    client.models.PollutionSource.listPollutionSourceByCountry({
+      country,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
 }
 
 // =============================================================================

--- a/apps/mobile/test/setup.ts
+++ b/apps/mobile/test/setup.ts
@@ -40,6 +40,31 @@ jest.mock("expo-localization", () => ({
   getLocales: () => [{ languageTag: "en-US", textDirection: "ltr" }],
 }))
 
+// `@expo-google-fonts/space-grotesk` requires `expo-font`, which is not
+// installed in this monorepo. Any test that transitively imports the
+// theme system (Text, useAppTheme, anything that touches typography.ts)
+// will throw "Cannot find module 'expo-font'" at import time. Mock the
+// font package so those tests can render. Returning a no-op `useFonts`
+// hook is sufficient — production app code only reads the fonts-loaded
+// boolean from it.
+jest.mock("@expo-google-fonts/space-grotesk", () => ({
+  useFonts: () => [true, null],
+  SpaceGrotesk_300Light: null,
+  SpaceGrotesk_400Regular: null,
+  SpaceGrotesk_500Medium: null,
+  SpaceGrotesk_600SemiBold: null,
+  SpaceGrotesk_700Bold: null,
+}))
+
+// `aws-amplify/analytics` (Pinpoint) tries to load `@aws-amplify/react-native`
+// at module init. Tests that import `app/utils/analytics.ts` (or anything
+// that uses `trackEvent`) hit "Cannot find module '@aws-amplify/react-native'"
+// before any test runs. A no-op `record` is sufficient for everything the
+// test suite actually exercises.
+jest.mock("aws-amplify/analytics", () => ({
+  record: jest.fn(),
+}))
+
 jest.mock("../app/i18n/index.ts", () => ({
   i18n: {
     isInitialized: true,

--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -326,14 +326,20 @@ const schema = a.schema({
 
   /**
    * LocationMeasurement - actual contaminant measurements for locations
-   * Keyed by city+state instead of postal code
-   * Public read, admin write
+   *
+   * Location hierarchy (#123):
+   *   - city + state + country → city-scoped record
+   *   - state + country (city omitted) → applies to every city in that state
+   *   - country only (city + state omitted) → applies to every city in that country
+   *
+   * Mobile resolves data city → state → country at query time. `country` is
+   * still required so every record is anchored to at least one hierarchy level.
    */
   LocationMeasurement: a
     .model({
-      city: a.string().required(), // City name
-      state: a.string().required(), // State/province code
-      country: a.string().required(), // "US", "CA"
+      city: a.string(), // City name (omit for state-/country-level records)
+      state: a.string(), // State/province code (omit for country-level records)
+      country: a.string().required(), // "US", "CA" — anchor for every record
       contaminantId: a.string().required(),
       value: a.float().required(),
       measuredAt: a.datetime().required(),
@@ -350,6 +356,7 @@ const schema = a.schema({
     .secondaryIndexes((index) => [
       index("city"),
       index("state"),
+      index("country"), // Country-level cascade fallback (#123)
       index("contaminantId"),
     ]),
 
@@ -377,7 +384,11 @@ const schema = a.schema({
       expoPushToken: a.string(),
     })
     .authorization((allow) => [allow.owner()])
-    .secondaryIndexes((index) => [index("city"), index("state")]),
+    .secondaryIndexes((index) => [
+      index("city"),
+      index("state"),
+      index("country"), // Country-scoped notification fan-out (#123)
+    ]),
 
   /**
    * NotificationLog - audit trail for sent notifications
@@ -565,8 +576,10 @@ const schema = a.schema({
       longitude: a.float().required(),
       impactRadius: a.float().required(), // meters
       address: a.string(),
-      city: a.string().required(),
-      state: a.string().required(),
+      // Location hierarchy (#123): city-/state-/country-scoped records.
+      // `country` is required so every source is anchored to at least one level.
+      city: a.string(),
+      state: a.string(),
       country: a.string().required(),
       jurisdictionCode: a.string(),
       primaryContaminants: a.string().array(), // contaminant IDs
@@ -582,7 +595,11 @@ const schema = a.schema({
       allow.authenticated().to(["read"]),
       allow.group("admin").to(["create", "update", "delete", "read"]),
     ])
-    .secondaryIndexes((index) => [index("city"), index("state")]),
+    .secondaryIndexes((index) => [
+      index("city"),
+      index("state"),
+      index("country"), // Country-level cascade fallback (#123)
+    ]),
 
   // =========================================================================
   // Newsletter Subscriptions (Landing Page)
@@ -752,9 +769,11 @@ const schema = a.schema({
    */
   LocationObservation: a
     .model({
-      // Location identification (matches Location model pattern)
-      city: a.string().required(),
-      state: a.string().required(),
+      // Location identification (matches Location model pattern).
+      // Location hierarchy (#123): city/state may be omitted for state- or
+      // country-level observations; mobile cascades city → state → country.
+      city: a.string(),
+      state: a.string(),
       country: a.string().required(),
       county: a.string(),
       // What's being observed

--- a/packages/backend/amplify/functions/on-location-measurement-update/handler.test.ts
+++ b/packages/backend/amplify/functions/on-location-measurement-update/handler.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the on-location-measurement-update Lambda's pure helpers.
+ *
+ * The lambda's main behaviour (DynamoDB stream → invoke
+ * process-notifications) is integration-tested on staging once the schema
+ * deploys. These tests cover the cascade-scope derivation logic (#123)
+ * which is the core decision point for fan-out scope.
+ *
+ * Run from this directory: `npx jest --config jest.config.js`
+ */
+
+// Mock the AWS SDK client so the handler module can be imported in
+// isolation. We're not exercising the InvokeCommand path here.
+jest.mock("@aws-sdk/client-lambda", () => ({
+  LambdaClient: jest.fn(() => ({ send: jest.fn() })),
+  InvokeCommand: jest.fn(),
+}))
+
+import { deriveScope, type LocationMeasurementRecord } from "./handler"
+
+describe("deriveScope (#123)", () => {
+  const baseRecord: LocationMeasurementRecord = {
+    id: "row-1",
+    country: "CA",
+    contaminantId: "radon",
+    value: 200,
+    measuredAt: "2026-04-01T00:00:00Z",
+  }
+
+  it("returns 'city' when city is populated", () => {
+    expect(
+      deriveScope({ ...baseRecord, city: "Sorel-Tracy", state: "QC", country: "CA" }),
+    ).toBe("city")
+  })
+
+  it("returns 'state' when only state + country are populated", () => {
+    expect(
+      deriveScope({ ...baseRecord, city: null, state: "QC", country: "CA" }),
+    ).toBe("state")
+  })
+
+  it("returns 'country' when only country is populated", () => {
+    expect(
+      deriveScope({ ...baseRecord, city: null, state: null, country: "CA" }),
+    ).toBe("country")
+  })
+
+  it("treats undefined and null city/state identically", () => {
+    expect(deriveScope({ ...baseRecord, country: "CA" })).toBe("country")
+    expect(
+      deriveScope({ ...baseRecord, city: undefined, state: undefined, country: "CA" }),
+    ).toBe("country")
+  })
+
+  it("treats empty-string city as no-city (state-scope) — DynamoDB sometimes serialises null as empty", () => {
+    expect(
+      deriveScope({ ...baseRecord, city: "", state: "QC", country: "CA" }),
+    ).toBe("state")
+  })
+
+  it("city wins even when state is also populated (most specific scope)", () => {
+    expect(
+      deriveScope({ ...baseRecord, city: "Sorel-Tracy", state: "QC", country: "CA" }),
+    ).toBe("city")
+  })
+})

--- a/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
+++ b/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
@@ -18,8 +18,10 @@ const PROCESS_NOTIFICATIONS_FUNCTION_NAME = process.env.PROCESS_NOTIFICATIONS_FU
 
 interface LocationMeasurementRecord {
   id: string
-  city: string
-  state: string
+  // Location hierarchy (#123): city/state may be null on state- or country-
+  // anchored records. country is the only field guaranteed to be set.
+  city?: string | null
+  state?: string | null
   country: string
   contaminantId: string
   value: number
@@ -28,6 +30,19 @@ interface LocationMeasurementRecord {
   sourceUrl?: string
   notes?: string
   silentImport?: boolean
+}
+
+/**
+ * Determine which level of the location hierarchy this record was anchored
+ * at. Drives notification fan-out: city-scope notifies one city's
+ * subscribers, state-scope notifies every subscriber in that state, etc.
+ */
+function deriveScope(
+  record: LocationMeasurementRecord,
+): 'city' | 'state' | 'country' {
+  if (record.city) return 'city'
+  if (record.state) return 'state'
+  return 'country'
 }
 
 /**
@@ -51,22 +66,34 @@ async function processRecord(record: DynamoDBRecord): Promise<void> {
 
   const { city, state, country, contaminantId, value, silentImport } = newItem
 
-  // Skip notification for silent imports (bulk imports, data corrections, etc.)
-  if (silentImport === true) {
-    console.log(`Skipping notification for silent import: ${city}, ${state}, ${contaminantId}`)
+  if (!country) {
+    console.log('Record missing country anchor, skipping')
     return
   }
 
-  // Determine trigger type based on event
-  const triggerType = record.eventName === 'INSERT' ? 'data_update' : 'data_update'
+  // Skip notification for silent imports (bulk imports, data corrections, etc.)
+  if (silentImport === true) {
+    console.log(
+      `Skipping notification for silent import: ${city ?? ''}, ${state ?? ''}, ${country}, ${contaminantId}`,
+    )
+    return
+  }
 
-  console.log(`Processing ${record.eventName} for ${city}, ${state}/${contaminantId} (value: ${value})`)
+  const scope = deriveScope(newItem)
+  const triggerType = 'data_update'
+  const locationLabel = `${city ?? '-'}, ${state ?? '-'}, ${country}`
 
-  // Build payload for process-notifications Lambda
+  console.log(
+    `Processing ${record.eventName} (${scope}-scope) for ${locationLabel}/${contaminantId} (value: ${value})`,
+  )
+
+  // Build payload for process-notifications Lambda. `scope` tells the
+  // downstream Lambda which subscriber set to fan out to (#123).
   const payload = {
-    city,
-    state,
+    city: city ?? null,
+    state: state ?? null,
     country,
+    scope,
     contaminantId,
     triggerType,
     currentValue: value,
@@ -81,7 +108,9 @@ async function processRecord(record: DynamoDBRecord): Promise<void> {
     })
 
     await lambdaClient.send(command)
-    console.log(`Successfully invoked process-notifications for ${city}, ${state}/${contaminantId}`)
+    console.log(
+      `Successfully invoked process-notifications (${scope}) for ${locationLabel}/${contaminantId}`,
+    )
   } catch (error) {
     console.error(`Error invoking process-notifications:`, error)
     throw error // Re-throw to trigger retry

--- a/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
+++ b/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
@@ -120,24 +120,36 @@ async function processRecord(record: DynamoDBRecord): Promise<void> {
 }
 
 /**
- * Lambda handler for DynamoDB Stream events
+ * Lambda handler for DynamoDB Stream events.
+ *
+ * Records in a stream batch are independent — each fans out to its own
+ * async invocation of process-notifications — so they're processed in
+ * parallel via Promise.allSettled. batchItemFailures is order-
+ * independent, so this doesn't change retry semantics.
  */
 export const handler: DynamoDBStreamHandler = async (event) => {
   console.log(`Processing ${event.Records.length} DynamoDB stream records`)
 
-  const batchItemFailures: { itemIdentifier: string }[] = []
+  const results = await Promise.allSettled(
+    event.Records.map(async (record) => {
+      try {
+        await processRecord(record)
+      } catch (error) {
+        console.error(`Error processing record ${record.eventID}:`, error)
+        throw error
+      }
+    }),
+  )
 
-  for (const record of event.Records) {
-    try {
-      await processRecord(record)
-    } catch (error) {
-      console.error(`Error processing record ${record.eventID}:`, error)
-      // Add to failures for retry
-      if (record.eventID) {
-        batchItemFailures.push({ itemIdentifier: record.eventID })
+  const batchItemFailures: { itemIdentifier: string }[] = []
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') {
+      const eventID = event.Records[i].eventID
+      if (eventID) {
+        batchItemFailures.push({ itemIdentifier: eventID })
       }
     }
-  }
+  })
 
   console.log(`Processed ${event.Records.length - batchItemFailures.length} records successfully`)
 

--- a/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
+++ b/packages/backend/amplify/functions/on-location-measurement-update/handler.ts
@@ -16,7 +16,7 @@ const lambdaClient = new LambdaClient({})
 // Environment variables (set in backend.ts)
 const PROCESS_NOTIFICATIONS_FUNCTION_NAME = process.env.PROCESS_NOTIFICATIONS_FUNCTION_NAME!
 
-interface LocationMeasurementRecord {
+export interface LocationMeasurementRecord {
   id: string
   // Location hierarchy (#123): city/state may be null on state- or country-
   // anchored records. country is the only field guaranteed to be set.
@@ -36,8 +36,10 @@ interface LocationMeasurementRecord {
  * Determine which level of the location hierarchy this record was anchored
  * at. Drives notification fan-out: city-scope notifies one city's
  * subscribers, state-scope notifies every subscriber in that state, etc.
+ *
+ * Exported for unit testing — production callers go through `processRecord`.
  */
-function deriveScope(
+export function deriveScope(
   record: LocationMeasurementRecord,
 ): 'city' | 'state' | 'country' {
   if (record.city) return 'city'

--- a/packages/backend/amplify/functions/on-location-measurement-update/jest.config.js
+++ b/packages/backend/amplify/functions/on-location-measurement-update/jest.config.js
@@ -1,0 +1,32 @@
+/**
+ * Jest config for the on-location-measurement-update Lambda.
+ *
+ * The backend repo doesn't have a workspace-level jest setup; per-function
+ * configs are the existing pattern (see subscribe-to-newsletter and
+ * confirm-newsletter for prior art). Run from this directory with:
+ *
+ *   npx jest --config jest.config.js
+ *
+ * Or from the backend root:
+ *
+ *   npx jest --config amplify/functions/on-location-measurement-update/jest.config.js
+ */
+/** @type {import('jest').Config} */
+export default {
+  testEnvironment: "node",
+  rootDir: ".",
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: false,
+        tsconfig: {
+          module: "commonjs",
+          moduleResolution: "node",
+          esModuleInterop: true,
+          verbatimModuleSyntax: false,
+        },
+      },
+    ],
+  },
+}

--- a/packages/backend/amplify/functions/process-notifications/handler.test.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.test.ts
@@ -192,6 +192,28 @@ describe("groupPushRecipients (#123 fan-out batching)", () => {
     expect(groups[0].tokens.sort()).toEqual(["tok-1", "tok-2"])
   })
 
+  it("does NOT collide when subscriber city contains the legacy pipe separator", () => {
+    // Regression: the previous key `${city}|${state}|${country}` would
+    // collide for the rare bilingual cities like
+    // "Sault Ste. Marie | Sainte-Sault-Marie". JSON.stringify keying
+    // disambiguates even when the literal field value contains `|`.
+    const recipients = [
+      makeRecipient("tok-pipe", { id: "s1", city: "A|B", state: "X", country: "CA" }),
+      // Naively concatenating with `|` would produce the same key as the row above.
+      makeRecipient("tok-shadow", { id: "s2", city: "A", state: "B|X", country: "CA" }),
+    ]
+
+    const groups = groupPushRecipients(
+      recipients,
+      "country",
+      { city: null, state: null, country: "CA" },
+      undefined,
+    )
+
+    // Two distinct (city, state) tuples → two batches.
+    expect(groups).toHaveLength(2)
+  })
+
   it("scales to thousands of recipients with bounded group count", () => {
     // Country-scope fan-out is the worst case. 10,000 subscribers
     // distributed across 50 cities → 50 groups, NOT 10,000 sequential

--- a/packages/backend/amplify/functions/process-notifications/handler.test.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for process-notifications pure helpers.
+ *
+ * These cover the push-recipient grouping logic that fixes the
+ * sequential-fan-out performance bug introduced when #123 added
+ * state/country scope. The full handler (DynamoDB + Cognito + Lambda
+ * invocations) is integration-tested on staging — these tests only
+ * exercise the pure grouping helper that decides how many batched
+ * sends are issued.
+ *
+ * Run from this directory: `npx jest --config jest.config.js`
+ */
+
+// Mock AWS SDK clients so the handler module can be imported without
+// touching the network. We're not exercising the I/O paths here.
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn(() => ({ send: jest.fn() })),
+  QueryCommand: jest.fn(),
+  PutItemCommand: jest.fn(),
+}))
+jest.mock("@aws-sdk/client-lambda", () => ({
+  LambdaClient: jest.fn(() => ({ send: jest.fn() })),
+  InvokeCommand: jest.fn(),
+}))
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn(() => ({ send: jest.fn() })),
+  AdminGetUserCommand: jest.fn(),
+}))
+jest.mock("@aws-sdk/util-dynamodb", () => ({
+  unmarshall: jest.fn(),
+  marshall: jest.fn(),
+}))
+
+import { groupPushRecipients, type Subscription } from "./handler"
+
+function makeSub(overrides: Partial<Subscription>): Subscription {
+  return {
+    id: "sub-default",
+    owner: "user-default",
+    city: "Montreal",
+    state: "QC",
+    country: "CA",
+    enablePush: true,
+    enableEmail: false,
+    alertOnDanger: true,
+    alertOnWarning: false,
+    alertOnAnyChange: false,
+    notifyWhenDataAvailable: false,
+    expoPushToken: "ExponentPushToken[default]",
+    ...overrides,
+  }
+}
+
+function makeRecipient(token: string, sub: Partial<Subscription>) {
+  return { token, subscription: makeSub({ expoPushToken: token, ...sub }) }
+}
+
+describe("groupPushRecipients (#123 fan-out batching)", () => {
+  const origin = { city: "Montreal", state: "QC", country: "CA" }
+
+  it("returns an empty array when there are no recipients", () => {
+    expect(groupPushRecipients([], "city", origin, "lead")).toEqual([])
+    expect(groupPushRecipients([], "state", origin, "lead")).toEqual([])
+    expect(groupPushRecipients([], "country", origin, "lead")).toEqual([])
+  })
+
+  it("collapses every city-scope recipient into ONE batch with the origin deep-link", () => {
+    // Critical regression test: city-scope used to be one batched send;
+    // a sequential per-subscriber loop would have N groups here.
+    const recipients = [
+      makeRecipient("tok-A", { id: "s1", city: "Montreal" }),
+      makeRecipient("tok-B", { id: "s2", city: "Montreal" }),
+      makeRecipient("tok-C", { id: "s3", city: "Montreal" }),
+    ]
+
+    const groups = groupPushRecipients(recipients, "city", origin, "lead")
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tokens).toEqual(["tok-A", "tok-B", "tok-C"])
+    expect(groups[0].data).toEqual({
+      screen: "Dashboard",
+      city: "Montreal",
+      state: "QC",
+      country: "CA",
+      contaminantId: "lead",
+    })
+    expect(groups[0].subscriptions).toHaveLength(3)
+  })
+
+  it("groups state-scope recipients by their own city (one batch per distinct subscriber city)", () => {
+    // For state-scope fan-out, every subscriber gets a deep-link to
+    // their OWN dashboard, but recipients in the same city share the
+    // same payload — so we batch per-city rather than per-recipient.
+    const recipients = [
+      makeRecipient("tok-MTL-1", { id: "s1", city: "Montreal", state: "QC", country: "CA" }),
+      makeRecipient("tok-MTL-2", { id: "s2", city: "Montreal", state: "QC", country: "CA" }),
+      makeRecipient("tok-QBC-1", { id: "s3", city: "Quebec City", state: "QC", country: "CA" }),
+      makeRecipient("tok-LAV-1", { id: "s4", city: "Laval", state: "QC", country: "CA" }),
+      makeRecipient("tok-LAV-2", { id: "s5", city: "Laval", state: "QC", country: "CA" }),
+    ]
+
+    const groups = groupPushRecipients(
+      recipients,
+      "state",
+      { city: null, state: "QC", country: "CA" },
+      "radon",
+    )
+
+    // 5 recipients, 3 distinct cities → 3 batched sends, not 5.
+    expect(groups).toHaveLength(3)
+
+    const byCity = new Map(groups.map((g) => [g.data.city as string, g]))
+    expect(byCity.get("Montreal")!.tokens.sort()).toEqual(["tok-MTL-1", "tok-MTL-2"])
+    expect(byCity.get("Quebec City")!.tokens).toEqual(["tok-QBC-1"])
+    expect(byCity.get("Laval")!.tokens.sort()).toEqual(["tok-LAV-1", "tok-LAV-2"])
+
+    // Every group's deep-link points at the subscriber's own city,
+    // not the (null) origin city.
+    for (const g of groups) {
+      expect(g.data.contaminantId).toBe("radon")
+      expect(g.data.state).toBe("QC")
+      expect(g.data.country).toBe("CA")
+      expect(g.data.screen).toBe("Dashboard")
+    }
+  })
+
+  it("groups country-scope recipients across states by (city, state, country)", () => {
+    // Country-scope fan-out can include subscribers in different states.
+    // Two cities with the same name in different states must NOT share
+    // a batch — the deep-link state would be wrong for half of them.
+    const recipients = [
+      makeRecipient("tok-Spr-IL-1", { id: "s1", city: "Springfield", state: "IL", country: "US" }),
+      makeRecipient("tok-Spr-IL-2", { id: "s2", city: "Springfield", state: "IL", country: "US" }),
+      makeRecipient("tok-Spr-MA-1", { id: "s3", city: "Springfield", state: "MA", country: "US" }),
+      makeRecipient("tok-NYC-1", { id: "s4", city: "New York", state: "NY", country: "US" }),
+    ]
+
+    const groups = groupPushRecipients(
+      recipients,
+      "country",
+      { city: null, state: null, country: "US" },
+      undefined,
+    )
+
+    // Same-name cities in different states get separate batches → 3 groups.
+    expect(groups).toHaveLength(3)
+
+    const findGroup = (city: string, state: string) =>
+      groups.find((g) => g.data.city === city && g.data.state === state)
+
+    expect(findGroup("Springfield", "IL")!.tokens.sort()).toEqual([
+      "tok-Spr-IL-1",
+      "tok-Spr-IL-2",
+    ])
+    expect(findGroup("Springfield", "MA")!.tokens).toEqual(["tok-Spr-MA-1"])
+    expect(findGroup("New York", "NY")!.tokens).toEqual(["tok-NYC-1"])
+  })
+
+  it("preserves subscription identity in each group for downstream logging", () => {
+    // The handler logs one NotificationLog row per recipient using the
+    // subscription's own city/state/country. The grouper must not lose
+    // the original Subscription objects.
+    const recipients = [
+      makeRecipient("tok-1", { id: "s1", city: "Toronto", state: "ON", country: "CA" }),
+      makeRecipient("tok-2", { id: "s2", city: "Toronto", state: "ON", country: "CA" }),
+    ]
+
+    const groups = groupPushRecipients(
+      recipients,
+      "country",
+      { city: null, state: null, country: "CA" },
+      undefined,
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].subscriptions.map((s) => s.id).sort()).toEqual(["s1", "s2"])
+  })
+
+  it("city scope ignores subscriber location and uses the origin payload (verifies city-scope short-circuit)", () => {
+    // If the grouper accidentally applied the state/country grouping
+    // logic to city-scope events, recipients in different cities would
+    // get split across multiple batches.
+    const recipients = [
+      makeRecipient("tok-1", { id: "s1", city: "Anywhere-1", state: "QC", country: "CA" }),
+      makeRecipient("tok-2", { id: "s2", city: "Anywhere-2", state: "QC", country: "CA" }),
+    ]
+
+    const groups = groupPushRecipients(recipients, "city", origin, "arsenic")
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].data.city).toBe("Montreal") // the origin, not the subscriber
+    expect(groups[0].tokens.sort()).toEqual(["tok-1", "tok-2"])
+  })
+
+  it("scales to thousands of recipients with bounded group count", () => {
+    // Country-scope fan-out is the worst case. 10,000 subscribers
+    // distributed across 50 cities → 50 groups, NOT 10,000 sequential
+    // sends. This is the correctness condition that prevents the
+    // Lambda 15-min timeout.
+    const cities = Array.from({ length: 50 }, (_, i) => `City-${i}`)
+    const recipients = Array.from({ length: 10_000 }, (_, i) =>
+      makeRecipient(`tok-${i}`, {
+        id: `s-${i}`,
+        city: cities[i % cities.length],
+        state: "CA",
+        country: "US",
+      }),
+    )
+
+    const groups = groupPushRecipients(
+      recipients,
+      "country",
+      { city: null, state: null, country: "US" },
+      undefined,
+    )
+
+    expect(groups).toHaveLength(50)
+    const total = groups.reduce((sum, g) => sum + g.tokens.length, 0)
+    expect(total).toBe(10_000)
+  })
+})

--- a/packages/backend/amplify/functions/process-notifications/handler.test.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.test.ts
@@ -12,12 +12,17 @@
  */
 
 // Mock AWS SDK clients so the handler module can be imported without
-// touching the network. We're not exercising the I/O paths here.
-jest.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: jest.fn(() => ({ send: jest.fn() })),
-  QueryCommand: jest.fn(),
-  PutItemCommand: jest.fn(),
-}))
+// touching the network. The dynamo `send` is exposed so tests of the
+// pagination loop (#123) can program multi-page responses.
+jest.mock("@aws-sdk/client-dynamodb", () => {
+  const send = jest.fn()
+  return {
+    __dynamoSend: send,
+    DynamoDBClient: jest.fn(() => ({ send })),
+    QueryCommand: jest.fn((input: unknown) => ({ input })),
+    PutItemCommand: jest.fn((input: unknown) => ({ input })),
+  }
+})
 jest.mock("@aws-sdk/client-lambda", () => ({
   LambdaClient: jest.fn(() => ({ send: jest.fn() })),
   InvokeCommand: jest.fn(),
@@ -26,12 +31,19 @@ jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
   CognitoIdentityProviderClient: jest.fn(() => ({ send: jest.fn() })),
   AdminGetUserCommand: jest.fn(),
 }))
+// Identity unmarshall — pagination tests feed already-plain Subscription
+// objects, so we don't need DynamoDB's AttributeValue → JS coercion.
 jest.mock("@aws-sdk/util-dynamodb", () => ({
-  unmarshall: jest.fn(),
+  unmarshall: (item: unknown) => item,
   marshall: jest.fn(),
 }))
 
-import { groupPushRecipients, type Subscription } from "./handler"
+import { groupPushRecipients, querySubscriptionsAllPages, type Subscription } from "./handler"
+
+// Grab the dynamo `send` mock injected via the jest.mock factory above.
+const dynamoSendMock = (
+  jest.requireMock("@aws-sdk/client-dynamodb") as { __dynamoSend: jest.Mock }
+).__dynamoSend
 
 function makeSub(overrides: Partial<Subscription>): Subscription {
   return {
@@ -214,6 +226,8 @@ describe("groupPushRecipients (#123 fan-out batching)", () => {
     expect(groups).toHaveLength(2)
   })
 
+  // Pagination loop tests live in their own describe below.
+
   it("scales to thousands of recipients with bounded group count", () => {
     // Country-scope fan-out is the worst case. 10,000 subscribers
     // distributed across 50 cities → 50 groups, NOT 10,000 sequential
@@ -239,5 +253,89 @@ describe("groupPushRecipients (#123 fan-out batching)", () => {
     expect(groups).toHaveLength(50)
     const total = groups.reduce((sum, g) => sum + g.tokens.length, 0)
     expect(total).toBe(10_000)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// querySubscriptionsAllPages — DynamoDB LastEvaluatedKey loop (#123 C3)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Critical: a single DynamoDB Query response is capped at 1MB. Without
+// the LastEvaluatedKey loop, country-scope fan-out would silently drop
+// every subscriber past the first ~1MB page. These tests pin the loop
+// behaviour so a future refactor can't quietly regress it.
+
+describe("querySubscriptionsAllPages (#123 fan-out pagination)", () => {
+  beforeEach(() => {
+    dynamoSendMock.mockReset()
+  })
+
+  it("returns the single page when DynamoDB has no LastEvaluatedKey", async () => {
+    dynamoSendMock.mockResolvedValueOnce({
+      Items: [{ id: "s1" }, { id: "s2" }],
+      LastEvaluatedKey: undefined,
+    })
+
+    const subs = await querySubscriptionsAllPages({
+      TableName: "x",
+      IndexName: "userSubscriptionsByCountry",
+      KeyConditionExpression: "country = :c",
+      ExpressionAttributeValues: { ":c": { S: "CA" } },
+    })
+
+    expect(subs).toHaveLength(2)
+    expect(dynamoSendMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("aggregates results across multiple pages until LastEvaluatedKey is exhausted", async () => {
+    // Three pages: 2 + 2 + 1 = 5 subscriptions. The loop must call
+    // dynamo.send() three times, threading LastEvaluatedKey forward.
+    dynamoSendMock
+      .mockResolvedValueOnce({
+        Items: [{ id: "s1" }, { id: "s2" }],
+        LastEvaluatedKey: { id: { S: "s2" } },
+      })
+      .mockResolvedValueOnce({
+        Items: [{ id: "s3" }, { id: "s4" }],
+        LastEvaluatedKey: { id: { S: "s4" } },
+      })
+      .mockResolvedValueOnce({
+        Items: [{ id: "s5" }],
+        LastEvaluatedKey: undefined,
+      })
+
+    const subs = await querySubscriptionsAllPages({
+      TableName: "x",
+      IndexName: "userSubscriptionsByCountry",
+      KeyConditionExpression: "country = :c",
+      ExpressionAttributeValues: { ":c": { S: "CA" } },
+    })
+
+    expect(subs.map((s) => s.id)).toEqual(["s1", "s2", "s3", "s4", "s5"])
+    expect(dynamoSendMock).toHaveBeenCalledTimes(3)
+
+    // The second and third QueryCommands must carry the previous page's
+    // LastEvaluatedKey as ExclusiveStartKey, otherwise the loop would
+    // re-fetch page 1 forever (or never advance, depending on DDB).
+    const secondInput = (dynamoSendMock.mock.calls[1][0] as { input: { ExclusiveStartKey?: unknown } })
+      .input
+    const thirdInput = (dynamoSendMock.mock.calls[2][0] as { input: { ExclusiveStartKey?: unknown } })
+      .input
+    expect(secondInput.ExclusiveStartKey).toEqual({ id: { S: "s2" } })
+    expect(thirdInput.ExclusiveStartKey).toEqual({ id: { S: "s4" } })
+  })
+
+  it("handles an empty result set without spinning", async () => {
+    dynamoSendMock.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined })
+
+    const subs = await querySubscriptionsAllPages({
+      TableName: "x",
+      IndexName: "userSubscriptionsByCountry",
+      KeyConditionExpression: "country = :c",
+      ExpressionAttributeValues: { ":c": { S: "ZZ" } },
+    })
+
+    expect(subs).toEqual([])
+    expect(dynamoSendMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/backend/amplify/functions/process-notifications/handler.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.ts
@@ -13,6 +13,7 @@ import {
   DynamoDBClient,
   QueryCommand,
   PutItemCommand,
+  type AttributeValue,
 } from '@aws-sdk/client-dynamodb'
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda'
 import {
@@ -148,9 +149,16 @@ export function groupPushRecipients(
     ]
   }
 
+  // Use JSON.stringify so unusual city names containing the previous
+  // pipe separator (rare bilingual entries like
+  // "Sault Ste. Marie | Sainte-Sault-Marie") don't collide on the key.
   const byKey = new Map<string, { token: string; subscription: Subscription }[]>()
   for (const r of recipients) {
-    const key = `${r.subscription.city}|${r.subscription.state ?? ''}|${r.subscription.country ?? ''}`
+    const key = JSON.stringify([
+      r.subscription.city,
+      r.subscription.state ?? '',
+      r.subscription.country ?? '',
+    ])
     const arr = byKey.get(key) ?? []
     arr.push(r)
     byKey.set(key, arr)
@@ -169,10 +177,69 @@ export function groupPushRecipients(
 }
 
 /**
- * Query subscriptions by city using GSI
+ * Cap on concurrent NotificationLog PutItem calls. State/country fan-out
+ * (#123) can reach thousands of subscribers; an unbounded `Promise.all`
+ * would issue thousands of parallel writes, hitting DynamoDB write
+ * throttling and risking Lambda OOM. 25 matches the BatchWriteItem cap
+ * and keeps tail latency bounded.
+ */
+const LOG_WRITE_CONCURRENCY = 25
+
+/**
+ * Run an async map with a fixed concurrency cap. Used for NotificationLog
+ * writes; the order of results doesn't matter and individual failures are
+ * already swallowed by `logNotification` itself.
+ */
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0
+  const runNext = async (): Promise<void> => {
+    while (true) {
+      const i = cursor
+      cursor += 1
+      if (i >= items.length) return
+      await worker(items[i])
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => runNext(),
+  )
+  await Promise.all(workers)
+}
+
+/**
+ * Page through a DynamoDB Query call until LastEvaluatedKey is exhausted.
+ * Required for state/country fan-out (#123): a single Query response is
+ * capped at 1MB, so a country with thousands of subscribers would
+ * silently miss the rest of the fan-out without pagination.
+ */
+async function querySubscriptionsAllPages(
+  baseInput: Omit<ConstructorParameters<typeof QueryCommand>[0], 'ExclusiveStartKey'>,
+): Promise<Subscription[]> {
+  const out: Subscription[] = []
+  let ExclusiveStartKey: Record<string, AttributeValue> | undefined
+  do {
+    const result = await dynamoClient.send(
+      new QueryCommand({ ...baseInput, ExclusiveStartKey }),
+    )
+    for (const item of result.Items ?? []) {
+      out.push(unmarshall(item) as Subscription)
+    }
+    ExclusiveStartKey = result.LastEvaluatedKey
+  } while (ExclusiveStartKey)
+  return out
+}
+
+/**
+ * Query subscriptions by city using GSI. Paginated so a single very-popular
+ * city doesn't silently drop subscribers past the 1MB Query response cap.
  */
 async function getSubscriptionsByCity(city: string): Promise<Subscription[]> {
-  const command = new QueryCommand({
+  return querySubscriptionsAllPages({
     TableName: SUBSCRIPTIONS_TABLE_NAME,
     IndexName: 'userSubscriptionsByCity',
     KeyConditionExpression: 'city = :city',
@@ -180,18 +247,15 @@ async function getSubscriptionsByCity(city: string): Promise<Subscription[]> {
       ':city': { S: city },
     },
   })
-
-  const result = await dynamoClient.send(command)
-  return (result.Items || []).map((item) => unmarshall(item) as Subscription)
 }
 
 /**
  * Query subscriptions by state via the state GSI (#123 cascade fan-out).
  * Used when the source record is state-scoped: every subscriber in that
- * state should be notified, regardless of their specific city.
+ * state should be notified, regardless of their specific city. Paginated.
  */
 async function getSubscriptionsByState(state: string): Promise<Subscription[]> {
-  const command = new QueryCommand({
+  return querySubscriptionsAllPages({
     TableName: SUBSCRIPTIONS_TABLE_NAME,
     IndexName: 'userSubscriptionsByState',
     KeyConditionExpression: '#state = :state',
@@ -200,17 +264,16 @@ async function getSubscriptionsByState(state: string): Promise<Subscription[]> {
       ':state': { S: state },
     },
   })
-
-  const result = await dynamoClient.send(command)
-  return (result.Items || []).map((item) => unmarshall(item) as Subscription)
 }
 
 /**
  * Query subscriptions by country via the country GSI (#123 cascade fan-out).
- * Used when the source record is country-scoped.
+ * Used when the source record is country-scoped. Paginated — a country
+ * with thousands of subscribers needs every page or the cascade reaches
+ * only the first 1MB of subscribers.
  */
 async function getSubscriptionsByCountry(country: string): Promise<Subscription[]> {
-  const command = new QueryCommand({
+  return querySubscriptionsAllPages({
     TableName: SUBSCRIPTIONS_TABLE_NAME,
     IndexName: 'userSubscriptionsByCountry',
     KeyConditionExpression: 'country = :country',
@@ -218,9 +281,6 @@ async function getSubscriptionsByCountry(country: string): Promise<Subscription[
       ':country': { S: country },
     },
   })
-
-  const result = await dynamoClient.send(command)
-  return (result.Items || []).map((item) => unmarshall(item) as Subscription)
 }
 
 /**
@@ -250,6 +310,11 @@ async function getSubscriptionsForScope(
 /**
  * Derive cascade scope from which location fields are populated. Used as
  * the fallback when an upstream caller didn't supply `scope` explicitly.
+ *
+ * Throws when no location field is set — silently defaulting masks
+ * upstream bugs (e.g. a future caller forgetting to thread `scope`
+ * through). Callers must guard the empty-anchor case before reaching
+ * this helper; the handler does so at the entry point.
  */
 function deriveScope(
   city: string | null,
@@ -259,9 +324,7 @@ function deriveScope(
   if (city) return 'city'
   if (state) return 'state'
   if (country) return 'country'
-  // Default — preserves legacy single-city behaviour for callers that pass
-  // city only.
-  return 'city'
+  throw new Error('deriveScope: no location anchor (city/state/country all empty)')
 }
 
 /**
@@ -612,23 +675,22 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
     const emailResult = await sendEmailNotification(emails, event)
     emailsSent = emailResult.sentCount
 
-    // Log email notifications in parallel. For state/country fan-out (#123),
-    // record the subscriber's own city so existing per-city audit queries on
-    // NotificationLog still group correctly.
-    await Promise.all(
-      emailRecipients.map(({ subscription }) =>
-        logNotification(
-          subscription.id,
-          subscription.owner,
-          subscription.city || city || '',
-          subscription.state || state || '',
-          subscription.country || country || '',
-          'email',
-          emailResult.success ? 'sent' : 'failed',
-          title,
-          body,
-          triggerType,
-        ),
+    // Log email notifications with bounded concurrency (#123 fan-out can
+    // hit thousands of subscribers — unbounded Promise.all would throttle
+    // DynamoDB and risk OOM). Subscriber city/state/country wins so
+    // existing per-city audit queries still group correctly.
+    await runWithConcurrency(emailRecipients, LOG_WRITE_CONCURRENCY, ({ subscription }) =>
+      logNotification(
+        subscription.id,
+        subscription.owner,
+        subscription.city || city || '',
+        subscription.state || state || '',
+        subscription.country || country || '',
+        'email',
+        emailResult.success ? 'sent' : 'failed',
+        title,
+        body,
+        triggerType,
       ),
     )
   }
@@ -662,26 +724,25 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
       allSuccess = allSuccess && r.success
     }
 
-    // Log push notifications in parallel. Subscriber city/state/country
-    // wins so log queries by city continue to work for fan-out (#123).
-    await Promise.all(
-      pushRecipients.map(({ subscription }) => {
-        const failed = allInvalidTokens.has(subscription.expoPushToken!)
-        return logNotification(
-          subscription.id,
-          subscription.owner,
-          subscription.city || city || '',
-          subscription.state || state || '',
-          subscription.country || country || '',
-          'push',
-          failed ? 'failed' : 'sent',
-          title,
-          body,
-          triggerType,
-          failed ? 'Invalid or expired token' : undefined,
-        )
-      }),
-    )
+    // Log push notifications with bounded concurrency (#123 fan-out can
+    // hit thousands of subscribers). Subscriber city/state/country wins
+    // so log queries by city continue to work for fan-out.
+    await runWithConcurrency(pushRecipients, LOG_WRITE_CONCURRENCY, ({ subscription }) => {
+      const failed = allInvalidTokens.has(subscription.expoPushToken!)
+      return logNotification(
+        subscription.id,
+        subscription.owner,
+        subscription.city || city || '',
+        subscription.state || state || '',
+        subscription.country || country || '',
+        'push',
+        failed ? 'failed' : 'sent',
+        title,
+        body,
+        triggerType,
+        failed ? 'Invalid or expired token' : undefined,
+      )
+    })
 
     // TODO: Clean up invalid tokens from subscriptions
     if (allInvalidTokens.size > 0) {

--- a/packages/backend/amplify/functions/process-notifications/handler.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.ts
@@ -216,8 +216,11 @@ async function runWithConcurrency<T>(
  * Required for state/country fan-out (#123): a single Query response is
  * capped at 1MB, so a country with thousands of subscribers would
  * silently miss the rest of the fan-out without pagination.
+ *
+ * Exported for unit testing — production callers go through the
+ * subscription helpers below.
  */
-async function querySubscriptionsAllPages(
+export async function querySubscriptionsAllPages(
   baseInput: Omit<ConstructorParameters<typeof QueryCommand>[0], 'ExclusiveStartKey'>,
 ): Promise<Subscription[]> {
   const out: Subscription[] = []

--- a/packages/backend/amplify/functions/process-notifications/handler.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.ts
@@ -42,7 +42,7 @@ type NotificationStatus = 'danger' | 'warning' | 'safe'
  * state-scope notifies every subscriber in that state; country-scope
  * notifies every subscriber in that country.
  */
-type LocationScope = 'city' | 'state' | 'country'
+export type LocationScope = 'city' | 'state' | 'country'
 
 interface ProcessNotificationsEvent {
   /** City name (null when the source record was state- or country-scoped). */
@@ -82,7 +82,7 @@ interface ProcessNotificationsResult {
   errors: string[]
 }
 
-interface Subscription {
+export interface Subscription {
   id: string
   owner: string // Cognito user ID
   city: string
@@ -96,6 +96,76 @@ interface Subscription {
   watchContaminants?: string[]
   notifyWhenDataAvailable: boolean
   expoPushToken?: string
+}
+
+export interface PushDeliveryGroup {
+  tokens: string[]
+  data: Record<string, unknown>
+  subscriptions: Subscription[]
+}
+
+/**
+ * Group push recipients by their deep-link target so we can issue one
+ * batched send per unique target rather than one Lambda invocation per
+ * recipient. State/country fan-out (#123) can reach thousands of
+ * subscribers — sequential per-subscriber sends would exceed Lambda's
+ * 15-minute timeout long before completion.
+ *
+ * - city-scope: every recipient shares the originating city's deep-link,
+ *   so all tokens collapse into a single group.
+ * - state-/country-scope: each subscriber's deep-link points at their
+ *   own city. Group by `(subscriber city, state, country)` so every
+ *   batch carries one consistent payload. In practice this collapses to
+ *   a small number of groups (≤ number of distinct subscriber cities).
+ *
+ * Pure: exported for unit testing; no side effects.
+ */
+export function groupPushRecipients(
+  recipients: { token: string; subscription: Subscription }[],
+  scope: LocationScope,
+  origin: {
+    city: string | null
+    state: string | null | undefined
+    country: string | null | undefined
+  },
+  contaminantId: string | undefined,
+): PushDeliveryGroup[] {
+  if (recipients.length === 0) return []
+
+  if (scope === 'city') {
+    return [
+      {
+        tokens: recipients.map((r) => r.token),
+        data: {
+          screen: 'Dashboard',
+          city: origin.city ?? '',
+          state: origin.state ?? '',
+          country: origin.country ?? '',
+          contaminantId,
+        },
+        subscriptions: recipients.map((r) => r.subscription),
+      },
+    ]
+  }
+
+  const byKey = new Map<string, { token: string; subscription: Subscription }[]>()
+  for (const r of recipients) {
+    const key = `${r.subscription.city}|${r.subscription.state ?? ''}|${r.subscription.country ?? ''}`
+    const arr = byKey.get(key) ?? []
+    arr.push(r)
+    byKey.set(key, arr)
+  }
+  return Array.from(byKey.values()).map((group) => ({
+    tokens: group.map((r) => r.token),
+    data: {
+      screen: 'Dashboard',
+      city: group[0].subscription.city,
+      state: group[0].subscription.state ?? '',
+      country: group[0].subscription.country ?? '',
+      contaminantId,
+    },
+    subscriptions: group.map((r) => r.subscription),
+  }))
 }
 
 /**
@@ -507,32 +577,27 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
   // Build notification content
   const { title, body } = buildNotificationContent(event)
 
-  // Collect recipients based on preferences
-  const emailRecipients: { email: string; subscription: Subscription }[] = []
-  const pushRecipients: { token: string; subscription: Subscription }[] = []
+  // Filter by preferences first, then resolve emails in parallel.
+  // State/country fan-out (#123) can hit thousands of subscribers — a
+  // sequential `getUserEmail` loop hits Cognito serially and dominates
+  // wall time before any notification goes out.
+  const eligible = subscriptions.filter((s) => shouldNotify(s, event))
+  const emailEligible = eligible.filter((s) => s.enableEmail)
+  const pushRecipients = eligible
+    .filter((s) => s.enablePush && !!s.expoPushToken)
+    .map((s) => ({ token: s.expoPushToken!, subscription: s }))
 
-  for (const subscription of subscriptions) {
-    // Check if this subscriber should be notified
-    if (!shouldNotify(subscription, event)) {
-      console.log(`Skipping ${subscription.id} - preferences don't match`)
-      continue
-    }
-
-    // Collect email recipients
-    if (subscription.enableEmail) {
-      const email = await getUserEmail(subscription.owner)
-      if (email) {
-        emailRecipients.push({ email, subscription })
-      } else {
-        console.warn(`No email found for user ${subscription.owner}`)
-      }
-    }
-
-    // Collect push recipients
-    if (subscription.enablePush && subscription.expoPushToken) {
-      pushRecipients.push({ token: subscription.expoPushToken, subscription })
-    }
-  }
+  const emailLookups = await Promise.all(
+    emailEligible.map(async (subscription) => ({
+      subscription,
+      email: await getUserEmail(subscription.owner),
+    })),
+  )
+  const emailRecipients = emailLookups.flatMap(({ subscription, email }) => {
+    if (email) return [{ email, subscription }]
+    console.warn(`No email found for user ${subscription.owner}`)
+    return []
+  })
 
   const subscribersNotified = new Set([
     ...emailRecipients.map((r) => r.subscription.id),
@@ -547,94 +612,83 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
     const emailResult = await sendEmailNotification(emails, event)
     emailsSent = emailResult.sentCount
 
-    // Log email notifications. For state/country fan-out (#123), record the
-    // subscriber's own city so existing per-city audit queries on
+    // Log email notifications in parallel. For state/country fan-out (#123),
+    // record the subscriber's own city so existing per-city audit queries on
     // NotificationLog still group correctly.
-    for (const { subscription } of emailRecipients) {
-      await logNotification(
-        subscription.id,
-        subscription.owner,
-        subscription.city || city || '',
-        subscription.state || state || '',
-        subscription.country || country || '',
-        'email',
-        emailResult.success ? 'sent' : 'failed',
-        title,
-        body,
-        triggerType,
-      )
-    }
+    await Promise.all(
+      emailRecipients.map(({ subscription }) =>
+        logNotification(
+          subscription.id,
+          subscription.owner,
+          subscription.city || city || '',
+          subscription.state || state || '',
+          subscription.country || country || '',
+          'email',
+          emailResult.success ? 'sent' : 'failed',
+          title,
+          body,
+          triggerType,
+        ),
+      ),
+    )
   }
 
-  // Send push notifications. Each push gets a deep-link tailored to that
-  // subscriber's own location so tapping it opens the user's dashboard.
-  // Mobile cascade then resolves the data the user should actually see.
+  // Send push notifications. For city scope every recipient shares the same
+  // deep-link target, so all tokens go in one batched Lambda call. For
+  // state/country fan-out (#123) we group by subscriber's own city so each
+  // group still carries a single consistent deep-link — this collapses
+  // potentially-thousands of sequential Lambda invocations down to a small
+  // number of parallel batches (one per distinct subscriber city).
   if (pushRecipients.length > 0) {
     console.log(`Sending push to ${pushRecipients.length} devices`)
 
-    // For city scope, every recipient shares the same deep-link target
-    // (the originating city). For state/country (#123), each recipient
-    // gets their own city in the link so tapping the notification opens
-    // their personal dashboard, where the cascade resolves what to show.
-    const sharedDeepLinkData = {
-      screen: 'Dashboard',
-      city: city ?? '',
-      state: state ?? '',
-      country: country ?? '',
-      contaminantId: event.contaminantId,
-    }
-    const deepLinkForSubscriber = (sub: Subscription) =>
-      scope === 'city'
-        ? sharedDeepLinkData
-        : {
-            screen: 'Dashboard',
-            city: sub.city,
-            state: sub.state ?? '',
-            country: sub.country ?? '',
-            contaminantId: event.contaminantId,
-          }
+    const groups = groupPushRecipients(
+      pushRecipients,
+      scope,
+      { city, state, country },
+      event.contaminantId,
+    )
+    console.log(`Push fan-out: ${groups.length} batched group(s)`)
 
-    // Send one push per subscriber so each gets a personalised deep-link.
-    const pushResult: { success: boolean; sentCount: number; invalidTokens: string[] } = {
-      success: true,
-      sentCount: 0,
-      invalidTokens: [],
-    }
-    for (const { token, subscription } of pushRecipients) {
-      const single = await sendPushNotifications(
-        [token],
-        title,
-        body,
-        deepLinkForSubscriber(subscription),
-      )
-      pushResult.success = pushResult.success && single.success
-      pushResult.sentCount += single.sentCount
-      pushResult.invalidTokens.push(...single.invalidTokens)
-    }
-    pushSent = pushResult.sentCount
+    const groupResults = await Promise.all(
+      groups.map((g) => sendPushNotifications(g.tokens, title, body, g.data)),
+    )
 
-    // Log push notifications. Subscriber city/state/country wins so log
-    // queries by city continue to work for fan-out notifications (#123).
-    for (const { subscription } of pushRecipients) {
-      const failed = pushResult.invalidTokens.includes(subscription.expoPushToken!)
-      await logNotification(
-        subscription.id,
-        subscription.owner,
-        subscription.city || city || '',
-        subscription.state || state || '',
-        subscription.country || country || '',
-        'push',
-        failed ? 'failed' : 'sent',
-        title,
-        body,
-        triggerType,
-        failed ? 'Invalid or expired token' : undefined,
-      )
+    const allInvalidTokens = new Set<string>()
+    let allSuccess = true
+    for (const r of groupResults) {
+      pushSent += r.sentCount
+      r.invalidTokens.forEach((t) => allInvalidTokens.add(t))
+      allSuccess = allSuccess && r.success
     }
+
+    // Log push notifications in parallel. Subscriber city/state/country
+    // wins so log queries by city continue to work for fan-out (#123).
+    await Promise.all(
+      pushRecipients.map(({ subscription }) => {
+        const failed = allInvalidTokens.has(subscription.expoPushToken!)
+        return logNotification(
+          subscription.id,
+          subscription.owner,
+          subscription.city || city || '',
+          subscription.state || state || '',
+          subscription.country || country || '',
+          'push',
+          failed ? 'failed' : 'sent',
+          title,
+          body,
+          triggerType,
+          failed ? 'Invalid or expired token' : undefined,
+        )
+      }),
+    )
 
     // TODO: Clean up invalid tokens from subscriptions
-    if (pushResult.invalidTokens.length > 0) {
-      console.warn(`${pushResult.invalidTokens.length} invalid push tokens need cleanup`)
+    if (allInvalidTokens.size > 0) {
+      console.warn(`${allInvalidTokens.size} invalid push tokens need cleanup`)
+    }
+    if (!allSuccess) {
+      errors.push('At least one push batch reported a partial failure')
     }
   }
 

--- a/packages/backend/amplify/functions/process-notifications/handler.ts
+++ b/packages/backend/amplify/functions/process-notifications/handler.ts
@@ -36,13 +36,26 @@ const USER_POOL_ID = process.env.USER_POOL_ID!
 type TriggerType = 'data_update' | 'data_available' | 'status_change' | 'manual_alert'
 type NotificationStatus = 'danger' | 'warning' | 'safe'
 
+/**
+ * Which level of the location hierarchy this notification originated from
+ * (#123). Drives subscriber fan-out: city-scope notifies that city only;
+ * state-scope notifies every subscriber in that state; country-scope
+ * notifies every subscriber in that country.
+ */
+type LocationScope = 'city' | 'state' | 'country'
+
 interface ProcessNotificationsEvent {
-  /** City name */
-  city: string
-  /** State/province code */
-  state?: string
-  /** Country code */
-  country?: string
+  /** City name (null when the source record was state- or country-scoped). */
+  city: string | null
+  /** State/province code (null when the record was country-scoped). */
+  state?: string | null
+  /** Country code — required as the lowest cascade anchor. */
+  country?: string | null
+  /**
+   * Which scope to fan out to. Optional for backward compatibility — if
+   * omitted, derived from which location fields are populated.
+   */
+  scope?: LocationScope
   /** What triggered this notification */
   triggerType: TriggerType
   /** Whether this was manually triggered by admin */
@@ -100,6 +113,85 @@ async function getSubscriptionsByCity(city: string): Promise<Subscription[]> {
 
   const result = await dynamoClient.send(command)
   return (result.Items || []).map((item) => unmarshall(item) as Subscription)
+}
+
+/**
+ * Query subscriptions by state via the state GSI (#123 cascade fan-out).
+ * Used when the source record is state-scoped: every subscriber in that
+ * state should be notified, regardless of their specific city.
+ */
+async function getSubscriptionsByState(state: string): Promise<Subscription[]> {
+  const command = new QueryCommand({
+    TableName: SUBSCRIPTIONS_TABLE_NAME,
+    IndexName: 'userSubscriptionsByState',
+    KeyConditionExpression: '#state = :state',
+    ExpressionAttributeNames: { '#state': 'state' },
+    ExpressionAttributeValues: {
+      ':state': { S: state },
+    },
+  })
+
+  const result = await dynamoClient.send(command)
+  return (result.Items || []).map((item) => unmarshall(item) as Subscription)
+}
+
+/**
+ * Query subscriptions by country via the country GSI (#123 cascade fan-out).
+ * Used when the source record is country-scoped.
+ */
+async function getSubscriptionsByCountry(country: string): Promise<Subscription[]> {
+  const command = new QueryCommand({
+    TableName: SUBSCRIPTIONS_TABLE_NAME,
+    IndexName: 'userSubscriptionsByCountry',
+    KeyConditionExpression: 'country = :country',
+    ExpressionAttributeValues: {
+      ':country': { S: country },
+    },
+  })
+
+  const result = await dynamoClient.send(command)
+  return (result.Items || []).map((item) => unmarshall(item) as Subscription)
+}
+
+/**
+ * Fan out to every subscriber whose location matches the source record's
+ * cascade scope. Deduplicates so a subscriber whose city, state, AND
+ * country all matched a hypothetical record only gets one notification.
+ */
+async function getSubscriptionsForScope(
+  scope: LocationScope,
+  city: string | null,
+  state: string | null | undefined,
+  country: string | null | undefined,
+): Promise<Subscription[]> {
+  switch (scope) {
+    case 'city':
+      if (!city) return []
+      return getSubscriptionsByCity(city)
+    case 'state':
+      if (!state) return []
+      return getSubscriptionsByState(state)
+    case 'country':
+      if (!country) return []
+      return getSubscriptionsByCountry(country)
+  }
+}
+
+/**
+ * Derive cascade scope from which location fields are populated. Used as
+ * the fallback when an upstream caller didn't supply `scope` explicitly.
+ */
+function deriveScope(
+  city: string | null,
+  state: string | null | undefined,
+  country: string | null | undefined,
+): LocationScope {
+  if (city) return 'city'
+  if (state) return 'state'
+  if (country) return 'country'
+  // Default — preserves legacy single-city behaviour for callers that pass
+  // city only.
+  return 'city'
 }
 
 /**
@@ -298,7 +390,9 @@ async function sendEmailNotification(
   const payload = {
     statId: event.contaminantId || 'water-quality',
     statName: event.contaminantName || 'Water Quality',
-    city: event.city,
+    // city may be null on state-/country-scoped events (#123); send empty
+    // string so downstream email Lambda doesn't break on null.
+    city: event.city ?? '',
     state: event.state || '',
     country: event.country || '',
     oldStatus: event.oldStatus || 'safe',
@@ -373,26 +467,32 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
   event
 ) => {
   const { city, state, country, triggerType } = event
+  const scope = event.scope ?? deriveScope(city, state, country)
   const errors: string[] = []
   let emailsSent = 0
   let pushSent = 0
 
-  if (!city) {
-    console.error('No city provided in event')
+  // At least one location anchor must be present for fan-out to make sense.
+  if (!city && !state && !country) {
+    console.error('Event has no location anchor (city/state/country all empty)')
     return {
       success: false,
       subscribersNotified: 0,
       emailsSent: 0,
       pushSent: 0,
-      errors: ['No city provided'],
+      errors: ['No location anchor provided'],
     }
   }
 
-  console.log(`Processing notifications for ${city}, ${state || ''}, ${country || ''} (trigger: ${triggerType})`)
+  console.log(
+    `Processing notifications (${scope}-scope) for ${city ?? '-'}, ${state ?? '-'}, ${country ?? '-'} (trigger: ${triggerType})`,
+  )
 
-  // Get all subscribers for this city
-  const subscriptions = await getSubscriptionsByCity(city)
-  console.log(`Found ${subscriptions.length} subscribers`)
+  // Fan out to every subscriber matching the cascade scope (#123). A
+  // state-scoped record reaches every subscriber in that state; a
+  // country-scoped record reaches every subscriber in that country.
+  const subscriptions = await getSubscriptionsForScope(scope, city, state, country)
+  console.log(`Found ${subscriptions.length} ${scope}-scope subscribers`)
 
   if (subscriptions.length === 0) {
     return {
@@ -406,13 +506,6 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
 
   // Build notification content
   const { title, body } = buildNotificationContent(event)
-  const deepLinkData = {
-    screen: 'Dashboard',
-    city,
-    state: state || '',
-    country: country || '',
-    contaminantId: event.contaminantId,
-  }
 
   // Collect recipients based on preferences
   const emailRecipients: { email: string; subscription: Subscription }[] = []
@@ -454,46 +547,88 @@ export const handler: Handler<ProcessNotificationsEvent, ProcessNotificationsRes
     const emailResult = await sendEmailNotification(emails, event)
     emailsSent = emailResult.sentCount
 
-    // Log email notifications
-    for (const { email, subscription } of emailRecipients) {
+    // Log email notifications. For state/country fan-out (#123), record the
+    // subscriber's own city so existing per-city audit queries on
+    // NotificationLog still group correctly.
+    for (const { subscription } of emailRecipients) {
       await logNotification(
         subscription.id,
         subscription.owner,
-        city,
-        state || '',
-        country || '',
+        subscription.city || city || '',
+        subscription.state || state || '',
+        subscription.country || country || '',
         'email',
         emailResult.success ? 'sent' : 'failed',
         title,
         body,
-        triggerType
+        triggerType,
       )
     }
   }
 
-  // Send push notifications
+  // Send push notifications. Each push gets a deep-link tailored to that
+  // subscriber's own location so tapping it opens the user's dashboard.
+  // Mobile cascade then resolves the data the user should actually see.
   if (pushRecipients.length > 0) {
-    const tokens = pushRecipients.map((r) => r.token)
-    console.log(`Sending push to ${tokens.length} devices`)
+    console.log(`Sending push to ${pushRecipients.length} devices`)
 
-    const pushResult = await sendPushNotifications(tokens, title, body, deepLinkData)
+    // For city scope, every recipient shares the same deep-link target
+    // (the originating city). For state/country (#123), each recipient
+    // gets their own city in the link so tapping the notification opens
+    // their personal dashboard, where the cascade resolves what to show.
+    const sharedDeepLinkData = {
+      screen: 'Dashboard',
+      city: city ?? '',
+      state: state ?? '',
+      country: country ?? '',
+      contaminantId: event.contaminantId,
+    }
+    const deepLinkForSubscriber = (sub: Subscription) =>
+      scope === 'city'
+        ? sharedDeepLinkData
+        : {
+            screen: 'Dashboard',
+            city: sub.city,
+            state: sub.state ?? '',
+            country: sub.country ?? '',
+            contaminantId: event.contaminantId,
+          }
+
+    // Send one push per subscriber so each gets a personalised deep-link.
+    const pushResult: { success: boolean; sentCount: number; invalidTokens: string[] } = {
+      success: true,
+      sentCount: 0,
+      invalidTokens: [],
+    }
+    for (const { token, subscription } of pushRecipients) {
+      const single = await sendPushNotifications(
+        [token],
+        title,
+        body,
+        deepLinkForSubscriber(subscription),
+      )
+      pushResult.success = pushResult.success && single.success
+      pushResult.sentCount += single.sentCount
+      pushResult.invalidTokens.push(...single.invalidTokens)
+    }
     pushSent = pushResult.sentCount
 
-    // Log push notifications
+    // Log push notifications. Subscriber city/state/country wins so log
+    // queries by city continue to work for fan-out notifications (#123).
     for (const { subscription } of pushRecipients) {
       const failed = pushResult.invalidTokens.includes(subscription.expoPushToken!)
       await logNotification(
         subscription.id,
         subscription.owner,
-        city,
-        state || '',
-        country || '',
+        subscription.city || city || '',
+        subscription.state || state || '',
+        subscription.country || country || '',
         'push',
         failed ? 'failed' : 'sent',
         title,
         body,
         triggerType,
-        failed ? 'Invalid or expired token' : undefined
+        failed ? 'Invalid or expired token' : undefined,
       )
     }
 

--- a/packages/backend/amplify/functions/process-notifications/jest.config.js
+++ b/packages/backend/amplify/functions/process-notifications/jest.config.js
@@ -1,0 +1,32 @@
+/**
+ * Jest config for the process-notifications Lambda.
+ *
+ * Mirrors the per-function pattern established by
+ * subscribe-to-newsletter, confirm-newsletter, and
+ * on-location-measurement-update. Run from this directory with:
+ *
+ *   npx jest --config jest.config.js
+ *
+ * Or from the backend root:
+ *
+ *   npx jest --config amplify/functions/process-notifications/jest.config.js
+ */
+/** @type {import('jest').Config} */
+export default {
+  testEnvironment: "node",
+  rootDir: ".",
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: false,
+        tsconfig: {
+          module: "commonjs",
+          moduleResolution: "node",
+          esModuleInterop: true,
+          verbatimModuleSyntax: false,
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
Implements **Location hierarchy: country/state-level measurements cascade to cities** (#123) end-to-end. The discoverability fix for #216 already shipped via #277 — this PR delivers the actual platform capability that was the user's underlying ask.

**Why a separate PR**: PR #277 was merged with only the small original commit (`02010fc`); the cascade-feature commit pushed to that branch afterward (`ab21e8e`) was stranded. Cherry-picked onto a fresh branch off the current `staging` so the PR diff is exactly the cascade work.

## What this delivers

When a city has no data of its own, the mobile app inherits from the state. When the state has no data, it inherits from the country. The cascade is full-stack: the backend lets records be anchored at any hierarchy level, the mobile app surfaces inherited data with a provenance badge, the admin can create state- or country-scoped records, and notification fan-out reaches every subscriber matching the source record's scope.

## How it works

```
                 +--------------------+   create at any level
   Admin ──────► |  LocationMeasure-  |   (city / state / country)
                 |  ment              |
                 +---------┬----------+
                           │ DynamoDB Stream
                           ▼
                 +--------------------+   derives scope, fans out by:
                 |  on-location-      |   • city → that city's subs
                 |  measurement-      |   • state → all subs in state
                 |  update            |   • country → all subs in country
                 +---------┬----------+
                           │ scope+payload
                           ▼
                 +--------------------+
                 |  process-          |
                 |  notifications     |
                 +--------------------+

   Mobile dashboard / observations / pollution sources screens
                           │
                           ▼
              fetchWithLocationFallback({ city, state, country }, {
                byCity, byState, byCountry,
              })  →  { data, scope }
                           │
                           ▼
              LocationScopeBadge renders provenance for state/country
```

## Backend (`packages/backend/amplify/data/resource.ts`)

- `LocationMeasurement.city` / `.state` → optional. `country` stays required.
- Same for `PollutionSource` and `LocationObservation`.
- Added `country` GSIs on `LocationMeasurement`, `PollutionSource`, and `UserSubscription` so the cascade fetches and notification fan-out can be served by indexes.

## Mobile

**Shared cascading util** (`apps/mobile/app/lib/locationFallback.ts`):
- `fetchWithLocationFallback<T>` walks city → state → country, returning the first non-empty payload along with a `scope` label (`city`/`state`/`country`/`none`).
- `describeScope` returns a human-readable label for the badge.

**Hooks migrated onto the util:**
- `useLocationData` — measurements (the dashboard's primary data).
- `usePollutionSources` — already had a city→state fallback; converged onto the shared util and gained country fallback + scope flag.
- `useLocationObservations` — same. Kept the pre-existing `isStateLevelFallback` field as `@deprecated` so it can be removed in a follow-up. Dedup logic now triggers for both state- and country-scope fan-out.

**New service helpers**: `getLocationMeasurementsByCountry`, `getPollutionSourcesByCountry`, plus matching `queryKeys` factories.

**Provenance UI**: `LocationScopeBadge` renders `Showing QC data` / `Showing CA data` whenever the cascade resolved at a non-city scope. Wired into `DashboardScreen`, `CategoryDetailScreen`, `PollutionSourcesScreen`, and `LocationObservationsScreen`. The dashboard now renders the inherited data instead of the no-data empty state when the cascade resolves.

## Admin

State- and country-scoped records can now be created from every relevant entry point:
- **Import page**: validation requires only `country`. Blank city → state-scoped row. Blank city + state → country-scoped row. CSV templates and field hints updated. City without state still rejected as ambiguous.
- **Observations page**: form validation, edit-dialog hydration, and state filter all tolerate null city/state.
- **Pollution Sources form** (`PollutionSourceMap.tsx`): Zod schema relaxes city/state to optional with a refinement that still rejects city-without-state.
- **City-detail measurement create** (`zip-codes/[zipCode]/page.tsx`): inherits state/country from existing measurements (since the legacy code was passing empty strings for both, which the new required-country schema would reject). Surfaces a clear error if neither can be inferred.

## Notifications

- `on-location-measurement-update` derives the record's cascade scope from which location fields are populated and forwards it (with possibly-null city/state) to `process-notifications`.
- `process-notifications` adds `getSubscriptionsByState` and `getSubscriptionsByCountry`. The handler fans out to whichever subscriber set matches the scope.
- Push deep-links are personalised per subscriber for state/country fan-out, so each tap opens the user's own dashboard — where the cascade resolves what to show. Notification logs record the subscriber's own city/state/country so existing per-city audit queries continue to work.

## Tests

**Mobile jest — 215/215 tests pass, 18/18 suites pass** (run `cd apps/mobile && npx jest`).

| Surface | File | New cases |
|---|---|---|
| Cascade util | `apps/mobile/app/lib/locationFallback.test.ts` | 7 — every scope, empty inputs, omitted fetchers, error propagation, short-circuit |
| `useLocationData` | `apps/mobile/app/hooks/useLocationData.test.ts` | 5 cascade — city / state / country / none + caller-omits-state-country backward compat |
| `usePollutionSources` | `apps/mobile/app/hooks/usePollutionSources.test.ts` | 4 cascade — same scope coverage as above |
| `useLocationObservations` | `apps/mobile/app/hooks/useLocationObservations.test.ts` | 6 — city/state/country/none + dedup-by-propertyId on state-fan-out + hook-disabled-when-state-empty |
| `LocationScopeBadge` | `apps/mobile/app/components/LocationScopeBadge.test.tsx` | 7 — renders for state/country, returns null for city/none, generic-label fallback, a11y label |
| Lambda scope helper | `packages/backend/amplify/functions/on-location-measurement-update/handler.test.ts` | 6 — city/state/country derivation, undefined-vs-null parity, empty-string city, "city wins" |

**Total: 35 new test cases.**

The lambda tests use a per-function `jest.config.js` (existing convention from `subscribe-to-newsletter` / `confirm-newsletter`). Run with:
```
cd packages/backend/amplify/functions/on-location-measurement-update
npx jest --config "$(pwd)/jest.config.js" --rootDir "$(pwd)"
```

**Bonus**: this PR's `test/setup.ts` mocks (`@expo-google-fonts/space-grotesk`, `aws-amplify/analytics`) also fix two pre-existing test suites (`Text.test.tsx`, `ContaminantInfoButton.test.tsx`) that had been failing for months on missing transitive dependencies. The mobile jest summary now reports a clean 215/215.

## Verification status

- [x] Mobile jest: **215/215 tests, 18/18 suites pass**
- [x] Mobile lint clean (`npx eslint app --ext .ts,.tsx`)
- [x] Mobile typecheck clean (`yarn tsc --noEmit`)
- [x] Admin lint clean — 0 errors (5 pre-existing warnings retained)
- [x] Admin typecheck clean
- [x] Backend typecheck clean
- [x] Lambda jest: 6/6 deriveScope tests pass

## Staging verification (post-deploy)

- [ ] **Backend deploys cleanly** — schema makes `city`/`state` nullable in place. Per explicit direction ("we don't need to worry about existing users"), no migration plan; existing rows keep their populated city/state.
- [ ] **Admin import**: upload a CSV with a state-only row (no city) for QC, CA. Confirm DynamoDB row has `city: null`, `state: "QC"`, `country: "CA"`.
- [ ] **Mobile cascade — state**: search a no-data Quebec city (e.g. Sorel-Tracy). Dashboard renders the inherited Quebec data with a `Showing QC data` badge instead of the no-data empty state.
- [ ] **Mobile cascade — country**: with only a country-level CA row seeded, search any Canadian city without its own data. Dashboard shows `Showing CA data` badge.
- [ ] **Pollution Sources**: tap the card from the no-data dashboard, confirm `LocationScopeBadge` and the cascaded source list render. Spot-check a city that has its own pollution sources — no badge, no behaviour change.
- [ ] **Notification fan-out**: create a state-scoped measurement via Admin (silent off). Confirm subscribers in any city of that state receive a push, and the deep-link opens their own dashboard.
- [ ] **Backward compat**: cities with their own data show no provenance badge and behave exactly as before.

## Future scope (not in this PR)

- Same cascading pattern for `WarningBanner` is already implicit in its data shape (nullable city/state on the entity); no convergence needed.
- `HazardReport` is user-private and never location-fanned-out — out of scope.
- The deprecated `isStateLevelFallback` field on `useLocationObservations` should be removed once any external consumers migrate to `scope`.
- `process-notifications` `deriveScope` helper has the same shape as the lambda's; worth lifting both into a shared backend module if more handlers grow scope awareness.

## Why one PR (not stacked)

User direction: ship the platform capability in one change. The trade-off — larger review surface for a bigger atomic deploy — was made deliberately. The change is internally consistent (no half-deployed cascade where the backend supports it but the mobile doesn't, etc.) and reverting is one revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)