### PR TITLE
fix(mobile): handle Cognito CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED challenge

### DIFF
--- a/apps/mobile/app/screens/LoginScreen.tsx
+++ b/apps/mobile/app/screens/LoginScreen.tsx
@@ -14,7 +14,7 @@ import {
   View,
   ViewStyle,
 } from "react-native"
-import { signIn } from "aws-amplify/auth"
+import { confirmSignIn, signIn } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
 import { Header } from "@/components/Header"
@@ -27,7 +27,18 @@ import { usePendingAction } from "@/context/PendingActionContext"
 import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { useAppTheme } from "@/theme/context"
 import type { ThemedStyle } from "@/theme/types"
-import { getLoginErrorMessage, isUnconfirmedUserError } from "@/utils/authErrors"
+import {
+  getLoginErrorMessage,
+  getNewPasswordErrorMessage,
+  isUnconfirmedUserError,
+} from "@/utils/authErrors"
+
+/**
+ * Auth flow phase. Most users only see SIGN_IN; admin-invited users land
+ * on NEW_PASSWORD_REQUIRED after their first sign-in with a Cognito
+ * temp password (Cognito user state FORCE_CHANGE_PASSWORD).
+ */
+type AuthStep = "SIGN_IN" | "NEW_PASSWORD_REQUIRED"
 
 interface LoginScreenProps extends AppStackScreenProps<"Login"> {}
 
@@ -44,6 +55,18 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
   const [emailError, setEmailError] = useState("")
   const [passwordError, setPasswordError] = useState("")
   const [generalError, setGeneralError] = useState("")
+
+  // New-password sub-form state. Only meaningful when authStep is
+  // NEW_PASSWORD_REQUIRED (after Cognito raises the
+  // CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED challenge).
+  const [authStep, setAuthStep] = useState<AuthStep>("SIGN_IN")
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [isNewPasswordHidden, setIsNewPasswordHidden] = useState(true)
+  const [isConfirmPasswordHidden, setIsConfirmPasswordHidden] = useState(true)
+  const [newPasswordError, setNewPasswordError] = useState("")
+  const [confirmPasswordError, setConfirmPasswordError] = useState("")
+  const confirmPasswordInput = useRef<TextInput>(null)
 
   const { refreshAuthState } = useAuth()
   const { pendingAction, executePendingAction } = usePendingAction()
@@ -84,6 +107,27 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
     return true
   }
 
