### PR TITLE
fix(mobile): clip animated logo and stretch coming soon copy

### DIFF
--- a/apps/mobile/app/components/AnimatedLogo.tsx
+++ b/apps/mobile/app/components/AnimatedLogo.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react"
-import { ViewStyle } from "react-native"
+import { StyleSheet, View, ViewStyle } from "react-native"
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -30,28 +30,38 @@ export const AnimatedLogo: FC<AnimatedLogoProps> = ({ size = 120, style }) => {
   }))
 
   return (
-    <Animated.View style={[{ width: size, height: size }, style, animatedStyle]}>
-      <Svg viewBox="0 0 1024 1024" width={size} height={size} fill="none">
-        {/* Shield Outline */}
-        <Path
-          d="M512 96 C512 96 760 170 864 216 V520 C864 694 736 824 512 928 C288 824 160 694 160 520 V216 C264 170 512 96 512 96Z"
-          stroke="#059669"
-          strokeWidth={72}
-          strokeLinejoin="round"
-        />
-        {/* Map Pin */}
-        <Path
-          d="M512 240 C400 240 312 328 312 440 C312 581 512 744 512 744 C512 744 712 581 712 440 C712 328 624 240 512 240Z"
-          fill="#10B981"
-        />
-        {/* Pin inner circle */}
-        <Circle cx={512} cy={440} r={96} fill="#059669" />
-        {/* Medical Plus */}
-        <Path
-          d="M512 376 C526 376 536 386 536 400 V416 H552 C566 416 576 426 576 440 C576 454 566 464 552 464 H536 V480 C536 494 526 504 512 504 C498 504 488 494 488 480 V464 H472 C458 464 448 454 448 440 C448 426 458 416 472 416 H488 V400 C488 386 498 376 512 376Z"
-          fill="#FFFFFF"
-        />
-      </Svg>
-    </Animated.View>
+    <View style={[styles.container, { width: size, height: size }, style]}>
+      <Animated.View style={[{ width: size, height: size }, animatedStyle]}>
+        <Svg viewBox="0 0 1024 1024" width={size} height={size} fill="none">
+          {/* Shield Outline */}
+          <Path
+            d="M512 96 C512 96 760 170 864 216 V520 C864 694 736 824 512 928 C288 824 160 694 160 520 V216 C264 170 512 96 512 96Z"
+            stroke="#059669"
+            strokeWidth={72}
+            strokeLinejoin="round"
+          />
+          {/* Map Pin */}
+          <Path
+            d="M512 240 C400 240 312 328 312 440 C312 581 512 744 512 744 C512 744 712 581 712 440 C712 328 624 240 512 240Z"
+            fill="#10B981"
+          />
+          {/* Pin inner circle */}
+          <Circle cx={512} cy={440} r={96} fill="#059669" />
+          {/* Medical Plus */}
+          <Path
+            d="M512 376 C526 376 536 386 536 400 V416 H552 C566 416 576 426 576 440 C576 454 566 464 552 464 H536 V480 C536 494 526 504 512 504 C498 504 488 494 488 480 V464 H472 C458 464 448 454 448 440 C448 426 458 416 472 416 H488 V400 C488 386 498 376 512 376Z"
+            fill="#FFFFFF"
+          />
+        </Svg>
+      </Animated.View>
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+})

--- a/apps/mobile/app/screens/ComingSoonScreen.tsx
+++ b/apps/mobile/app/screens/ComingSoonScreen.tsx
@@ -43,20 +43,23 @@ const $root: ThemedStyle<ViewStyle> = ({ spacing }) => ({
 const $topSection: ThemedStyle<ViewStyle> = ({ spacing }) => ({
   flex: 1,
   justifyContent: "center",
-  alignItems: "center",
+  alignItems: "stretch",
   paddingTop: spacing.xxl,
 })
 
 const $logo: ThemedStyle<ViewStyle> = ({ spacing }) => ({
+  alignSelf: "center",
   marginBottom: spacing.lg,
 })
 
 const $heading: ThemedStyle<TextStyle> = ({ spacing }) => ({
+  alignSelf: "stretch",
   textAlign: "center",
   marginBottom: spacing.sm,
 })
 
 const $preparing: ThemedStyle<TextStyle> = ({ colors, spacing }) => ({
+  width: "100%",
   textAlign: "center",
   color: colors.textDim,
   marginBottom: spacing.md,
@@ -67,6 +70,7 @@ const $bottomSection: ThemedStyle<ViewStyle> = ({ spacing }) => ({
 })
 
 const $description: ThemedStyle<TextStyle> = ({ colors, spacing }) => ({
+  width: "100%",
   textAlign: "center",
   color: colors.textDim,
   marginBottom: spacing.xl,


### PR DESCRIPTION
## Summary
- Wrap `AnimatedLogo`'s rotating Svg in a clipping `View` so the 3D `rotateY` no longer paints outside the intended size on smaller screens
- Stretch `ComingSoonScreen`'s heading and body text blocks to full width so centered copy actually centers on narrow devices

## Test plan
- [ ] Open the Coming Soon screen on iOS (iPhone SE / 13 mini) and confirm the logo no longer overflows during rotation
- [ ] Confirm the heading and body text are visually centered on the same device
- [ ] Confirm web build still renders the screen correctly at narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)