### PR TITLE
chore(mobile): wire EAS Update for staging and production OTA delivery

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -155,3 +155,41 @@ jobs:
             --commit-id ${{ github.sha }} \
             --commit-message "$COMMIT_MSG" \
             --commit-time "$COMMIT_TIME"
+
+  ota-update:
+    name: Publish EAS Update
+    runs-on: ubuntu-latest
+    needs: [detect-changes, wait-for-backend]
+    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Sync amplify_outputs.json
+        run: yarn sync:amplify
+        continue-on-error: true
+
+      - name: Publish update
+        working-directory: apps/mobile
+        run: |
+          BRANCH=${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          eas update --branch "$BRANCH" --message "$COMMIT_MSG" --non-interactive

--- a/README.md
+++ b/README.md
@@ -218,12 +218,64 @@ GitHub Actions workflows in `.github/workflows/`:
 | `backend-ci.yml` | PR to main | Backend CI |
 | `backend-seed.yml` | Manual | Seed database |
 | `admin-deploy.yml` | Push to main | Deploy admin dashboard |
-| `mobile-deploy.yml` | Push to main | Deploy mobile web |
+| `mobile-deploy.yml` | Push to main/staging | Deploy mobile web + publish EAS Update OTA |
 | `e2e-tests.yml` | PR, manual | E2E test suite |
 | `e2e-ios.yml` | Manual | iOS E2E tests |
 | `playwright-tests.yml` | PR | Web Playwright tests |
 
 Deployments are managed via AWS Amplify Hosting — pushes to `main` auto-deploy backend, mobile web, and admin dashboard.
+
+## Mobile OTA Updates (EAS Update)
+
+The native mobile app receives JavaScript / asset changes over-the-air via [EAS Update](https://docs.expo.dev/eas-update/introduction/), so most fixes ship to installed devices without a new App Store / Play Store binary.
+
+### How it works
+
+```
+git push staging  ──►  mobile-deploy.yml  ──►  eas update --branch staging      ──►  staging channel    ──►  installs on staging build
+git push main     ──►  mobile-deploy.yml  ──►  eas update --branch production  ──►  production channel ──►  installs on production build
+```
+
+- **Project:** `@epiphanyapps/MapYourHealth`
+- **Branches:** `staging`, `production` (created on EAS — these are EAS Update branches, not git branches)
+- **Channels:** `staging` → `staging` branch, `production` → `production` branch
+- **Runtime version policy:** `appVersion` — the JS bundle delivered to a device must match the device binary's `version` in `app.json`. Bumping `version` requires a new native build.
+- **Auto-update behavior:** `expo-updates` checks on every cold start (`checkAutomatically: ON_LOAD`, the default). Updates download in the background and apply on the next launch.
+
+### Auto-publish on merge
+
+`.github/workflows/mobile-deploy.yml` runs an `ota-update` job that publishes automatically when `apps/mobile/**` changes:
+
+| Git branch | EAS branch / channel | URL |
+| ---------- | -------------------- | --- |
+| `staging` → merge | `staging` | https://staging.d2z5ddqhlc1q5.amplifyapp.com (web mirror) |
+| `main` → merge | `production` | https://app.mapyourhealth.info (web mirror) |
+
+The job needs the `EXPO_TOKEN` repository secret (set once at https://expo.dev/accounts/epiphanyapps/settings/access-tokens).
+
+### Manual publish
+
+```bash
+cd apps/mobile
+eas update --branch staging    --message "fix: ..."   # smoke-test before promoting
+eas update --branch production --message "release: ..."
+```
+
+### When you must rebuild the native binary
+
+OTA can ship JS, assets, and config — it cannot ship native code. Trigger a fresh `eas build` whenever you:
+
+- Bump `version` in `app.json` (runtimeVersion changes)
+- Add / remove a native module or Expo plugin
+- Change anything under `ios/` / `android/` config (icons, entitlements, Info.plist, gradle)
+
+```bash
+cd apps/mobile
+eas build --profile staging    --platform all
+eas build --profile production --platform all
+```
+
+After the new binary is on a device, every merge afterwards reaches it via OTA.
 
 ## Project URLs
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,7 +8,8 @@
   "userInterfaceStyle": "automatic",
   "icon": "./assets/images/app-icon-all.png",
   "updates": {
-    "fallbackToCacheTimeout": 0
+    "fallbackToCacheTimeout": 0,
+    "url": "https://u.expo.dev/2d5329f5-5724-4814-a718-86011c93c9e3"
   },
   "newArchEnabled": true,
   "jsEngine": "hermes",
@@ -39,6 +40,16 @@
     },
     "config": {
       "googleMapsApiKey": ""
+    },
+    "privacyManifests": {
+      "NSPrivacyAccessedAPITypes": [
+        {
+          "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+          "NSPrivacyAccessedAPITypeReasons": [
+            "CA92.1"
+          ]
+        }
+      ]
     }
   },
   "web": {
@@ -79,5 +90,8 @@
     "eas": {
       "projectId": "2d5329f5-5724-4814-a718-86011c93c9e3"
     }
+  },
+  "runtimeVersion": {
+    "policy": "appVersion"
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,7 +13,8 @@
       "ios": {
         "buildConfiguration": "Debug",
         "simulator": true
-      }
+      },
+      "channel": "development"
     },
     "development:device": {
       "extends": "development",
@@ -21,13 +22,19 @@
       "ios": {
         "buildConfiguration": "Debug",
         "simulator": false
-      }
+      },
+      "channel": "development-device"
     },
     "preview": {
       "extends": "production",
       "distribution": "internal",
-      "ios": { "simulator": true },
-      "android": { "buildType": "apk" }
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "channel": "preview"
     },
     "e2e": {
       "extends": "production",
@@ -35,14 +42,29 @@
       "env": {
         "E2E_TEST": "true"
       },
-      "ios": { "simulator": true },
-      "android": { "buildType": "apk" }
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "channel": "e2e"
     },
     "preview:device": {
       "extends": "preview",
-      "ios": { "simulator": false }
+      "ios": {
+        "simulator": false
+      },
+      "channel": "preview-device"
     },