+  // Shared post-sign-in side effects. Used after the standard signIn()
+  // returns isSignedIn=true and again after confirmSignIn resolves the
+  // FORCE_CHANGE_PASSWORD challenge with nextStep="DONE".
+  async function finishSignIn() {
+    await refreshAuthState()
+    await executePendingAction()
+    navigation.navigate("Dashboard")
+  }
+
+  // Reset the new-password sub-form back to the sign-in form. Triggered
+  // by the "Back to sign in" link and by the Header back button so the
+  // user can't escape mid-challenge into a half-completed state.
+  function resetToSignIn() {
+    setAuthStep("SIGN_IN")
+    setNewPassword("")
+    setConfirmPassword("")
+    setNewPasswordError("")
+    setConfirmPasswordError("")
+    setGeneralError("")
+  }
+
   async function handleLogin() {
     setGeneralError("")
     const isEmailValid = validateEmail(email)
@@ -98,15 +142,17 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
       const result = await signIn({ username: email, password })
 
       if (result.isSignedIn) {
-        // Refresh auth state to update the navigator
-        await refreshAuthState()
-        // Execute any pending action (e.g., follow location from guest flow)
-        await executePendingAction()
-        // Navigate back to Dashboard
-        navigation.navigate("Dashboard")
+        await finishSignIn()
       } else if (result.nextStep?.signInStep === "CONFIRM_SIGN_UP") {
         // User hasn't confirmed their email yet
         navigation.navigate("ConfirmSignup", { email })
+      } else if (result.nextStep?.signInStep === "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED") {
+        // Admin-invited user (FORCE_CHANGE_PASSWORD): switch to the
+        // new-password sub-form. Clear the password field so the temp
+        // password isn't reused or visible. Mirrors the admin portal
+        // flow at apps/admin/src/app/login/page.tsx:157-158.
+        setPassword("")
+        setAuthStep("NEW_PASSWORD_REQUIRED")
       } else {
         // Handle other sign-in steps if needed
         setGeneralError(`Additional step required: ${result.nextStep?.signInStep}`)
@@ -119,6 +165,42 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
       if (isUnconfirmedUserError(error)) {
         navigation.navigate("ConfirmSignup", { email })
       }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  function validateNewPassword(): boolean {
+    let ok = true
+    if (newPassword.length < 8) {
+      setNewPasswordError("Password must be at least 8 characters")
+      ok = false
+    } else {
+      setNewPasswordError("")
+    }
+    if (confirmPassword !== newPassword) {
+      setConfirmPasswordError("Passwords do not match")
+      ok = false
+    } else {
+      setConfirmPasswordError("")
+    }
+    return ok
+  }
+
+  async function handleNewPassword() {
+    setGeneralError("")
+    if (!validateNewPassword()) return
+
+    setIsSubmitting(true)
+    try {
+      const result = await confirmSignIn({ challengeResponse: newPassword })
+      if (result.nextStep?.signInStep === "DONE") {
+        await finishSignIn()
+      } else {
+        setGeneralError(`Additional step required: ${result.nextStep?.signInStep}`)
+      }
+    } catch (error) {
+      setGeneralError(getNewPasswordErrorMessage(error))
     } finally {
       setIsSubmitting(false)
     }
@@ -140,120 +222,248 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
     [isPasswordHidden, colors.palette.neutral800],
   )
 
+  const NewPasswordRightAccessory: ComponentType<TextFieldAccessoryProps> = useMemo(
+    () =>
+      function NewPasswordRightAccessory(props: TextFieldAccessoryProps) {
+        return (
+          <PressableIcon
+            icon={isNewPasswordHidden ? "view" : "hidden"}
+            color={colors.palette.neutral800}
+            containerStyle={props.style}
+            size={20}
+            onPress={() => setIsNewPasswordHidden(!isNewPasswordHidden)}
+          />
+        )
+      },
+    [isNewPasswordHidden, colors.palette.neutral800],
+  )
+
+  const ConfirmPasswordRightAccessory: ComponentType<TextFieldAccessoryProps> = useMemo(
+    () =>
+      function ConfirmPasswordRightAccessory(props: TextFieldAccessoryProps) {
+        return (
+          <PressableIcon
+            icon={isConfirmPasswordHidden ? "view" : "hidden"}
+            color={colors.palette.neutral800}
+            containerStyle={props.style}
+            size={20}
+            onPress={() => setIsConfirmPasswordHidden(!isConfirmPasswordHidden)}
+          />
+        )
+      },
+    [isConfirmPasswordHidden, colors.palette.neutral800],
+  )
+
   return (
     <Screen
       preset="auto"
       contentContainerStyle={themed($screenContentContainer)}
       safeAreaEdges={["top", "bottom"]}
     >
-      <Header title="" leftIcon="back" onLeftPress={() => navigation.goBack()} safeAreaEdges={[]} />
+      <Header
+        title=""
+        leftIcon="back"
+        onLeftPress={() => {
+          // While on the new-password sub-form, the back button must
+          // reset the local state instead of navigating away — otherwise
+          // the user is left in a half-completed FORCE_CHANGE_PASSWORD
+          // session with no way to recover other than killing the app.
+          if (authStep === "NEW_PASSWORD_REQUIRED") {
+            resetToSignIn()
+          } else {
+            navigation.goBack()
+          }
+        }}
+        safeAreaEdges={[]}
+      />
 
       {/* Welcome Icon */}
       <View style={themed($iconContainer)}>
         <Icon icon="lock" size={32} color={colors.tint} />
       </View>
 
-      <Text text="Welcome Back" preset="heading" style={themed($heading)} />
-      {pendingAction && (
-        <Text
-          text="Sign in to complete your action"
-          preset="formHelper"
-          style={themed($pendingActionHint)}
-        />
+      {authStep === "NEW_PASSWORD_REQUIRED" ? (
+        <>
+          <Text text="Set a new password" preset="heading" style={themed($heading)} />
+          <Text
+            text="Your account requires a password change to continue. Choose a password you'll use from now on."
+            style={themed($subheading)}
+            size="sm"
+          />
+
+          {generalError ? (
+            <View style={themed($errorContainer)}>
+              <Text text={generalError} style={themed($errorText)} size="sm" />
+            </View>
+          ) : null}
+
+          <TextField
+            value={newPassword}
+            onChangeText={(text) => {
+              setNewPassword(text)
+              if (newPasswordError) setNewPasswordError("")
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="new-password"
+            autoCorrect={false}
+            secureTextEntry={isNewPasswordHidden}
+            label="New password"
+            placeholder="At least 8 characters"
+            helper={newPasswordError}
+            status={newPasswordError ? "error" : undefined}
+            onSubmitEditing={() => confirmPasswordInput.current?.focus()}
+            RightAccessory={NewPasswordRightAccessory}
+            testID="new-password-input"
+          />
+
+          <TextField
+            ref={confirmPasswordInput}
+            value={confirmPassword}
+            onChangeText={(text) => {
+              setConfirmPassword(text)
+              if (confirmPasswordError) setConfirmPasswordError("")
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="new-password"
+            autoCorrect={false}
+            secureTextEntry={isConfirmPasswordHidden}
+            label="Confirm new password"
+            placeholder="Re-enter the new password"
+            helper={confirmPasswordError}
+            status={confirmPasswordError ? "error" : undefined}
+            onSubmitEditing={handleNewPassword}
+            RightAccessory={ConfirmPasswordRightAccessory}
+            testID="confirm-new-password-input"
+          />
+
+          <Button
+            text={isSubmitting ? "Setting password..." : "Set password and continue"}
+            style={themed($loginButton)}
+            preset="reversed"
+            onPress={handleNewPassword}
+            disabled={isSubmitting}
+            testID="new-password-submit-button"
+          />
+
+          <Pressable onPress={resetToSignIn} style={themed($forgotPasswordLink)}>
+            <Text
+              text="Back to sign in"
+              style={themed($forgotPasswordText)}
+              size="xs"
+              testID="new-password-back-to-sign-in"
+            />
+          </Pressable>
+        </>
+      ) : (
+        <>
+          <Text text="Welcome Back" preset="heading" style={themed($heading)} />
+          {pendingAction && (
+            <Text
+              text="Sign in to complete your action"
+              preset="formHelper"
+              style={themed($pendingActionHint)}
+            />
+          )}
+          <Text
+            text="Sign in to access your safety alerts and subscriptions"
+            style={themed($subheading)}
+            size="sm"
+          />
+
+          {generalError ? (
+            <View style={themed($errorContainer)}>
+              <Text text={generalError} style={themed($errorText)} size="sm" />
+            </View>
+          ) : null}
+
+          <TextField
+            value={email}
+            onChangeText={(text) => {
+              setEmail(text)
+              if (emailError) validateEmail(text)
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            label="Email"
+            placeholder="Enter your email"
+            helper={emailError}
+            status={emailError ? "error" : undefined}
+            onSubmitEditing={() => passwordInput.current?.focus()}
+            testID="login-email-input"
+          />
+
+          <TextField
+            ref={passwordInput}
+            value={password}
+            onChangeText={(text) => {
+              setPassword(text)
+              if (passwordError) validatePassword(text)
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="password"
+            autoCorrect={false}
+            secureTextEntry={isPasswordHidden}
+            label="Password"
+            placeholder="Enter your password"
+            helper={passwordError}
+            status={passwordError ? "error" : undefined}
+            onSubmitEditing={handleLogin}
+            RightAccessory={PasswordRightAccessory}
+            testID="login-password-input"
+          />
+
+          {/* Forgot Password Link */}
+          <Pressable
+            onPress={() => navigation.navigate("ForgotPassword")}
+            style={themed($forgotPasswordLink)}
+          >
+            <Text text="Forgot password?" style={themed($forgotPasswordText)} size="xs" />
+          </Pressable>
+
+          {/* Primary Sign In Button */}
+          <Button
+            text={isSubmitting ? "Signing In..." : "Sign In"}
+            style={themed($loginButton)}
+            preset="reversed"
+            onPress={handleLogin}
+            disabled={isSubmitting}
+            testID="login-submit-button"
+          />
+
+          {/* Divider */}
+          <View style={themed($dividerContainer)}>
+            <View style={themed($dividerLine)} />
+            <Text text="or" style={themed($dividerText)} size="xs" />
+            <View style={themed($dividerLine)} />
+          </View>
+
+          {/* Magic Link Button */}
+          <Button
+            text="Sign in with email link"
+            style={themed($magicLinkButton)}
+            preset="default"
+            textStyle={themed($magicLinkText)}
+            onPress={() => navigation.navigate("MagicLink")}
+          />
+        </>
       )}
-      <Text
-        text="Sign in to access your safety alerts and subscriptions"
-        style={themed($subheading)}
-        size="sm"
-      />
 
-      {generalError ? (
-        <View style={themed($errorContainer)}>
-          <Text text={generalError} style={themed($errorText)} size="sm" />
+      {/* Sign Up Link — hidden during NEW_PASSWORD_REQUIRED so the
+          user isn't tempted to abandon a forced-change session. */}
+      {authStep === "SIGN_IN" && (
+        <View style={themed($signupContainer)}>
+          <Text text="Don't have an account? " style={themed($signupText)} size="sm" />
+          <Pressable onPress={() => navigation.navigate("Signup")}>
+            <Text text="Sign up" style={themed($signupLink)} size="sm" weight="semiBold" />
+          </Pressable>
         </View>
-      ) : null}
-
-      <TextField
-        value={email}
-        onChangeText={(text) => {
-          setEmail(text)
-          if (emailError) validateEmail(text)
-        }}
-        containerStyle={themed($textField)}
-        autoCapitalize="none"
-        autoComplete="email"
-        autoCorrect={false}
-        keyboardType="email-address"
-        label="Email"
-        placeholder="Enter your email"
-        helper={emailError}
-        status={emailError ? "error" : undefined}
-        onSubmitEditing={() => passwordInput.current?.focus()}
-        testID="login-email-input"
-      />
-
-      <TextField
-        ref={passwordInput}
-        value={password}
-        onChangeText={(text) => {
-          setPassword(text)
-          if (passwordError) validatePassword(text)
-        }}
-        containerStyle={themed($textField)}
-        autoCapitalize="none"
-        autoComplete="password"
-        autoCorrect={false}
-        secureTextEntry={isPasswordHidden}
-        label="Password"
-        placeholder="Enter your password"
-        helper={passwordError}
-        status={passwordError ? "error" : undefined}
-        onSubmitEditing={handleLogin}
-        RightAccessory={PasswordRightAccessory}
-        testID="login-password-input"
-      />
-
-      {/* Forgot Password Link */}
-      <Pressable
-        onPress={() => navigation.navigate("ForgotPassword")}
-        style={themed($forgotPasswordLink)}
-      >
-        <Text text="Forgot password?" style={themed($forgotPasswordText)} size="xs" />
-      </Pressable>
-
-      {/* Primary Sign In Button */}
-      <Button
-        text={isSubmitting ? "Signing In..." : "Sign In"}
-        style={themed($loginButton)}
-        preset="reversed"
-        onPress={handleLogin}
-        disabled={isSubmitting}
-        testID="login-submit-button"
-      />
-
-      {/* Divider */}
-      <View style={themed($dividerContainer)}>
-        <View style={themed($dividerLine)} />
-        <Text text="or" style={themed($dividerText)} size="xs" />
-        <View style={themed($dividerLine)} />
-      </View>
-
-      {/* Magic Link Button */}
-      <Button
-        text="Sign in with email link"
-        style={themed($magicLinkButton)}
-        preset="default"
-        textStyle={themed($magicLinkText)}
-        onPress={() => navigation.navigate("MagicLink")}
-      />
-
-      {/* Sign Up Link */}
-      <View style={themed($signupContainer)}>
-        <Text text="Don't have an account? " style={themed($signupText)} size="sm" />
-        <Pressable onPress={() => navigation.navigate("Signup")}>
-          <Text text="Sign up" style={themed($signupLink)} size="sm" weight="semiBold" />
-        </Pressable>
-      </View>
+      )}
     </Screen>
   )
 }

--- a/apps/mobile/app/utils/authErrors.ts
+++ b/apps/mobile/app/utils/authErrors.ts
@@ -55,6 +55,19 @@ const LOGIN_ERROR_MESSAGES: Record<string, string> = {
 }
 
 /**
+ * User-friendly error messages for the new-password challenge that
+ * Cognito raises when an admin-invited user (FORCE_CHANGE_PASSWORD)
+ * signs in with their temporary password.
+ */
+const NEW_PASSWORD_ERROR_MESSAGES: Record<string, string> = {
+  InvalidPasswordException:
+    "Password doesn't meet the security requirements. Try a longer password with a mix of letters, numbers, and symbols.",
+  LimitExceededException: "Too many attempts. Please wait a moment and try again.",
+  TooManyRequestsException: "Too many requests. Please wait a moment and try again.",
+  NotAuthorizedException: "Your sign-in session has expired. Please sign in again.",
+}
+
+/**
  * Extract error code from Cognito error
  */
 function getErrorCode(error: unknown): CognitoErrorCode | null {
@@ -111,6 +124,30 @@ export function getLoginErrorMessage(error: unknown): string {
   }
 
   return "Login failed. Please check your credentials and try again."
+}
+
+/**
+ * Get user-friendly message for the new-password challenge.
+ *
+ * Used when an admin-invited user (Cognito FORCE_CHANGE_PASSWORD state)
+ * is required to set a permanent password before reaching their session.
+ */
+export function getNewPasswordErrorMessage(error: unknown): string {
+  const code = getErrorCode(error)
+  if (code && NEW_PASSWORD_ERROR_MESSAGES[code]) {
+    return NEW_PASSWORD_ERROR_MESSAGES[code]
+  }
+
+  // Cognito sometimes surfaces password-policy violations as
+  // InvalidParameterException when the password is malformed (e.g.,
+  // includes characters outside the allowed set). Pattern-match the
+  // message to give a useful hint rather than a generic string.
+  const message = error instanceof Error ? error.message : ""
+  if (message.toLowerCase().includes("password")) {
+    return "Password doesn't meet the security requirements. Try a longer password with a mix of letters, numbers, and symbols."
+  }
+
+  return "Failed to set new password. Please try again."
 }
 
 /**


### PR DESCRIPTION
## Why

Admin-invited Cognito users (FORCE_CHANGE_PASSWORD state) couldn't sign into the mobile app. \`signIn()\` returned \`nextStep.signInStep === \"CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED\"\`, but \`LoginScreen\`'s switch only knew about \`isSignedIn\` and \`CONFIRM_SIGN_UP\`; every other step fell through to a generic *\"Additional step required: …\"* error with no path forward.

The admin portal already handles this correctly at \`apps/admin/src/app/login/page.tsx:157, 204–238\`. This PR mirrors that pattern in mobile.

This unblocks Rayane's staging test session. Per his April 11, 2026 email (the cascade discoverability bug — *\"Sorel-Tracy should have at least the water contamination standards, since it is in the province of Quebec (same as Montreal)\"*), he needs to verify PR #278 on staging mobile-web. The Cognito accounts I provisioned (\`rayane@mapyourhealth.info\`, \`rayane+admin@mapyourhealth.info\` on pool \`ca-central-1_tPykL7wal\`) start in \`FORCE_CHANGE_PASSWORD\`, so without this fix his temp-password experience dead-ends.

## What

- **\`apps/mobile/app/screens/LoginScreen.tsx\`** — add an \`authStep\` state machine (\`\"SIGN_IN\" | \"NEW_PASSWORD_REQUIRED\"\`); render a dedicated sub-form on the new-password branch (two password fields with show/hide toggles, primary submit button, \"Back to sign in\" link). Override the Header back button while on the sub-form so it resets local state rather than abandoning the half-completed Cognito session. Hide the Sign Up footer link during \`NEW_PASSWORD_REQUIRED\`. Reuse existing themed styles (\`\$errorContainer\`, \`\$errorText\`, \`\$textField\`, \`\$loginButton\`) — no new style work.
- **\`apps/mobile/app/utils/authErrors.ts\`** — add \`NEW_PASSWORD_ERROR_MESSAGES\` + \`getNewPasswordErrorMessage(error)\` mirroring the existing \`LOGIN_ERROR_MESSAGES\` / \`getLoginErrorMessage\` shape. Maps \`InvalidPasswordException\`, \`LimitExceededException\`, \`TooManyRequestsException\`, \`NotAuthorizedException\`. Pattern-matches \"password\" in raw error messages as a fallback for the \`InvalidParameter\` form Cognito sometimes emits.

No other files touched. \`confirmSignIn\` was already imported in \`AuthContext.tsx\`. The post-sign-in side effects (\`refreshAuthState\` → \`executePendingAction\` → navigate Dashboard) live in LoginScreen and are reused by both the regular sign-in path and the new \`handleNewPassword\` path via a shared \`finishSignIn\` helper.

## Test plan

- [x] \`cd apps/mobile && yarn tsc --noEmit\` — clean
- [x] \`cd apps/mobile && npx eslint app --ext .ts,.tsx\` — clean
- [x] \`cd apps/mobile && npx jest\` — 19 suites / 222 tests pass
- [ ] **Staging mobile-web**: sign in as \`rayane@mapyourhealth.info\` with the Cognito-emailed temp password
- [ ] Confirm the *\"Set a new password\"* form renders (not the dead-end generic error)
- [ ] Set a new password (≥8 chars, both fields matching)
- [ ] Confirm navigation lands on Dashboard
- [ ] Confirm the Cognito user's status flips from \`FORCE_CHANGE_PASSWORD\` to \`CONFIRMED\`:
  \`\`\`
  aws cognito-idp list-users --profile rayane --region ca-central-1 \\
    --user-pool-id ca-central-1_tPykL7wal \\
    --query 'Users[?Attributes[?Name==\`email\` && Value==\`rayane@mapyourhealth.info\`]].UserStatus'
  \`\`\`
- [ ] Negative paths: mismatched passwords, <8 chars, server rejection, \"Back to sign in\"

## Out of scope

- Custom staging URLs (per direction — explain the autogen URLs to Rayane in the testing email instead).
- Email subdomain (\`@staging.mapyourhealth.info\`) for test users — defer.
- Magic-link interaction with \`FORCE_CHANGE_PASSWORD\` — Cognito won't let a forced-change user complete CUSTOM_AUTH; magic link would also fail. Separate gap.
- Cognito password policy tightening in \`packages/backend/amplify/auth/resource.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)