-    "production": {}
+    "staging": {
+      "extends": "production",
+      "distribution": "internal",
+      "channel": "staging"
+    },
+    "production": {
+      "channel": "production"
+    }
   },
   "submit": {
     "production": {}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -83,6 +83,7 @@
     "expo-notifications": "~0.32.16",
     "expo-splash-screen": "~31.0.10",
     "expo-system-ui": "~6.0.7",
+    "expo-updates": "~29.0.17",
     "i18next": "^23.14.0",
     "intl-pluralrules": "^2.0.1",
     "react": "19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11138,6 +11138,7 @@ __metadata:
     expo-notifications: "npm:~0.32.16"
     expo-splash-screen: "npm:~31.0.10"
     expo-system-ui: "npm:~6.0.7"
+    expo-updates: "npm:~29.0.17"
     i18next: "npm:^23.14.0"
     intl-pluralrules: "npm:^2.0.1"
     jest: "npm:~29.7.0"
@@ -17153,6 +17154,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:4.1.0":
+  version: 4.1.0
+  resolution: "arg@npm:4.1.0"
+  checksum: 10c0/a453e07f25370c7910df9b8a8eecb1a0c71e902a3843339ff9391ea4b4dac6871cd99a1a11e38642cf6d0723c7ab7f15f5824f1ccb862f3317a9c05c56a251c7
+  languageName: node
+  linkType: hard
+
 "arg@npm:^5.0.2":
   version: 5.0.2
   resolution: "arg@npm:5.0.2"
@@ -20958,6 +20966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-eas-client@npm:~1.0.8":
+  version: 1.0.8
+  resolution: "expo-eas-client@npm:1.0.8"
+  checksum: 10c0/c291351db616f6163900b5ef6294240068e2d7b916dde1aee5b82353375f63cdfe4523f63ff72903c6ee81e5f1be2a20555f0c024d6fb11b5de1507c7c2d8b09
+  languageName: node
+  linkType: hard
+
 "expo-file-system@npm:~19.0.21":
   version: 19.0.21
   resolution: "expo-file-system@npm:19.0.21"
@@ -21044,6 +21059,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-manifests@npm:~1.0.11":
+  version: 1.0.11
+  resolution: "expo-manifests@npm:1.0.11"
+  dependencies:
+    "@expo/config": "npm:~12.0.13"
+    expo-json-utils: "npm:~0.15.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/184f3ce01f9f0099ef08433c33a42ca1f865045bfcde00a6bb7f8c51825288b5b4d9f2150fc4e57aea9f6aff34093f49157f4d78fdd0d79157a199a03cdb4243
+  languageName: node
+  linkType: hard
+
 "expo-modules-autolinking@npm:3.0.24":
   version: 3.0.24
   resolution: "expo-modules-autolinking@npm:3.0.24"
@@ -21108,6 +21135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-structured-headers@npm:~5.0.0":
+  version: 5.0.0
+  resolution: "expo-structured-headers@npm:5.0.0"
+  checksum: 10c0/bbe0f9cb91ca5fd8482fd15723bfe279b26f34a37360af2ce9a510434351e50d889e429037915be9ede493893b99eb8e7f0be56bfcebaebb5d9a25443b1fa419
+  languageName: node
+  linkType: hard
+
 "expo-system-ui@npm:~6.0.7":
   version: 6.0.9
   resolution: "expo-system-ui@npm:6.0.9"
@@ -21131,6 +21165,34 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10c0/d2ccf8325c1c8092fac6cfa521291943dce92f56a633bcc60abe1db54c88da601d6b0174aa1e824db6d3508486ccccafa16e39f05b7014dd70442ba91340b02e
+  languageName: node
+  linkType: hard
+
+"expo-updates@npm:~29.0.17":
+  version: 29.0.17
+  resolution: "expo-updates@npm:29.0.17"
+  dependencies:
+    "@expo/code-signing-certificates": "npm:^0.0.6"
+    "@expo/plist": "npm:^0.4.8"
+    "@expo/spawn-async": "npm:^1.7.2"
+    arg: "npm:4.1.0"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.4"
+    expo-eas-client: "npm:~1.0.8"
+    expo-manifests: "npm:~1.0.11"
+    expo-structured-headers: "npm:~5.0.0"
+    expo-updates-interface: "npm:~2.0.0"
+    getenv: "npm:^2.0.0"
+    glob: "npm:^13.0.0"
+    ignore: "npm:^5.3.1"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  bin:
+    expo-updates: bin/cli.js
+  checksum: 10c0/b6af869928b025dc1e70e1cb0d628553640646b68b349770b5fea1724624ab8b5f300b6ddf15a045918e3f4f8746f3f68e65d98345c47f609dd9dd4af1363d7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Install `expo-updates` in `apps/mobile` and configure it against the existing `@epiphanyapps/MapYourHealth` EAS project (slug, owner, projectId all unchanged).
- Add a `staging` build profile and `channel` mappings to `eas.json`; rename the auto-generated channels that contained colons (EAS rejects them).
- Add an `ota-update` job to `.github/workflows/mobile-deploy.yml` that publishes OTAs automatically: `staging` → `staging` channel, `main` → `production` channel.
- Document the OTA flow in the README (how it works, branches/channels, manual publish, when a native rebuild is required).

`EXPO_TOKEN` repo secret is already set; no further action needed in CI.

## Test plan

- [ ] CI: lint + type-check pass on this PR
- [ ] After merge to `staging`, the `Mobile Web Deploy` workflow's new `ota-update` job runs and publishes to the `staging` EAS branch — verify on https://expo.dev/accounts/epiphanyapps/projects/MapYourHealth/updates
- [ ] Trigger a fresh `eas build --profile staging --platform ios` (one-time) and install on a device; subsequent merges to `staging` should land on the device on cold start
- [ ] Promote to `main` once staging is validated; confirm `ota-update` job publishes to the `production` EAS branch

## Notes

- Existing TestFlight / App Store / Play installs predate this change — they'll start receiving OTAs only after a fresh native build (with `expo-updates` + matching channel) is installed.
- `runtimeVersion` policy is `appVersion`, so bumping `version` in `app.json` requires a new native build before OTAs of the new JS can reach devices.