### PR TITLE
release: promote staging to main (mobile auth + EAS OTA + seed-script safety)

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -155,3 +155,41 @@ jobs:
             --commit-id ${{ github.sha }} \
             --commit-message "$COMMIT_MSG" \
             --commit-time "$COMMIT_TIME"
+
+  ota-update:
+    name: Publish EAS Update
+    runs-on: ubuntu-latest
+    needs: [detect-changes, wait-for-backend]
+    if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Sync amplify_outputs.json
+        run: yarn sync:amplify
+        continue-on-error: true
+
+      - name: Publish update
+        working-directory: apps/mobile
+        run: |
+          BRANCH=${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
+          eas update --branch "$BRANCH" --message "$COMMIT_MSG" --non-interactive

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -168,6 +168,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -183,9 +190,19 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Sync amplify_outputs.json
-        run: yarn sync:amplify
-        continue-on-error: true
+      # Generate the prod amplify_outputs.json from the live Amplify backend.
+      # The mobile app imports it at module load (apps/mobile/app/app.tsx) and
+      # bundling fails without it. Mirrors the equivalent step in amplify.yml.
+      # The staging override file (apps/mobile/amplify_outputs.staging.json)
+      # is committed and already present in the checkout.
+      - name: Generate amplify_outputs.json (prod)
+        working-directory: packages/backend
+        run: |
+          AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs \
+            --branch main \
+            --app-id d3jl0ykn4qgj9r
+          cp amplify_outputs.json ../../apps/mobile/amplify_outputs.json
+          cp amplify_outputs.json ../../amplify_outputs.json
 
       - name: Publish update
         working-directory: apps/mobile

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Amplify
 .amplify/
 amplify_outputs.json
+# Backend's staging copy is local-only — the canonical bundled copy lives at
+# apps/mobile/amplify_outputs.staging.json and IS tracked so prod builds can
+# ship it to power the in-app staging-backend switcher.
+packages/backend/amplify_outputs.staging.json
 
 # Yarn
 .yarn/*

--- a/README.md
+++ b/README.md
@@ -218,12 +218,64 @@ GitHub Actions workflows in `.github/workflows/`:
 | `backend-ci.yml` | PR to main | Backend CI |
 | `backend-seed.yml` | Manual | Seed database |
 | `admin-deploy.yml` | Push to main | Deploy admin dashboard |
-| `mobile-deploy.yml` | Push to main | Deploy mobile web |
+| `mobile-deploy.yml` | Push to main/staging | Deploy mobile web + publish EAS Update OTA |
 | `e2e-tests.yml` | PR, manual | E2E test suite |
 | `e2e-ios.yml` | Manual | iOS E2E tests |
 | `playwright-tests.yml` | PR | Web Playwright tests |
 
 Deployments are managed via AWS Amplify Hosting — pushes to `main` auto-deploy backend, mobile web, and admin dashboard.
+
+## Mobile OTA Updates (EAS Update)
+
+The native mobile app receives JavaScript / asset changes over-the-air via [EAS Update](https://docs.expo.dev/eas-update/introduction/), so most fixes ship to installed devices without a new App Store / Play Store binary.
+
+### How it works
+
+```
+git push staging  ──►  mobile-deploy.yml  ──►  eas update --branch staging      ──►  staging channel    ──►  installs on staging build
+git push main     ──►  mobile-deploy.yml  ──►  eas update --branch production  ──►  production channel ──►  installs on production build
+```
+
+- **Project:** `@epiphanyapps/MapYourHealth`
+- **Branches:** `staging`, `production` (created on EAS — these are EAS Update branches, not git branches)
+- **Channels:** `staging` → `staging` branch, `production` → `production` branch
+- **Runtime version policy:** `appVersion` — the JS bundle delivered to a device must match the device binary's `version` in `app.json`. Bumping `version` requires a new native build.
+- **Auto-update behavior:** `expo-updates` checks on every cold start (`checkAutomatically: ON_LOAD`, the default). Updates download in the background and apply on the next launch.
+
+### Auto-publish on merge
+
+`.github/workflows/mobile-deploy.yml` runs an `ota-update` job that publishes automatically when `apps/mobile/**` changes:
+
+| Git branch | EAS branch / channel | URL |
+| ---------- | -------------------- | --- |
+| `staging` → merge | `staging` | https://staging.d2z5ddqhlc1q5.amplifyapp.com (web mirror) |
+| `main` → merge | `production` | https://app.mapyourhealth.info (web mirror) |
+
+The job needs the `EXPO_TOKEN` repository secret (set once at https://expo.dev/accounts/epiphanyapps/settings/access-tokens).
+
+### Manual publish
+
+```bash
+cd apps/mobile
+eas update --branch staging    --message "fix: ..."   # smoke-test before promoting
+eas update --branch production --message "release: ..."
+```
+
+### When you must rebuild the native binary
+
+OTA can ship JS, assets, and config — it cannot ship native code. Trigger a fresh `eas build` whenever you:
+
+- Bump `version` in `app.json` (runtimeVersion changes)
+- Add / remove a native module or Expo plugin
+- Change anything under `ios/` / `android/` config (icons, entitlements, Info.plist, gradle)
+
+```bash
+cd apps/mobile
+eas build --profile staging    --platform all
+eas build --profile production --platform all
+```
+
+After the new binary is on a device, every merge afterwards reaches it via OTA.
 
 ## Project URLs
 

--- a/apps/admin/src/app/(admin)/banners/page.tsx
+++ b/apps/admin/src/app/(admin)/banners/page.tsx
@@ -33,7 +33,27 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
-import { Plus, Pencil, Trash2, Loader2, Eye, EyeOff } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Loader2,
+  Eye,
+  EyeOff,
+  AlertOctagon,
+  AlertTriangle,
+  Info,
+  Clock,
+  CalendarX2,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -51,6 +71,26 @@ const SEVERITY_COLORS: Record<Severity, string> = {
   critical: "bg-red-100 text-red-800",
   warning: "bg-amber-100 text-amber-800",
   info: "bg-blue-100 text-blue-800",
+};
+
+const SEVERITY_ICONS: Record<Severity, LucideIcon> = {
+  critical: AlertOctagon,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+type DisplayStatus = "active" | "scheduled" | "expired" | "inactive";
+
+const getDisplayStatus = (banner: WarningBanner): DisplayStatus => {
+  if (!banner.isActive) return "inactive";
+  const now = Date.now();
+  const start = new Date(banner.startsAt).getTime();
+  if (Number.isFinite(start) && start > now) return "scheduled";
+  if (banner.expiresAt) {
+    const end = new Date(banner.expiresAt).getTime();
+    if (Number.isFinite(end) && end <= now) return "expired";
+  }
+  return "active";
 };
 
 const bannerFormSchema = z
@@ -126,6 +166,10 @@ export default function BannersPage() {
   );
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState<FormData>(defaultFormData);
+  const [bannerToDelete, setBannerToDelete] = useState<WarningBanner | null>(
+    null,
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const fetchBanners = async () => {
     try {
@@ -242,19 +286,21 @@ export default function BannersPage() {
     }
   };
 
-  const handleDelete = async (banner: WarningBanner) => {
-    if (!confirm(`Are you sure you want to delete "${banner.title}"?`)) {
-      return;
-    }
+  const confirmDelete = async () => {
+    if (!bannerToDelete) return;
 
+    setIsDeleting(true);
     try {
       const client = generateClient<Schema>();
-      await client.models.WarningBanner.delete({ id: banner.id });
+      await client.models.WarningBanner.delete({ id: bannerToDelete.id });
       toast.success("Banner deleted");
+      setBannerToDelete(null);
       fetchBanners();
     } catch (error) {
       console.error("Error deleting banner:", error);
       toast.error("Failed to delete banner");
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -360,25 +406,31 @@ export default function BannersPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="severity">Severity *</Label>
-                <select
-                  id="severity"
-                  required
-                  aria-required="true"
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                <Select
                   value={formData.severity}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      severity: e.target.value as Severity,
-                    })
+                  onValueChange={(value) =>
+                    setFormData({ ...formData, severity: value as Severity })
                   }
                 >
-                  {SEVERITY_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger
+                    id="severity"
+                    aria-required="true"
+                    className="w-full"
+                  >
+                    <SelectValue placeholder="Select severity" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SEVERITY_OPTIONS.map((opt) => {
+                      const Icon = SEVERITY_ICONS[opt.value];
+                      return (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          <Icon className="h-4 w-4" />
+                          {opt.label}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
               </div>
 
               <div className="grid grid-cols-3 gap-4">
@@ -520,16 +572,15 @@ export default function BannersPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {banners.map((banner) => (
+                {banners.map((banner) => {
+                  const severity = (banner.severity as Severity) || "warning";
+                  const SeverityIcon = SEVERITY_ICONS[severity];
+                  const status = getDisplayStatus(banner);
+                  return (
                   <TableRow key={banner.id}>
                     <TableCell>
-                      <Badge
-                        className={
-                          SEVERITY_COLORS[
-                            (banner.severity as Severity) || "warning"
-                          ]
-                        }
-                      >
+                      <Badge className={SEVERITY_COLORS[severity]}>
+                        <SeverityIcon className="h-3 w-3 mr-1" />
                         {banner.severity || "warning"}
                       </Badge>
                     </TableCell>
@@ -551,10 +602,20 @@ export default function BannersPage() {
                         : "Never"}
                     </TableCell>
                     <TableCell>
-                      {banner.isActive ? (
+                      {status === "active" ? (
                         <Badge className="bg-green-100 text-green-800">
                           <Eye className="h-3 w-3 mr-1" />
                           Active
+                        </Badge>
+                      ) : status === "scheduled" ? (
+                        <Badge className="bg-blue-100 text-blue-800">
+                          <Clock className="h-3 w-3 mr-1" />
+                          Scheduled
+                        </Badge>
+                      ) : status === "expired" ? (
+                        <Badge variant="secondary">
+                          <CalendarX2 className="h-3 w-3 mr-1" />
+                          Expired
                         </Badge>
                       ) : (
                         <Badge variant="secondary">
@@ -577,20 +638,63 @@ export default function BannersPage() {
                           variant="ghost"
                           size="icon"
                           aria-label={`Delete banner: ${banner.title}`}
-                          onClick={() => handleDelete(banner)}
+                          onClick={() => setBannerToDelete(banner)}
                         >
                           <Trash2 className="h-4 w-4 text-red-500" />
                         </Button>
                       </div>
                     </TableCell>
                   </TableRow>
-                ))}
+                  );
+                })}
               </TableBody>
             </Table>
             </div>
           )}
         </CardContent>
       </Card>
+
+      <Dialog
+        open={bannerToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setBannerToDelete(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle>Delete banner?</DialogTitle>
+            <DialogDescription>
+              This will permanently remove
+              {bannerToDelete ? ` "${bannerToDelete.title}"` : " this banner"}.
+              Mobile users will stop seeing it on their next refresh. This
+              action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBannerToDelete(null)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting…
+                </>
+              ) : (
+                "Delete banner"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/admin/src/app/(admin)/banners/page.tsx
+++ b/apps/admin/src/app/(admin)/banners/page.tsx
@@ -94,6 +94,15 @@ interface FormData {
   isActive: boolean;
 }
 
+// Format a Date as `YYYY-MM-DDTHH:mm` in the user's LOCAL timezone, suitable
+// for an <input type="datetime-local">. Using `toISOString()` would emit UTC
+// wall-clock and the input would parse it back as local time, shifting the
+// stored timestamp by the user's UTC offset on every save.
+const formatLocalDateTime = (date: Date) => {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
 const defaultFormData: FormData = {
   title: "",
   titleFr: "",
@@ -103,7 +112,7 @@ const defaultFormData: FormData = {
   city: "",
   state: "",
   country: "",
-  startsAt: new Date().toISOString().slice(0, 16),
+  startsAt: formatLocalDateTime(new Date()),
   expiresAt: "",
   isActive: true,
 };
@@ -172,10 +181,10 @@ export default function BannersPage() {
       state: banner.state || "",
       country: banner.country || "",
       startsAt: banner.startsAt
-        ? new Date(banner.startsAt).toISOString().slice(0, 16)
+        ? formatLocalDateTime(new Date(banner.startsAt))
         : "",
       expiresAt: banner.expiresAt
-        ? new Date(banner.expiresAt).toISOString().slice(0, 16)
+        ? formatLocalDateTime(new Date(banner.expiresAt))
         : "",
       isActive: banner.isActive ?? true,
     });
@@ -185,8 +194,8 @@ export default function BannersPage() {
   const handleSave = async () => {
     const result = bannerFormSchema.safeParse(formData);
     if (!result.success) {
-      const firstError = result.error.issues[0]?.message;
-      toast.error(firstError || "Please fix the form errors");
+      const messages = result.error.issues.map((i) => i.message).join(". ");
+      toast.error(messages || "Please fix the form errors");
       return;
     }
 
@@ -299,6 +308,8 @@ export default function BannersPage() {
                   <Label htmlFor="title">Title (English) *</Label>
                   <Input
                     id="title"
+                    required
+                    aria-required="true"
                     placeholder="e.g., Boil Water Advisory"
                     value={formData.title}
                     onChange={(e) =>
@@ -323,6 +334,8 @@ export default function BannersPage() {
                 <Label htmlFor="description">Description (English) *</Label>
                 <Textarea
                   id="description"
+                  required
+                  aria-required="true"
                   placeholder="Describe the warning..."
                   value={formData.description}
                   onChange={(e) =>
@@ -349,6 +362,8 @@ export default function BannersPage() {
                 <Label htmlFor="severity">Severity *</Label>
                 <select
                   id="severity"
+                  required
+                  aria-required="true"
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   value={formData.severity}
                   onChange={(e) =>
@@ -412,6 +427,8 @@ export default function BannersPage() {
                   <Input
                     id="startsAt"
                     type="datetime-local"
+                    required
+                    aria-required="true"
                     value={formData.startsAt}
                     onChange={(e) =>
                       setFormData({ ...formData, startsAt: e.target.value })
@@ -474,7 +491,9 @@ export default function BannersPage() {
         <CardHeader>
           <CardTitle>All Banners</CardTitle>
           <CardDescription>
-            {banners.length} banner{banners.length !== 1 ? "s" : ""} configured
+            {isLoading
+              ? "Loading…"
+              : `${banners.length} banner${banners.length !== 1 ? "s" : ""} configured`}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -487,6 +506,7 @@ export default function BannersPage() {
               No banners yet. Click &quot;Add Banner&quot; to create one.
             </div>
           ) : (
+            <div className="overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -548,6 +568,7 @@ export default function BannersPage() {
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label={`Edit banner: ${banner.title}`}
                           onClick={() => openEditDialog(banner)}
                         >
                           <Pencil className="h-4 w-4" />
@@ -555,6 +576,7 @@ export default function BannersPage() {
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label={`Delete banner: ${banner.title}`}
                           onClick={() => handleDelete(banner)}
                         >
                           <Trash2 className="h-4 w-4 text-red-500" />
@@ -565,6 +587,7 @@ export default function BannersPage() {
                 ))}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/apps/admin/src/app/(admin)/zip-codes/page.tsx
+++ b/apps/admin/src/app/(admin)/zip-codes/page.tsx
@@ -29,15 +29,29 @@ type LocationMeasurement = Schema["LocationMeasurement"]["type"];
 type ContaminantThreshold = Schema["ContaminantThreshold"]["type"];
 type Contaminant = Schema["Contaminant"]["type"];
 
-// Extended type for LocationMeasurement with city/state fields from schema
-type LocationMeasurementWithLocation = LocationMeasurement & {
-  city: string;
-  state: string;
-};
-
+// Aggregation results, one per scope. The cascade introduced in #278
+// allows a `LocationMeasurement` to be anchored at city, state, or
+// country level (city/state nullable, country required). The admin
+// page surfaces all three via separate sections so admins can verify
+// what data lives at each scope without a DynamoDB scan.
 interface LocationStats {
   city: string;
   state: string;
+  measurementCount: number;
+  worstStatus: StatStatus;
+  lastUpdated: string;
+}
+
+interface StateStats {
+  state: string;
+  country: string;
+  measurementCount: number;
+  worstStatus: StatStatus;
+  lastUpdated: string;
+}
+
+interface CountryStats {
+  country: string;
   measurementCount: number;
   worstStatus: StatStatus;
   lastUpdated: string;
@@ -73,9 +87,53 @@ function calculateStatus(
   }
 }
 
+/**
+ * Shared aggregator: contributes one measurement to a running aggregate.
+ * Mutates and returns the aggregate so callers can use the
+ * `map.set(key, contribute(map.get(key) ?? init, m))` idiom in three
+ * scope-specific loops without three copies of the same code.
+ */
+function contributeMeasurement<
+  T extends {
+    measurementCount: number;
+    worstStatus: StatStatus;
+    lastUpdated: string;
+  },
+>(
+  agg: T,
+  measurement: LocationMeasurement,
+  thresholdMap: Map<string, ContaminantThreshold>,
+  contaminantMap: Map<string, Contaminant>,
+): T {
+  agg.measurementCount += 1;
+
+  const threshold =
+    thresholdMap.get(`${measurement.contaminantId}:WHO`) ||
+    thresholdMap.get(`${measurement.contaminantId}:US`);
+  const contaminant = contaminantMap.get(measurement.contaminantId);
+  const higherIsBad = contaminant?.higherIsBad ?? true;
+  const status = calculateStatus(measurement.value, threshold, higherIsBad);
+
+  if (status === "danger") {
+    agg.worstStatus = "danger";
+  } else if (status === "warning" && agg.worstStatus !== "danger") {
+    agg.worstStatus = "warning";
+  }
+
+  const measurementDate = new Date(measurement.measuredAt ?? 0);
+  const existingDate = new Date(agg.lastUpdated);
+  if (measurementDate > existingDate) {
+    agg.lastUpdated = measurement.measuredAt ?? agg.lastUpdated;
+  }
+
+  return agg;
+}
+
 export default function ZipCodesPage() {
   const router = useRouter();
   const [locationStats, setLocationStats] = useState<LocationStats[]>([]);
+  const [stateStats, setStateStats] = useState<StateStats[]>([]);
+  const [countryStats, setCountryStats] = useState<CountryStats[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [newCity, setNewCity] = useState("");
@@ -116,75 +174,74 @@ export default function ZipCodesPage() {
         contaminantMap.set(c.contaminantId, c);
       }
 
-      // Group by city+state and calculate status
-      const locationMap = new Map<
-        string,
-        {
-          city: string;
-          state: string;
-          measurements: LocationMeasurement[];
-          worstStatus: StatStatus;
-          lastUpdated: string;
+      // Aggregate measurements into three Maps keyed by anchor scope.
+      // Classification mirrors the cascade lambda's deriveScope at
+      // packages/backend/amplify/functions/on-location-measurement-update/handler.ts
+      // — city wins, then state, then country. country is required by the
+      // schema so the else-branch is always reachable when a row has no
+      // city/state. Rows missing all three are dropped defensively.
+      const cityMap = new Map<string, LocationStats>();
+      const stateMapAgg = new Map<string, StateStats>();
+      const countryMapAgg = new Map<string, CountryStats>();
+
+      for (const m of measurements) {
+        if (!m.country) continue;
+        const fallbackTimestamp = m.measuredAt ?? new Date().toISOString();
+
+        if (m.city) {
+          const key = `${m.city}|${m.state ?? ""}`;
+          const init: LocationStats = cityMap.get(key) ?? {
+            city: m.city,
+            state: m.state ?? "",
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          cityMap.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
+        } else if (m.state) {
+          const key = `${m.state}|${m.country}`;
+          const init: StateStats = stateMapAgg.get(key) ?? {
+            state: m.state,
+            country: m.country,
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          stateMapAgg.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
+        } else {
+          const key = m.country;
+          const init: CountryStats = countryMapAgg.get(key) ?? {
+            country: m.country,
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          countryMapAgg.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
         }
-      >();
-
-      for (const measurement of measurements) {
-        const m = measurement as LocationMeasurementWithLocation;
-        const city = m.city ?? "Unknown";
-        const state = m.state ?? "";
-        const key = `${city}|${state}`;
-        const existing = locationMap.get(key) || {
-          city,
-          state,
-          measurements: [] as LocationMeasurement[],
-          worstStatus: "safe" as StatStatus,
-          lastUpdated: measurement.measuredAt ?? new Date().toISOString(),
-        };
-
-        existing.measurements.push(measurement);
-
-        // Calculate status for this measurement
-        const threshold =
-          thresholdMap.get(`${measurement.contaminantId}:WHO`) ||
-          thresholdMap.get(`${measurement.contaminantId}:US`);
-        const contaminant = contaminantMap.get(measurement.contaminantId);
-        const higherIsBad = contaminant?.higherIsBad ?? true;
-        const status = calculateStatus(
-          measurement.value,
-          threshold,
-          higherIsBad,
-        );
-
-        if (status === "danger") {
-          existing.worstStatus = "danger";
-        } else if (status === "warning" && existing.worstStatus !== "danger") {
-          existing.worstStatus = "warning";
-        }
-
-        const measurementDate = new Date(measurement.measuredAt ?? 0);
-        const existingDate = new Date(existing.lastUpdated);
-        if (measurementDate > existingDate) {
-          existing.lastUpdated = measurement.measuredAt ?? existing.lastUpdated;
-        }
-
-        locationMap.set(key, existing);
       }
 
-      const result: LocationStats[] = Array.from(locationMap.values()).map(
-        ({ city, state, measurements: m, worstStatus, lastUpdated }) => ({
-          city,
-          state,
-          measurementCount: m.length,
-          worstStatus,
-          lastUpdated,
-        }),
-      );
-
-      result.sort((a, b) =>
+      const cityResult = Array.from(cityMap.values()).sort((a, b) =>
         `${a.city}, ${a.state}`.localeCompare(`${b.city}, ${b.state}`),
       );
+      const stateResult = Array.from(stateMapAgg.values()).sort((a, b) =>
+        `${a.state}, ${a.country}`.localeCompare(`${b.state}, ${b.country}`),
+      );
+      const countryResult = Array.from(countryMapAgg.values()).sort((a, b) =>
+        a.country.localeCompare(b.country),
+      );
 
-      setLocationStats(result);
+      setLocationStats(cityResult);
+      setStateStats(stateResult);
+      setCountryStats(countryResult);
     } catch (error) {
       console.error("Error fetching data:", error);
     } finally {
@@ -196,10 +253,19 @@ export default function ZipCodesPage() {
     fetchData();
   }, []);
 
+  // Each section gets its own filter so a single search box matches
+  // across all three: typing "QC" surfaces Boucherville/Montreal in the
+  // city section AND the QC row in the state section; "CA" matches
+  // Canadian cities AND the country-wide row.
+  const lowerQuery = searchQuery.toLowerCase();
   const filteredLocations = locationStats.filter((loc) =>
-    `${loc.city}, ${loc.state}`
-      .toLowerCase()
-      .includes(searchQuery.toLowerCase()),
+    `${loc.city}, ${loc.state}`.toLowerCase().includes(lowerQuery),
+  );
+  const filteredStateStats = stateStats.filter((s) =>
+    `${s.state}, ${s.country}`.toLowerCase().includes(lowerQuery),
+  );
+  const filteredCountryStats = countryStats.filter((c) =>
+    c.country.toLowerCase().includes(lowerQuery),
   );
 
   const handleAddLocation = () => {
@@ -215,7 +281,8 @@ export default function ZipCodesPage() {
           Location Measurements
         </h1>
         <p className="text-muted-foreground">
-          View and manage contaminant measurements by city
+          View and manage contaminant measurements by city, state/province, or
+          country
         </p>
       </div>
 
@@ -223,7 +290,7 @@ export default function ZipCodesPage() {
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search by city..."
+            placeholder="Search city, state, or country..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-10"
@@ -245,10 +312,10 @@ export default function ZipCodesPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>All Locations</CardTitle>
+          <CardTitle>By city</CardTitle>
           <CardDescription>
             {locationStats.length} cit{locationStats.length !== 1 ? "ies" : "y"}{" "}
-            with measurements
+            with measurements anchored at city level
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -259,8 +326,8 @@ export default function ZipCodesPage() {
           ) : filteredLocations.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               {searchQuery
-                ? "No locations match your search."
-                : "No measurement data yet. Add a location to get started."}
+                ? "No cities match your search."
+                : "No city-anchored measurement data yet. Add a location to get started."}
             </div>
           ) : (
             <Table>
@@ -310,6 +377,126 @@ export default function ZipCodesPage() {
                       >
                         Manage
                       </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By state / province</CardTitle>
+          <CardDescription>
+            {stateStats.length} state-wide record
+            {stateStats.length !== 1 ? "s" : ""} — apply to every city in the
+            state without its own data (#123 cascade fallback)
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredStateStats.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No state-wide records match your search."
+                : "No state-anchored measurements yet. Use the Import page and leave the city column blank to add one."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>State / Province</TableHead>
+                  <TableHead>Country</TableHead>
+                  <TableHead>Measurements</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredStateStats.map((s) => (
+                  <TableRow key={`${s.state}-${s.country}`}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{s.state}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{s.country}</TableCell>
+                    <TableCell>{s.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={statStatusColors[s.worstStatus]}
+                      >
+                        {s.worstStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(s.lastUpdated).toLocaleDateString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By country</CardTitle>
+          <CardDescription>
+            {countryStats.length} country-wide record
+            {countryStats.length !== 1 ? "s" : ""} — apply to every city in the
+            country without its own (or its state&apos;s) data
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredCountryStats.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No country-wide records match your search."
+                : "No country-anchored measurements yet. Use the Import page and leave the city + state columns blank to add one."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Country</TableHead>
+                  <TableHead>Measurements</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredCountryStats.map((c) => (
+                  <TableRow key={c.country}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{c.country}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{c.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={statStatusColors[c.worstStatus]}
+                      >
+                        {c.worstStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(c.lastUpdated).toLocaleDateString()}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/admin/src/app/(admin)/zip-codes/page.tsx
+++ b/apps/admin/src/app/(admin)/zip-codes/page.tsx
@@ -314,8 +314,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By city</CardTitle>
           <CardDescription>
-            {locationStats.length} cit{locationStats.length !== 1 ? "ies" : "y"}{" "}
+            {filteredLocations.length} cit
+            {filteredLocations.length !== 1 ? "ies" : "y"}{" "}
             with measurements anchored at city level
+            {searchQuery && filteredLocations.length !== locationStats.length
+              ? ` (of ${locationStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -352,7 +356,8 @@ export default function ZipCodesPage() {
                     </TableCell>
                     <TableCell>{location.state}</TableCell>
                     <TableCell>
-                      {location.measurementCount} measurements
+                      {location.measurementCount} measurement
+                      {location.measurementCount !== 1 ? "s" : ""}
                     </TableCell>
                     <TableCell>
                       <Badge
@@ -390,9 +395,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By state / province</CardTitle>
           <CardDescription>
-            {stateStats.length} state-wide record
-            {stateStats.length !== 1 ? "s" : ""} — apply to every city in the
-            state without its own data (#123 cascade fallback)
+            {filteredStateStats.length} state-wide record
+            {filteredStateStats.length !== 1 ? "s" : ""} — apply to every city
+            in the state without its own data (#123 cascade fallback)
+            {searchQuery && filteredStateStats.length !== stateStats.length
+              ? ` (of ${stateStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -427,7 +435,10 @@ export default function ZipCodesPage() {
                       </div>
                     </TableCell>
                     <TableCell>{s.country}</TableCell>
-                    <TableCell>{s.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      {s.measurementCount} measurement
+                      {s.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
                     <TableCell>
                       <Badge
                         variant="secondary"
@@ -451,9 +462,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By country</CardTitle>
           <CardDescription>
-            {countryStats.length} country-wide record
-            {countryStats.length !== 1 ? "s" : ""} — apply to every city in the
-            country without its own (or its state&apos;s) data
+            {filteredCountryStats.length} country-wide record
+            {filteredCountryStats.length !== 1 ? "s" : ""} — apply to every city
+            in the country without its own (or its state&apos;s) data
+            {searchQuery && filteredCountryStats.length !== countryStats.length
+              ? ` (of ${countryStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -486,7 +500,10 @@ export default function ZipCodesPage() {
                         <span className="font-medium">{c.country}</span>
                       </div>
                     </TableCell>
-                    <TableCell>{c.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      {c.measurementCount} measurement
+                      {c.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
                     <TableCell>
                       <Badge
                         variant="secondary"

--- a/apps/mobile/amplify_outputs.staging.json
+++ b/apps/mobile/amplify_outputs.staging.json
@@ -1,0 +1,3910 @@
+{
+  "auth": {
+    "user_pool_id": "ca-central-1_tPykL7wal",
+    "aws_region": "ca-central-1",
+    "user_pool_client_id": "b8t7edjsr19dp7gv89lsqfi7p",
+    "identity_pool_id": "ca-central-1:f5175153-0f02-488d-80fb-c89f24cd8089",
+    "mfa_methods": [],
+    "standard_required_attributes": [
+      "email"
+    ],
+    "username_attributes": [
+      "email"
+    ],
+    "user_verification_types": [
+      "email"
+    ],
+    "groups": [
+      {
+        "admin": {
+          "precedence": 0
+        }
+      }
+    ],
+    "mfa_configuration": "NONE",
+    "password_policy": {
+      "min_length": 8,
+      "require_lowercase": true,
+      "require_numbers": true,
+      "require_symbols": true,
+      "require_uppercase": true
+    },
+    "unauthenticated_identities_enabled": true
+  },
+  "data": {
+    "url": "https://p3k3ocutbvg2njqmjuvww7o2ou.appsync-api.ca-central-1.amazonaws.com/graphql",
+    "aws_region": "ca-central-1",
+    "default_authorization_type": "AMAZON_COGNITO_USER_POOLS",
+    "authorization_types": [
+      "AWS_IAM"
+    ],
+    "model_introspection": {
+      "version": 1,
+      "models": {
+        "HealthRecord": {
+          "name": "HealthRecord",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "date": {
+              "name": "date",
+              "isArray": false,
+              "type": "AWSDate",
+              "isRequired": true,
+              "attributes": []
+            },
+            "type": {
+              "name": "type",
+              "isArray": false,
+              "type": {
+                "enum": "HealthRecordType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "HealthRecords",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "identityClaim": "cognito:username",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Category": {
+          "name": "Category",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "categoryId": {
+              "name": "categoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "icon": {
+              "name": "icon",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "color": {
+              "name": "color",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sortOrder": {
+              "name": "sortOrder",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "links": {
+              "name": "links",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "showStandardsTable": {
+              "name": "showStandardsTable",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Categories",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "categoriesByCategoryId",
+                "queryField": "listCategoryByCategoryId",
+                "fields": [
+                  "categoryId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "SubCategory": {
+          "name": "SubCategory",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "subCategoryId": {
+              "name": "subCategoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "categoryId": {
+              "name": "categoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "icon": {
+              "name": "icon",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "color": {
+              "name": "color",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sortOrder": {
+              "name": "sortOrder",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "links": {
+              "name": "links",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "SubCategories",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "subCategoriesBySubCategoryId",
+                "queryField": "listSubCategoryBySubCategoryId",
+                "fields": [
+                  "subCategoryId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "subCategoriesByCategoryId",
+                "queryField": "listSubCategoryByCategoryId",
+                "fields": [
+                  "categoryId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Contaminant": {
+          "name": "Contaminant",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "ContaminantCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "studies": {
+              "name": "studies",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "higherIsBad": {
+              "name": "higherIsBad",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Contaminants",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantsByContaminantId",
+                "queryField": "listContaminantByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "ContaminantThreshold": {
+          "name": "ContaminantThreshold",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "limitValue": {
+              "name": "limitValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "warningRatio": {
+              "name": "warningRatio",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "ContaminantThresholdStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "ContaminantThresholds",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantThresholdsByContaminantId",
+                "queryField": "listContaminantThresholdByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantThresholdsByJurisdictionCode",
+                "queryField": "listContaminantThresholdByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Jurisdiction": {
+          "name": "Jurisdiction",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "code": {
+              "name": "code",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "region": {
+              "name": "region",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "parentCode": {
+              "name": "parentCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isDefault": {
+              "name": "isDefault",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Jurisdictions",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "jurisdictionsByCode",
+                "queryField": "listJurisdictionByCode",
+                "fields": [
+                  "code"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "jurisdictionsByCountry",
+                "queryField": "listJurisdictionByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Location": {
+          "name": "Location",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Locations",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCity",
+                "queryField": "listLocationByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCounty",
+                "queryField": "listLocationByCounty",
+                "fields": [
+                  "county"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByState",
+                "queryField": "listLocationByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCountry",
+                "queryField": "listLocationByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByJurisdictionCode",
+                "queryField": "listLocationByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationMeasurement": {
+          "name": "LocationMeasurement",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "measuredAt": {
+              "name": "measuredAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sourceUrl": {
+              "name": "sourceUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "silentImport": {
+              "name": "silentImport",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationMeasurements",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByCity",
+                "queryField": "listLocationMeasurementByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByState",
+                "queryField": "listLocationMeasurementByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByCountry",
+                "queryField": "listLocationMeasurementByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByContaminantId",
+                "queryField": "listLocationMeasurementByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "UserSubscription": {
+          "name": "UserSubscription",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "enablePush": {
+              "name": "enablePush",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "enableEmail": {
+              "name": "enableEmail",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnDanger": {
+              "name": "alertOnDanger",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnWarning": {
+              "name": "alertOnWarning",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnAnyChange": {
+              "name": "alertOnAnyChange",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "watchContaminants": {
+              "name": "watchContaminants",
+              "isArray": true,
+              "type": "String",
+              "isRequired": false,
+              "attributes": [],
+              "isArrayNullable": true
+            },
+            "notifyWhenDataAvailable": {
+              "name": "notifyWhenDataAvailable",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "expoPushToken": {
+              "name": "expoPushToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "UserSubscriptions",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByCity",
+                "queryField": "listUserSubscriptionByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByState",
+                "queryField": "listUserSubscriptionByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByCountry",
+                "queryField": "listUserSubscriptionByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "identityClaim": "cognito:username",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "NotificationLog": {
+          "name": "NotificationLog",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "subscriptionId": {
+              "name": "subscriptionId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "userId": {
+              "name": "userId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "type": {
+              "name": "type",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "title": {
+              "name": "title",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "body": {
+              "name": "body",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sentAt": {
+              "name": "sentAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "deliveredAt": {
+              "name": "deliveredAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "triggerType": {
+              "name": "triggerType",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogTriggerType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "NotificationLogs",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "notificationLogsByUserId",
+                "queryField": "listNotificationLogByUserId",
+                "fields": [
+                  "userId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "notificationLogsByCity",
+                "queryField": "listNotificationLogByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "HazardReport": {
+          "name": "HazardReport",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "HazardReportCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "location": {
+              "name": "location",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "HazardReportStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "adminNotes": {
+              "name": "adminNotes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "HazardReports",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "operations": [
+                      "create",
+                      "read"
+                    ],
+                    "identityClaim": "cognito:username"
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationVisit": {
+          "name": "LocationVisit",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "visitedAt": {
+              "name": "visitedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationVisits",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "WarningBanner": {
+          "name": "WarningBanner",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "title": {
+              "name": "title",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "titleFr": {
+              "name": "titleFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "severity": {
+              "name": "severity",
+              "isArray": false,
+              "type": {
+                "enum": "WarningBannerSeverity"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "startsAt": {
+              "name": "startsAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "expiresAt": {
+              "name": "expiresAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdBy": {
+              "name": "createdBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "WarningBanners",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "AppConfig": {
+          "name": "AppConfig",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "configKey": {
+              "name": "configKey",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "isEnabled": {
+              "name": "isEnabled",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "AppConfigs",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "appConfigsByConfigKey",
+                "queryField": "listAppConfigByConfigKey",
+                "fields": [
+                  "configKey"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LandingPageContent": {
+          "name": "LandingPageContent",
+          "fields": {
+            "locale": {
+              "name": "locale",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "content": {
+              "name": "content",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": true,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LandingPageContents",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "locale"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "locale",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LandingTheme": {
+          "name": "LandingTheme",
+          "fields": {
+            "key": {
+              "name": "key",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "tokens": {
+              "name": "tokens",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": true,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LandingThemes",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "key"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "key",
+            "sortKeyFieldNames": []
+          }
+        },
+        "PollutionSource": {
+          "name": "PollutionSource",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sourceId": {
+              "name": "sourceId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sourceType": {
+              "name": "sourceType",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceSourceType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "impactRadius": {
+              "name": "impactRadius",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "address": {
+              "name": "address",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "primaryContaminants": {
+              "name": "primaryContaminants",
+              "isArray": true,
+              "type": "String",
+              "isRequired": false,
+              "attributes": [],
+              "isArrayNullable": true
+            },
+            "severityLevel": {
+              "name": "severityLevel",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceSeverityLevel"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "reportedAt": {
+              "name": "reportedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "reportedBy": {
+              "name": "reportedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "PollutionSources",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByCity",
+                "queryField": "listPollutionSourceByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByState",
+                "queryField": "listPollutionSourceByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByCountry",
+                "queryField": "listPollutionSourceByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "NewsletterSubscriber": {
+          "name": "NewsletterSubscriber",
+          "fields": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "AWSEmail",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zip": {
+              "name": "zip",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "confirmed": {
+              "name": "confirmed",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "confirmationCode": {
+              "name": "confirmationCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "NewsletterSubscribers",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "email"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "newsletterSubscribersBySource",
+                "queryField": "listNewsletterSubscriberBySource",
+                "fields": [
+                  "source"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "newsletterSubscribersByConfirmationCode",
+                "queryField": "listNewsletterSubscriberByConfirmationCode",
+                "fields": [
+                  "confirmationCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "update",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "email",
+            "sortKeyFieldNames": []
+          }
+        },
+        "ObservedProperty": {
+          "name": "ObservedProperty",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "ObservedPropertyCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "observationType": {
+              "name": "observationType",
+              "isArray": false,
+              "type": {
+                "enum": "ObservedPropertyObservationType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "higherIsBad": {
+              "name": "higherIsBad",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "metadata": {
+              "name": "metadata",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "ObservedProperties",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "observedPropertiesByPropertyId",
+                "queryField": "listObservedPropertyByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "observedPropertiesByCategory",
+                "queryField": "listObservedPropertyByCategory",
+                "fields": [
+                  "category"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "PropertyThreshold": {
+          "name": "PropertyThreshold",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "limitValue": {
+              "name": "limitValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "warningValue": {
+              "name": "warningValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zoneMapping": {
+              "name": "zoneMapping",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "endemicIsDanger": {
+              "name": "endemicIsDanger",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceWarningThreshold": {
+              "name": "incidenceWarningThreshold",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceDangerThreshold": {
+              "name": "incidenceDangerThreshold",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "PropertyThresholdStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "PropertyThresholds",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "propertyThresholdsByPropertyId",
+                "queryField": "listPropertyThresholdByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "propertyThresholdsByJurisdictionCode",
+                "queryField": "listPropertyThresholdByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationObservation": {
+          "name": "LocationObservation",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "numericValue": {
+              "name": "numericValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zoneValue": {
+              "name": "zoneValue",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "endemicValue": {
+              "name": "endemicValue",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceValue": {
+              "name": "incidenceValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "binaryValue": {
+              "name": "binaryValue",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "observedAt": {
+              "name": "observedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "validUntil": {
+              "name": "validUntil",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sourceUrl": {
+              "name": "sourceUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "rawData": {
+              "name": "rawData",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationObservations",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByCity",
+                "queryField": "listLocationObservationByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByState",
+                "queryField": "listLocationObservationByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByCountry",
+                "queryField": "listLocationObservationByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByPropertyId",
+                "queryField": "listLocationObservationByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        }
+      },
+      "enums": {
+        "ManageDataAction": {
+          "name": "ManageDataAction",
+          "values": [
+            "wipeContaminants",
+            "wipeLocations",
+            "wipeAll",
+            "reseedAll"
+          ]
+        },
+        "HealthRecordType": {
+          "name": "HealthRecordType",
+          "values": [
+            "WEIGHT",
+            "BLOOD_PRESSURE",
+            "HEART_RATE",
+            "BLOOD_SUGAR",
+            "STEPS",
+            "SLEEP",
+            "OTHER"
+          ]
+        },
+        "ContaminantCategory": {
+          "name": "ContaminantCategory",
+          "values": [
+            "fertilizer",
+            "pesticide",
+            "radioactive",
+            "disinfectant",
+            "inorganic",
+            "organic",
+            "microbiological"
+          ]
+        },
+        "ContaminantThresholdStatus": {
+          "name": "ContaminantThresholdStatus",
+          "values": [
+            "regulated",
+            "banned",
+            "not_approved",
+            "not_controlled"
+          ]
+        },
+        "NotificationLogType": {
+          "name": "NotificationLogType",
+          "values": [
+            "push",
+            "email"
+          ]
+        },
+        "NotificationLogStatus": {
+          "name": "NotificationLogStatus",
+          "values": [
+            "pending",
+            "sent",
+            "failed",
+            "delivered"
+          ]
+        },
+        "NotificationLogTriggerType": {
+          "name": "NotificationLogTriggerType",
+          "values": [
+            "data_update",
+            "data_available",
+            "status_change",
+            "manual_alert"
+          ]
+        },
+        "HazardReportCategory": {
+          "name": "HazardReportCategory",
+          "values": [
+            "water",
+            "air",
+            "health",
+            "disaster"
+          ]
+        },
+        "HazardReportStatus": {
+          "name": "HazardReportStatus",
+          "values": [
+            "pending",
+            "reviewed",
+            "resolved",
+            "dismissed"
+          ]
+        },
+        "WarningBannerSeverity": {
+          "name": "WarningBannerSeverity",
+          "values": [
+            "critical",
+            "warning",
+            "info"
+          ]
+        },
+        "PollutionSourceSourceType": {
+          "name": "PollutionSourceSourceType",
+          "values": [
+            "industrial",
+            "agricultural",
+            "waste_site",
+            "spill",
+            "mining",
+            "transportation",
+            "construction",
+            "other"
+          ]
+        },
+        "PollutionSourceSeverityLevel": {
+          "name": "PollutionSourceSeverityLevel",
+          "values": [
+            "low",
+            "moderate",
+            "high",
+            "critical"
+          ]
+        },
+        "PollutionSourceStatus": {
+          "name": "PollutionSourceStatus",
+          "values": [
+            "active",
+            "monitored",
+            "remediated",
+            "closed"
+          ]
+        },
+        "ObservedPropertyCategory": {
+          "name": "ObservedPropertyCategory",
+          "values": [
+            "water_quality",
+            "air_quality",
+            "disease",
+            "radiation",
+            "soil",
+            "noise",
+            "climate",
+            "infrastructure"
+          ]
+        },
+        "ObservedPropertyObservationType": {
+          "name": "ObservedPropertyObservationType",
+          "values": [
+            "numeric",
+            "zone",
+            "endemic",
+            "incidence",
+            "binary"
+          ]
+        },
+        "PropertyThresholdStatus": {
+          "name": "PropertyThresholdStatus",
+          "values": [
+            "active",
+            "historical",
+            "not_applicable"
+          ]
+        }
+      },
+      "nonModels": {
+        "PlacesPrediction": {
+          "name": "PlacesPrediction",
+          "fields": {
+            "place_id": {
+              "name": "place_id",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "main_text": {
+              "name": "main_text",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "secondary_text": {
+              "name": "secondary_text",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "PlacesAutocompleteResponse": {
+          "name": "PlacesAutocompleteResponse",
+          "fields": {
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "predictions": {
+              "name": "predictions",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lat": {
+              "name": "lat",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lng": {
+              "name": "lng",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "cached": {
+              "name": "cached",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ResolveLocationResponse": {
+          "name": "ResolveLocationResponse",
+          "fields": {
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "hasData": {
+              "name": "hasData",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "isNew": {
+              "name": "isNew",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ManageDataResponse": {
+          "name": "ManageDataResponse",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "action": {
+              "name": "action",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "details": {
+              "name": "details",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "tablesAffected": {
+              "name": "tablesAffected",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "recordCount": {
+              "name": "recordCount",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": true,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "DeleteAccountDataReturnType": {
+          "name": "DeleteAccountDataReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "deletedCounts": {
+              "name": "deletedCounts",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "SubscribeToNewsletterReturnType": {
+          "name": "SubscribeToNewsletterReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ConfirmNewsletterReturnType": {
+          "name": "ConfirmNewsletterReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ResendConfirmationReturnType": {
+          "name": "ResendConfirmationReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        }
+      },
+      "queries": {
+        "placesAutocomplete": {
+          "name": "placesAutocomplete",
+          "isArray": false,
+          "type": {
+            "nonModel": "PlacesAutocompleteResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "query": {
+              "name": "query",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "sessionToken": {
+              "name": "sessionToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        }
+      },
+      "mutations": {
+        "resolveLocation": {
+          "name": "resolveLocation",
+          "isArray": false,
+          "type": {
+            "nonModel": "ResolveLocationResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "placeId": {
+              "name": "placeId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "sessionToken": {
+              "name": "sessionToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false
+            }
+          }
+        },
+        "deleteAccountData": {
+          "name": "deleteAccountData",
+          "isArray": false,
+          "type": {
+            "nonModel": "DeleteAccountDataReturnType"
+          },
+          "isRequired": false
+        },
+        "manageData": {
+          "name": "manageData",
+          "isArray": false,
+          "type": {
+            "nonModel": "ManageDataResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "action": {
+              "name": "action",
+              "isArray": false,
+              "type": {
+                "enum": "ManageDataAction"
+              },
+              "isRequired": false
+            }
+          }
+        },
+        "subscribeToNewsletter": {
+          "name": "subscribeToNewsletter",
+          "isArray": false,
+          "type": {
+            "nonModel": "SubscribeToNewsletterReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "zip": {
+              "name": "zip",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "callbackURL": {
+              "name": "callbackURL",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "lang": {
+              "name": "lang",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        },
+        "confirmNewsletter": {
+          "name": "confirmNewsletter",
+          "isArray": false,
+          "type": {
+            "nonModel": "ConfirmNewsletterReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "confirmationCode": {
+              "name": "confirmationCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            }
+          }
+        },
+        "resendConfirmation": {
+          "name": "resendConfirmation",
+          "isArray": false,
+          "type": {
+            "nonModel": "ResendConfirmationReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "lang": {
+              "name": "lang",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.4",
+  "analytics": {
+    "amazon_pinpoint": {
+      "app_id": "b24826e79d90457ba3b3a33374632a5c",
+      "aws_region": "ca-central-1"
+    }
+  }
+}

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,7 +8,8 @@
   "userInterfaceStyle": "automatic",
   "icon": "./assets/images/app-icon-all.png",
   "updates": {
-    "fallbackToCacheTimeout": 0
+    "fallbackToCacheTimeout": 0,
+    "url": "https://u.expo.dev/2d5329f5-5724-4814-a718-86011c93c9e3"
   },
   "newArchEnabled": true,
   "jsEngine": "hermes",
@@ -39,6 +40,16 @@
     },
     "config": {
       "googleMapsApiKey": ""
+    },
+    "privacyManifests": {
+      "NSPrivacyAccessedAPITypes": [
+        {
+          "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+          "NSPrivacyAccessedAPITypeReasons": [
+            "CA92.1"
+          ]
+        }
+      ]
     }
   },
   "web": {
@@ -79,5 +90,8 @@
     "eas": {
       "projectId": "2d5329f5-5724-4814-a718-86011c93c9e3"
     }
+  },
+  "runtimeVersion": {
+    "policy": "appVersion"
   }
 }

--- a/apps/mobile/app/app.tsx
+++ b/apps/mobile/app/app.tsx
@@ -19,10 +19,17 @@ if (__DEV__) {
 import "./utils/gestureHandler"
 
 import { Amplify } from "aws-amplify"
-import outputs from "../amplify_outputs.json" // eslint-disable-line import/no-unresolved
+import prodOutputs from "../amplify_outputs.json" // eslint-disable-line import/no-unresolved
+import stagingOutputs from "../amplify_outputs.staging.json" // eslint-disable-line import/no-unresolved
+
+import { getEnvOverride } from "./utils/envOverride"
+
+const envOverride = getEnvOverride()
+const outputs = envOverride === "staging" ? stagingOutputs : prodOutputs
 
 if (__DEV__) {
   console.log("=== AMPLIFY CONFIG ===")
+  console.log("Env override:", envOverride)
   console.log("Region:", outputs.auth?.aws_region)
   console.log("GraphQL URL:", outputs.data?.url)
 }

--- a/apps/mobile/app/components/AdminWarningBanner.tsx
+++ b/apps/mobile/app/components/AdminWarningBanner.tsx
@@ -112,10 +112,10 @@ export function AdminWarningBanner(props: AdminWarningBannerProps) {
         <View style={$textContainer}>
           <Text style={themedStyles.labelText}>
             {severity === "critical"
-              ? i18n.t("warningBanner.critical")
+              ? i18n.t("warningBanner:critical")
               : severity === "warning"
-                ? i18n.t("warningBanner.warning")
-                : i18n.t("warningBanner.info")}
+                ? i18n.t("warningBanner:warning")
+                : i18n.t("warningBanner:info")}
           </Text>
           <Text style={themedStyles.titleText}>{title}</Text>
           <Text style={themedStyles.descriptionText}>{description}</Text>

--- a/apps/mobile/app/components/EnvBadge.tsx
+++ b/apps/mobile/app/components/EnvBadge.tsx
@@ -1,0 +1,40 @@
+import { TextStyle, ViewStyle } from "react-native"
+
+import { useAppTheme } from "@/theme/context"
+import type { ThemedStyle } from "@/theme/types"
+import { getEnvOverride } from "@/utils/envOverride"
+
+import { Text } from "./Text"
+
+/**
+ * Renders a small "STAGING" chip when the in-app env override is active.
+ * Reads MMKV synchronously on render, which is fine because the override
+ * only changes via a full bundle reload.
+ */
+export function EnvBadge() {
+  const { themed } = useAppTheme()
+
+  if (getEnvOverride() !== "staging") return null
+
+  return (
+    <Text
+      text="STAGING BACKEND"
+      style={themed($badge)}
+      size="xxs"
+      weight="semiBold"
+      testID="env-badge"
+    />
+  )
+}
+
+const $badge: ThemedStyle<ViewStyle & TextStyle> = ({ colors, spacing }) => ({
+  alignSelf: "center",
+  backgroundColor: colors.palette.statusWarningBg,
+  borderRadius: 6,
+  color: colors.palette.offlineText,
+  letterSpacing: 1,
+  marginBottom: spacing.sm,
+  overflow: "hidden",
+  paddingHorizontal: spacing.sm,
+  paddingVertical: spacing.xxs,
+})

--- a/apps/mobile/app/components/EnvSwitchDialog.tsx
+++ b/apps/mobile/app/components/EnvSwitchDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react"
+import { DevSettings, Modal, Pressable, StyleSheet, View } from "react-native"
+import * as Updates from "expo-updates"
+import { signOut } from "aws-amplify/auth"
+import { Divider, IconButton } from "react-native-paper"
+
+import { useAppTheme } from "@/theme/context"
+import type { AppEnv } from "@/utils/envOverride"
+import { getEnvOverride, setEnvOverride } from "@/utils/envOverride"
+
+import { Button } from "./Button"
+import { infoModalStyles as styles } from "./infoModalStyles"
+import { Text } from "./Text"
+
+interface EnvSwitchDialogProps {
+  visible: boolean
+  onClose: () => void
+}
+
+const ENV_LABEL: Record<AppEnv, string> = {
+  prod: "PROD",
+  staging: "STAGING",
+}
+
+export function EnvSwitchDialog({ visible, onClose }: EnvSwitchDialogProps) {
+  const { theme } = useAppTheme()
+  const [isSwitching, setIsSwitching] = useState(false)
+
+  const current = getEnvOverride()
+  const target: AppEnv = current === "staging" ? "prod" : "staging"
+
+  async function handleConfirm() {
+    setIsSwitching(true)
+    try {
+      try {
+        await signOut()
+      } catch {
+        // user may not be signed in — best effort.
+      }
+      setEnvOverride(target)
+      if (__DEV__) {
+        DevSettings.reload()
+      } else {
+        await Updates.reloadAsync()
+      }
+    } finally {
+      setIsSwitching(false)
+    }
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable
+          style={[styles.container, { backgroundColor: theme.colors.background }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.header}>
+            <Text
+              style={[styles.title, { color: theme.colors.text }]}
+              text="Switch backend environment?"
+            />
+            <IconButton icon="close" size={24} onPress={onClose} disabled={isSwitching} />
+          </View>
+
+          <Divider />
+
+          <View style={styles.content}>
+            <View style={styles.section}>
+              <Text
+                style={[styles.sectionTitle, { color: theme.colors.tint }]}
+                text={`Currently: ${ENV_LABEL[current]}  →  ${ENV_LABEL[target]}`}
+              />
+              <Text
+                style={[styles.body, { color: theme.colors.text }]}
+                text={
+                  target === "staging"
+                    ? "The app will restart and connect to the STAGING backend. Sign in with staging credentials. Production data will not be visible until you switch back."
+                    : "The app will restart and connect to the PRODUCTION backend. Sign in with your normal credentials."
+                }
+              />
+            </View>
+
+            <Button
+              text={isSwitching ? "Restarting..." : `Switch to ${ENV_LABEL[target]} & restart`}
+              preset="reversed"
+              onPress={handleConfirm}
+              disabled={isSwitching}
+              testID="env-switch-confirm-button"
+            />
+            <View style={localStyles.cancelSpacing} />
+            <Button
+              text="Cancel"
+              preset="default"
+              onPress={onClose}
+              disabled={isSwitching}
+              testID="env-switch-cancel-button"
+            />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const localStyles = StyleSheet.create({
+  cancelSpacing: {
+    height: 8,
+  },
+})

--- a/apps/mobile/app/components/SecretEnvTrigger.tsx
+++ b/apps/mobile/app/components/SecretEnvTrigger.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useCallback, useRef } from "react"
+import { Pressable, StyleProp, ViewStyle } from "react-native"
+
+const REQUIRED_TAPS = 5
+const WINDOW_MS = 3000
+
+interface SecretEnvTriggerProps {
+  children: ReactNode
+  onTrigger: () => void
+  style?: StyleProp<ViewStyle>
+  testID?: string
+}
+
+/**
+ * Counts taps on its child and fires `onTrigger` once REQUIRED_TAPS happen
+ * within WINDOW_MS. Resets on success or after a quiet window. Has no visible
+ * UI of its own — it inherits whatever the children draw.
+ *
+ * Used to gate the hidden staging-backend switch behind a 5-tap gesture so
+ * end-users can't trip it accidentally.
+ */
+export function SecretEnvTrigger({ children, onTrigger, style, testID }: SecretEnvTriggerProps) {
+  const tapCount = useRef(0)
+  const firstTapAt = useRef(0)
+
+  const handlePress = useCallback(() => {
+    const now = Date.now()
+    if (tapCount.current === 0 || now - firstTapAt.current > WINDOW_MS) {
+      tapCount.current = 1
+      firstTapAt.current = now
+      return
+    }
+    tapCount.current += 1
+    if (tapCount.current >= REQUIRED_TAPS) {
+      tapCount.current = 0
+      firstTapAt.current = 0
+      onTrigger()
+    }
+  }, [onTrigger])
+
+  return (
+    <Pressable onPress={handlePress} style={style} testID={testID}>
+      {children}
+    </Pressable>
+  )
+}

--- a/apps/mobile/app/screens/ComingSoonScreen.tsx
+++ b/apps/mobile/app/screens/ComingSoonScreen.tsx
@@ -5,11 +5,14 @@
  * Authenticated users bypass this screen entirely via the navigator.
  */
 
-import { FC } from "react"
+import { FC, useState } from "react"
 import { TextStyle, View, ViewStyle } from "react-native"
 
 import { AnimatedLogo } from "@/components/AnimatedLogo"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { useAppTheme } from "@/theme/context"
 import type { ThemedStyle } from "@/theme/types"
@@ -18,11 +21,22 @@ interface ComingSoonScreenProps {}
 
 export const ComingSoonScreen: FC<ComingSoonScreenProps> = function ComingSoonScreen() {
   const { themed } = useAppTheme()
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
 
   return (
     <Screen preset="fixed" safeAreaEdges={["top", "bottom"]} contentContainerStyle={themed($root)}>
       <View style={themed($topSection)}>
-        <AnimatedLogo size={140} style={themed($logo)} />
+        <EnvBadge />
+        {/* Hidden 5-tap gesture on the logo opens the staging-backend switcher.
+            Critical for QA on prod-feature-gated builds where the rest of the
+            app is hidden behind this screen. */}
+        <SecretEnvTrigger
+          onTrigger={() => setEnvDialogOpen(true)}
+          style={themed($logo)}
+          testID="coming-soon-secret-env-trigger"
+        >
+          <AnimatedLogo size={140} />
+        </SecretEnvTrigger>
         <Text tx="comingSoonScreen:heading" preset="heading" style={themed($heading)} />
         <Text tx="comingSoonScreen:preparing" style={themed($preparing)} size="md" />
       </View>
@@ -30,6 +44,8 @@ export const ComingSoonScreen: FC<ComingSoonScreenProps> = function ComingSoonSc
       <View style={themed($bottomSection)}>
         <Text tx="comingSoonScreen:description" style={themed($description)} size="sm" />
       </View>
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -579,6 +579,18 @@ View details: ${shareUrl}`
     marginTop: 8,
   }
 
+  // Admin warning banners — rendered in every branch (populated, empty-data,
+  // error) so emergency advisories reach users for cities that haven't been
+  // seeded with measurement data yet, not just on populated dashboards.
+  const adminBannersJsx =
+    adminBanners.length > 0
+      ? adminBanners.map((banner) => (
+          <View key={banner.id} style={$warningBannerContainer}>
+            <AdminWarningBanner banner={banner} />
+          </View>
+        ))
+      : null
+
   // Empty state for guests - prompt to search for a location
   if (!currentLocation) {
     return (
@@ -674,6 +686,7 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        {adminBannersJsx}
         <View style={$emptyStateContainer}>
           <MaterialCommunityIcons name="wifi-off" size={64} color={theme.colors.textDim} />
           <Text style={$emptyStateTitle}>Unable to load data</Text>
@@ -724,6 +737,7 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        {adminBannersJsx}
         {/* Pollution Sources Card — gated on a real location to avoid landing on
             an empty PollutionSourcesScreen when no city/state is set. */}
         {currentLocation && renderPollutionSourcesCard()}
@@ -900,12 +914,7 @@ View details: ${shareUrl}`
       </View>
 
       {/* Admin Warning Banners */}
-      {adminBanners.length > 0 &&
-        adminBanners.map((banner) => (
-          <View key={banner.id} style={$warningBannerContainer}>
-            <AdminWarningBanner banner={banner} />
-          </View>
-        ))}
+      {adminBannersJsx}
 
       {/* Category Cards */}
       <View style={$categoriesContainer}>

--- a/apps/mobile/app/screens/LoginScreen.tsx
+++ b/apps/mobile/app/screens/LoginScreen.tsx
@@ -14,7 +14,7 @@ import {
   View,
   ViewStyle,
 } from "react-native"
-import { signIn } from "aws-amplify/auth"
+import { confirmSignIn, signIn } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
 import { Header } from "@/components/Header"
@@ -27,7 +27,18 @@ import { usePendingAction } from "@/context/PendingActionContext"
 import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { useAppTheme } from "@/theme/context"
 import type { ThemedStyle } from "@/theme/types"
-import { getLoginErrorMessage, isUnconfirmedUserError } from "@/utils/authErrors"
+import {
+  getLoginErrorMessage,
+  getNewPasswordErrorMessage,
+  isUnconfirmedUserError,
+} from "@/utils/authErrors"
+
+/**
+ * Auth flow phase. Most users only see SIGN_IN; admin-invited users land
+ * on NEW_PASSWORD_REQUIRED after their first sign-in with a Cognito
+ * temp password (Cognito user state FORCE_CHANGE_PASSWORD).
+ */
+type AuthStep = "SIGN_IN" | "NEW_PASSWORD_REQUIRED"
 
 interface LoginScreenProps extends AppStackScreenProps<"Login"> {}
 
@@ -44,6 +55,18 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
   const [emailError, setEmailError] = useState("")
   const [passwordError, setPasswordError] = useState("")
   const [generalError, setGeneralError] = useState("")
+
+  // New-password sub-form state. Only meaningful when authStep is
+  // NEW_PASSWORD_REQUIRED (after Cognito raises the
+  // CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED challenge).
+  const [authStep, setAuthStep] = useState<AuthStep>("SIGN_IN")
+  const [newPassword, setNewPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [isNewPasswordHidden, setIsNewPasswordHidden] = useState(true)
+  const [isConfirmPasswordHidden, setIsConfirmPasswordHidden] = useState(true)
+  const [newPasswordError, setNewPasswordError] = useState("")
+  const [confirmPasswordError, setConfirmPasswordError] = useState("")
+  const confirmPasswordInput = useRef<TextInput>(null)
 
   const { refreshAuthState } = useAuth()
   const { pendingAction, executePendingAction } = usePendingAction()
@@ -84,6 +107,27 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
     return true
   }
 
+  // Shared post-sign-in side effects. Used after the standard signIn()
+  // returns isSignedIn=true and again after confirmSignIn resolves the
+  // FORCE_CHANGE_PASSWORD challenge with nextStep="DONE".
+  async function finishSignIn() {
+    await refreshAuthState()
+    await executePendingAction()
+    navigation.navigate("Dashboard")
+  }
+
+  // Reset the new-password sub-form back to the sign-in form. Triggered
+  // by the "Back to sign in" link and by the Header back button so the
+  // user can't escape mid-challenge into a half-completed state.
+  function resetToSignIn() {
+    setAuthStep("SIGN_IN")
+    setNewPassword("")
+    setConfirmPassword("")
+    setNewPasswordError("")
+    setConfirmPasswordError("")
+    setGeneralError("")
+  }
+
   async function handleLogin() {
     setGeneralError("")
     const isEmailValid = validateEmail(email)
@@ -98,15 +142,17 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
       const result = await signIn({ username: email, password })
 
       if (result.isSignedIn) {
-        // Refresh auth state to update the navigator
-        await refreshAuthState()
-        // Execute any pending action (e.g., follow location from guest flow)
-        await executePendingAction()
-        // Navigate back to Dashboard
-        navigation.navigate("Dashboard")
+        await finishSignIn()
       } else if (result.nextStep?.signInStep === "CONFIRM_SIGN_UP") {
         // User hasn't confirmed their email yet
         navigation.navigate("ConfirmSignup", { email })
+      } else if (result.nextStep?.signInStep === "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED") {
+        // Admin-invited user (FORCE_CHANGE_PASSWORD): switch to the
+        // new-password sub-form. Clear the password field so the temp
+        // password isn't reused or visible. Mirrors the admin portal
+        // flow at apps/admin/src/app/login/page.tsx:157-158.
+        setPassword("")
+        setAuthStep("NEW_PASSWORD_REQUIRED")
       } else {
         // Handle other sign-in steps if needed
         setGeneralError(`Additional step required: ${result.nextStep?.signInStep}`)
@@ -119,6 +165,42 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
       if (isUnconfirmedUserError(error)) {
         navigation.navigate("ConfirmSignup", { email })
       }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  function validateNewPassword(): boolean {
+    let ok = true
+    if (newPassword.length < 8) {
+      setNewPasswordError("Password must be at least 8 characters")
+      ok = false
+    } else {
+      setNewPasswordError("")
+    }
+    if (confirmPassword !== newPassword) {
+      setConfirmPasswordError("Passwords do not match")
+      ok = false
+    } else {
+      setConfirmPasswordError("")
+    }
+    return ok
+  }
+
+  async function handleNewPassword() {
+    setGeneralError("")
+    if (!validateNewPassword()) return
+
+    setIsSubmitting(true)
+    try {
+      const result = await confirmSignIn({ challengeResponse: newPassword })
+      if (result.nextStep?.signInStep === "DONE") {
+        await finishSignIn()
+      } else {
+        setGeneralError(`Additional step required: ${result.nextStep?.signInStep}`)
+      }
+    } catch (error) {
+      setGeneralError(getNewPasswordErrorMessage(error))
     } finally {
       setIsSubmitting(false)
     }
@@ -140,120 +222,248 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
     [isPasswordHidden, colors.palette.neutral800],
   )
 
+  const NewPasswordRightAccessory: ComponentType<TextFieldAccessoryProps> = useMemo(
+    () =>
+      function NewPasswordRightAccessory(props: TextFieldAccessoryProps) {
+        return (
+          <PressableIcon
+            icon={isNewPasswordHidden ? "view" : "hidden"}
+            color={colors.palette.neutral800}
+            containerStyle={props.style}
+            size={20}
+            onPress={() => setIsNewPasswordHidden(!isNewPasswordHidden)}
+          />
+        )
+      },
+    [isNewPasswordHidden, colors.palette.neutral800],
+  )
+
+  const ConfirmPasswordRightAccessory: ComponentType<TextFieldAccessoryProps> = useMemo(
+    () =>
+      function ConfirmPasswordRightAccessory(props: TextFieldAccessoryProps) {
+        return (
+          <PressableIcon
+            icon={isConfirmPasswordHidden ? "view" : "hidden"}
+            color={colors.palette.neutral800}
+            containerStyle={props.style}
+            size={20}
+            onPress={() => setIsConfirmPasswordHidden(!isConfirmPasswordHidden)}
+          />
+        )
+      },
+    [isConfirmPasswordHidden, colors.palette.neutral800],
+  )
+
   return (
     <Screen
       preset="auto"
       contentContainerStyle={themed($screenContentContainer)}
       safeAreaEdges={["top", "bottom"]}
     >
-      <Header title="" leftIcon="back" onLeftPress={() => navigation.goBack()} safeAreaEdges={[]} />
+      <Header
+        title=""
+        leftIcon="back"
+        onLeftPress={() => {
+          // While on the new-password sub-form, the back button must
+          // reset the local state instead of navigating away — otherwise
+          // the user is left in a half-completed FORCE_CHANGE_PASSWORD
+          // session with no way to recover other than killing the app.
+          if (authStep === "NEW_PASSWORD_REQUIRED") {
+            resetToSignIn()
+          } else {
+            navigation.goBack()
+          }
+        }}
+        safeAreaEdges={[]}
+      />
 
       {/* Welcome Icon */}
       <View style={themed($iconContainer)}>
         <Icon icon="lock" size={32} color={colors.tint} />
       </View>
 
-      <Text text="Welcome Back" preset="heading" style={themed($heading)} />
-      {pendingAction && (
-        <Text
-          text="Sign in to complete your action"
-          preset="formHelper"
-          style={themed($pendingActionHint)}
-        />
+      {authStep === "NEW_PASSWORD_REQUIRED" ? (
+        <>
+          <Text text="Set a new password" preset="heading" style={themed($heading)} />
+          <Text
+            text="Your account requires a password change to continue. Choose a password you'll use from now on."
+            style={themed($subheading)}
+            size="sm"
+          />
+
+          {generalError ? (
+            <View style={themed($errorContainer)}>
+              <Text text={generalError} style={themed($errorText)} size="sm" />
+            </View>
+          ) : null}
+
+          <TextField
+            value={newPassword}
+            onChangeText={(text) => {
+              setNewPassword(text)
+              if (newPasswordError) setNewPasswordError("")
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="new-password"
+            autoCorrect={false}
+            secureTextEntry={isNewPasswordHidden}
+            label="New password"
+            placeholder="At least 8 characters"
+            helper={newPasswordError}
+            status={newPasswordError ? "error" : undefined}
+            onSubmitEditing={() => confirmPasswordInput.current?.focus()}
+            RightAccessory={NewPasswordRightAccessory}
+            testID="new-password-input"
+          />
+
+          <TextField
+            ref={confirmPasswordInput}
+            value={confirmPassword}
+            onChangeText={(text) => {
+              setConfirmPassword(text)
+              if (confirmPasswordError) setConfirmPasswordError("")
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="new-password"
+            autoCorrect={false}
+            secureTextEntry={isConfirmPasswordHidden}
+            label="Confirm new password"
+            placeholder="Re-enter the new password"
+            helper={confirmPasswordError}
+            status={confirmPasswordError ? "error" : undefined}
+            onSubmitEditing={handleNewPassword}
+            RightAccessory={ConfirmPasswordRightAccessory}
+            testID="confirm-new-password-input"
+          />
+
+          <Button
+            text={isSubmitting ? "Setting password..." : "Set password and continue"}
+            style={themed($loginButton)}
+            preset="reversed"
+            onPress={handleNewPassword}
+            disabled={isSubmitting}
+            testID="new-password-submit-button"
+          />
+
+          <Pressable onPress={resetToSignIn} style={themed($forgotPasswordLink)}>
+            <Text
+              text="Back to sign in"
+              style={themed($forgotPasswordText)}
+              size="xs"
+              testID="new-password-back-to-sign-in"
+            />
+          </Pressable>
+        </>
+      ) : (
+        <>
+          <Text text="Welcome Back" preset="heading" style={themed($heading)} />
+          {pendingAction && (
+            <Text
+              text="Sign in to complete your action"
+              preset="formHelper"
+              style={themed($pendingActionHint)}
+            />
+          )}
+          <Text
+            text="Sign in to access your safety alerts and subscriptions"
+            style={themed($subheading)}
+            size="sm"
+          />
+
+          {generalError ? (
+            <View style={themed($errorContainer)}>
+              <Text text={generalError} style={themed($errorText)} size="sm" />
+            </View>
+          ) : null}
+
+          <TextField
+            value={email}
+            onChangeText={(text) => {
+              setEmail(text)
+              if (emailError) validateEmail(text)
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="email"
+            autoCorrect={false}
+            keyboardType="email-address"
+            label="Email"
+            placeholder="Enter your email"
+            helper={emailError}
+            status={emailError ? "error" : undefined}
+            onSubmitEditing={() => passwordInput.current?.focus()}
+            testID="login-email-input"
+          />
+
+          <TextField
+            ref={passwordInput}
+            value={password}
+            onChangeText={(text) => {
+              setPassword(text)
+              if (passwordError) validatePassword(text)
+            }}
+            containerStyle={themed($textField)}
+            autoCapitalize="none"
+            autoComplete="password"
+            autoCorrect={false}
+            secureTextEntry={isPasswordHidden}
+            label="Password"
+            placeholder="Enter your password"
+            helper={passwordError}
+            status={passwordError ? "error" : undefined}
+            onSubmitEditing={handleLogin}
+            RightAccessory={PasswordRightAccessory}
+            testID="login-password-input"
+          />
+
+          {/* Forgot Password Link */}
+          <Pressable
+            onPress={() => navigation.navigate("ForgotPassword")}
+            style={themed($forgotPasswordLink)}
+          >
+            <Text text="Forgot password?" style={themed($forgotPasswordText)} size="xs" />
+          </Pressable>
+
+          {/* Primary Sign In Button */}
+          <Button
+            text={isSubmitting ? "Signing In..." : "Sign In"}
+            style={themed($loginButton)}
+            preset="reversed"
+            onPress={handleLogin}
+            disabled={isSubmitting}
+            testID="login-submit-button"
+          />
+
+          {/* Divider */}
+          <View style={themed($dividerContainer)}>
+            <View style={themed($dividerLine)} />
+            <Text text="or" style={themed($dividerText)} size="xs" />
+            <View style={themed($dividerLine)} />
+          </View>
+
+          {/* Magic Link Button */}
+          <Button
+            text="Sign in with email link"
+            style={themed($magicLinkButton)}
+            preset="default"
+            textStyle={themed($magicLinkText)}
+            onPress={() => navigation.navigate("MagicLink")}
+          />
+        </>
       )}
-      <Text
-        text="Sign in to access your safety alerts and subscriptions"
-        style={themed($subheading)}
-        size="sm"
-      />
 
-      {generalError ? (
-        <View style={themed($errorContainer)}>
-          <Text text={generalError} style={themed($errorText)} size="sm" />
+      {/* Sign Up Link — hidden during NEW_PASSWORD_REQUIRED so the
+          user isn't tempted to abandon a forced-change session. */}
+      {authStep === "SIGN_IN" && (
+        <View style={themed($signupContainer)}>
+          <Text text="Don't have an account? " style={themed($signupText)} size="sm" />
+          <Pressable onPress={() => navigation.navigate("Signup")}>
+            <Text text="Sign up" style={themed($signupLink)} size="sm" weight="semiBold" />
+          </Pressable>
         </View>
-      ) : null}
-
-      <TextField
-        value={email}
-        onChangeText={(text) => {
-          setEmail(text)
-          if (emailError) validateEmail(text)
-        }}
-        containerStyle={themed($textField)}
-        autoCapitalize="none"
-        autoComplete="email"
-        autoCorrect={false}
-        keyboardType="email-address"
-        label="Email"
-        placeholder="Enter your email"
-        helper={emailError}
-        status={emailError ? "error" : undefined}
-        onSubmitEditing={() => passwordInput.current?.focus()}
-        testID="login-email-input"
-      />
-
-      <TextField
-        ref={passwordInput}
-        value={password}
-        onChangeText={(text) => {
-          setPassword(text)
-          if (passwordError) validatePassword(text)
-        }}
-        containerStyle={themed($textField)}
-        autoCapitalize="none"
-        autoComplete="password"
-        autoCorrect={false}
-        secureTextEntry={isPasswordHidden}
-        label="Password"
-        placeholder="Enter your password"
-        helper={passwordError}
-        status={passwordError ? "error" : undefined}
-        onSubmitEditing={handleLogin}
-        RightAccessory={PasswordRightAccessory}
-        testID="login-password-input"
-      />
-
-      {/* Forgot Password Link */}
-      <Pressable
-        onPress={() => navigation.navigate("ForgotPassword")}
-        style={themed($forgotPasswordLink)}
-      >
-        <Text text="Forgot password?" style={themed($forgotPasswordText)} size="xs" />
-      </Pressable>
-
-      {/* Primary Sign In Button */}
-      <Button
-        text={isSubmitting ? "Signing In..." : "Sign In"}
-        style={themed($loginButton)}
-        preset="reversed"
-        onPress={handleLogin}
-        disabled={isSubmitting}
-        testID="login-submit-button"
-      />
-
-      {/* Divider */}
-      <View style={themed($dividerContainer)}>
-        <View style={themed($dividerLine)} />
-        <Text text="or" style={themed($dividerText)} size="xs" />
-        <View style={themed($dividerLine)} />
-      </View>
-
-      {/* Magic Link Button */}
-      <Button
-        text="Sign in with email link"
-        style={themed($magicLinkButton)}
-        preset="default"
-        textStyle={themed($magicLinkText)}
-        onPress={() => navigation.navigate("MagicLink")}
-      />
-
-      {/* Sign Up Link */}
-      <View style={themed($signupContainer)}>
-        <Text text="Don't have an account? " style={themed($signupText)} size="sm" />
-        <Pressable onPress={() => navigation.navigate("Signup")}>
-          <Text text="Sign up" style={themed($signupLink)} size="sm" weight="semiBold" />
-        </Pressable>
-      </View>
+      )}
     </Screen>
   )
 }

--- a/apps/mobile/app/screens/LoginScreen.tsx
+++ b/apps/mobile/app/screens/LoginScreen.tsx
@@ -17,9 +17,12 @@ import {
 import { confirmSignIn, signIn } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Header } from "@/components/Header"
 import { Icon, PressableIcon } from "@/components/Icon"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { TextField, type TextFieldAccessoryProps } from "@/components/TextField"
 import { useAuth } from "@/context/AuthContext"
@@ -60,6 +63,7 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
   // NEW_PASSWORD_REQUIRED (after Cognito raises the
   // CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED challenge).
   const [authStep, setAuthStep] = useState<AuthStep>("SIGN_IN")
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isNewPasswordHidden, setIsNewPasswordHidden] = useState(true)
@@ -277,10 +281,18 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
         safeAreaEdges={[]}
       />
 
-      {/* Welcome Icon */}
-      <View style={themed($iconContainer)}>
+      <EnvBadge />
+
+      {/* Welcome Icon — hidden 5-tap gesture opens the staging-backend switcher.
+          Mounted above the authStep branch so the same trigger covers both the
+          SIGN_IN form and the NEW_PASSWORD_REQUIRED admin gate. */}
+      <SecretEnvTrigger
+        onTrigger={() => setEnvDialogOpen(true)}
+        style={themed($iconContainer)}
+        testID="login-secret-env-trigger"
+      >
         <Icon icon="lock" size={32} color={colors.tint} />
-      </View>
+      </SecretEnvTrigger>
 
       {authStep === "NEW_PASSWORD_REQUIRED" ? (
         <>
@@ -464,6 +476,8 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
           </Pressable>
         </View>
       )}
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/screens/SignupScreen.tsx
+++ b/apps/mobile/app/screens/SignupScreen.tsx
@@ -16,10 +16,13 @@ import {
 import { signUp } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Header } from "@/components/Header"
 import { PressableIcon } from "@/components/Icon"
 import { PasswordRequirements, isPasswordValid } from "@/components/PasswordRequirements"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { TextField, type TextFieldAccessoryProps } from "@/components/TextField"
 import { usePendingAction, type PendingAction } from "@/context/PendingActionContext"
@@ -55,6 +58,7 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
   const [passwordError, setPasswordError] = useState("")
   const [generalError, setGeneralError] = useState("")
   const [showLoginLink, setShowLoginLink] = useState(false)
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
 
   const { pendingAction } = usePendingAction()
 
@@ -150,7 +154,12 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
     >
       <Header title="" leftIcon="back" onLeftPress={() => navigation.goBack()} safeAreaEdges={[]} />
 
-      <Text text="Create Account" preset="heading" style={themed($heading)} />
+      <EnvBadge />
+
+      {/* Hidden 5-tap gesture on the heading opens the staging-backend switcher. */}
+      <SecretEnvTrigger onTrigger={() => setEnvDialogOpen(true)} testID="signup-secret-env-trigger">
+        <Text text="Create Account" preset="heading" style={themed($heading)} />
+      </SecretEnvTrigger>
       {pendingAction && (
         <Text
           text={getContextMessage(pendingAction)}
@@ -249,6 +258,8 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
         preset="default"
         onPress={() => navigation.navigate("Login")}
       />
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/utils/authErrors.ts
+++ b/apps/mobile/app/utils/authErrors.ts
@@ -55,6 +55,19 @@ const LOGIN_ERROR_MESSAGES: Record<string, string> = {
 }
 
 /**
+ * User-friendly error messages for the new-password challenge that
+ * Cognito raises when an admin-invited user (FORCE_CHANGE_PASSWORD)
+ * signs in with their temporary password.
+ */
+const NEW_PASSWORD_ERROR_MESSAGES: Record<string, string> = {
+  InvalidPasswordException:
+    "Password doesn't meet the security requirements. Try a longer password with a mix of letters, numbers, and symbols.",
+  LimitExceededException: "Too many attempts. Please wait a moment and try again.",
+  TooManyRequestsException: "Too many requests. Please wait a moment and try again.",
+  NotAuthorizedException: "Your sign-in session has expired. Please sign in again.",
+}
+
+/**
  * Extract error code from Cognito error
  */
 function getErrorCode(error: unknown): CognitoErrorCode | null {
@@ -111,6 +124,30 @@ export function getLoginErrorMessage(error: unknown): string {
   }
 
   return "Login failed. Please check your credentials and try again."
+}
+
+/**
+ * Get user-friendly message for the new-password challenge.
+ *
+ * Used when an admin-invited user (Cognito FORCE_CHANGE_PASSWORD state)
+ * is required to set a permanent password before reaching their session.
+ */
+export function getNewPasswordErrorMessage(error: unknown): string {
+  const code = getErrorCode(error)
+  if (code && NEW_PASSWORD_ERROR_MESSAGES[code]) {
+    return NEW_PASSWORD_ERROR_MESSAGES[code]
+  }
+
+  // Cognito sometimes surfaces password-policy violations as
+  // InvalidParameterException when the password is malformed (e.g.,
+  // includes characters outside the allowed set). Pattern-match the
+  // message to give a useful hint rather than a generic string.
+  const message = error instanceof Error ? error.message : ""
+  if (message.toLowerCase().includes("password")) {
+    return "Password doesn't meet the security requirements. Try a longer password with a mix of letters, numbers, and symbols."
+  }
+
+  return "Failed to set new password. Please try again."
 }
 
 /**

--- a/apps/mobile/app/utils/envOverride.ts
+++ b/apps/mobile/app/utils/envOverride.ts
@@ -1,0 +1,22 @@
+import { storage } from "./storage"
+
+export type AppEnv = "prod" | "staging"
+
+export const ENV_OVERRIDE_KEY = "envOverride"
+
+/**
+ * Read synchronously at module load (before Amplify.configure) — MMKV is sync,
+ * so the picked outputs are available on the first JS tick.
+ */
+export function getEnvOverride(): AppEnv {
+  const value = storage.getString(ENV_OVERRIDE_KEY)
+  return value === "staging" ? "staging" : "prod"
+}
+
+export function setEnvOverride(env: AppEnv): void {
+  if (env === "prod") {
+    storage.delete(ENV_OVERRIDE_KEY)
+  } else {
+    storage.set(ENV_OVERRIDE_KEY, env)
+  }
+}

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,7 +13,8 @@
       "ios": {
         "buildConfiguration": "Debug",
         "simulator": true
-      }
+      },
+      "channel": "development"
     },
     "development:device": {
       "extends": "development",
@@ -21,13 +22,19 @@
       "ios": {
         "buildConfiguration": "Debug",
         "simulator": false
-      }
+      },
+      "channel": "development-device"
     },
     "preview": {
       "extends": "production",
       "distribution": "internal",
-      "ios": { "simulator": true },
-      "android": { "buildType": "apk" }
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "channel": "preview"
     },
     "e2e": {
       "extends": "production",
@@ -35,14 +42,29 @@
       "env": {
         "E2E_TEST": "true"
       },
-      "ios": { "simulator": true },
-      "android": { "buildType": "apk" }
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "channel": "e2e"
     },
     "preview:device": {
       "extends": "preview",
-      "ios": { "simulator": false }
+      "ios": {
+        "simulator": false
+      },
+      "channel": "preview-device"
     },
-    "production": {}
+    "staging": {
+      "extends": "production",
+      "distribution": "internal",
+      "channel": "staging"
+    },
+    "production": {
+      "channel": "production"
+    }
   },
   "submit": {
     "production": {}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -83,6 +83,7 @@
     "expo-notifications": "~0.32.16",
     "expo-splash-screen": "~31.0.10",
     "expo-system-ui": "~6.0.7",
+    "expo-updates": "~29.0.17",
     "i18next": "^23.14.0",
     "intl-pluralrules": "^2.0.1",
     "react": "19.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,6 +9,7 @@
     "sandbox": "ampx sandbox",
     "deploy": "ampx pipeline-deploy --branch main --app-id d3jl0ykn4qgj9r",
     "fetch:outputs": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch main --app-id d3jl0ykn4qgj9r --profile rayane && cp amplify_outputs.json ../../apps/mobile/ && cp amplify_outputs.json ../../apps/admin/ && cp amplify_outputs.json ../../",
+    "fetch:outputs:staging": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch staging --app-id d3jl0ykn4qgj9r --profile rayane --out-dir ./.tmp-staging && mv ./.tmp-staging/amplify_outputs.json ./amplify_outputs.staging.json && rm -rf ./.tmp-staging && cp amplify_outputs.staging.json ../../apps/mobile/",
     "lint:check": "echo 'No lint configured'",
     "compile": "tsc --noEmit",
     "clean": "rm -rf dist .amplify",

--- a/packages/backend/scripts/reseed-all.sh
+++ b/packages/backend/scripts/reseed-all.sh
@@ -1,13 +1,33 @@
 #!/bin/bash
 # Wipe all data, re-parse Risks.xlsx, and re-seed from scratch
 #
-# Usage: cd packages/backend && bash scripts/reseed-all.sh
+# Usage: TABLE_SUFFIX=<env-suffix>-NONE \
+#        COGNITO_EMAIL=<email> COGNITO_PASSWORD=<password> \
+#        bash scripts/reseed-all.sh
 #
-# Steps 4 & 5 require: COGNITO_EMAIL and COGNITO_PASSWORD env vars
+# TABLE_SUFFIX picks which environment to wipe + reseed. There is no
+# default; the underlying scripts will refuse to run without it. Look it
+# up via `aws dynamodb list-tables` for the chosen Amplify branch.
+#   staging: dwz5zs2ghrc5xplczomoh4fzke-NONE
+#   main:    uusoeozunzdy5biliji7vxbjcy-NONE  (PRODUCTION — confirm twice)
+#
+# Steps 4 & 5 require: COGNITO_EMAIL and COGNITO_PASSWORD env vars.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+# Validate TABLE_SUFFIX up-front so we fail before doing anything (rather
+# than wiping nothing because step 1 errors out, which would leave the
+# operator unsure where the failure originated).
+if [ -z "$TABLE_SUFFIX" ]; then
+  echo "ERROR: TABLE_SUFFIX must be set so we know which environment to wipe + reseed."
+  echo ""
+  echo "  staging: TABLE_SUFFIX=dwz5zs2ghrc5xplczomoh4fzke-NONE"
+  echo "  main:    TABLE_SUFFIX=uusoeozunzdy5biliji7vxbjcy-NONE  (PRODUCTION — confirm twice)"
+  exit 1
+fi
+export TABLE_SUFFIX
 
 # Validate Cognito credentials for steps 4 & 5
 if [ -z "$COGNITO_EMAIL" ] || [ -z "$COGNITO_PASSWORD" ]; then

--- a/packages/backend/scripts/seed-cascade-test-rows.ts
+++ b/packages/backend/scripts/seed-cascade-test-rows.ts
@@ -21,6 +21,14 @@
  *   - `Sorel-Tracy, QC` → "Showing QC data" (state cascade)
  *   - any non-QC, non-ON Canadian city → "Showing CA data" (country cascade)
  *
+ * Caveat: `getLocationMeasurementsByCountry` is a GSI scan on `country`
+ * and returns every row tagged with that country, including the
+ * city-anchored rows seeded from Risks.xlsx. So the country-cascade badge
+ * fires even without these fixtures on a populated env — the fixture's
+ * unique value is in adding visibly-distinguishable rows (uranium-238
+ * with `source = "cascade-coverage-fixture"`) you can pick out in the
+ * dashboard and admin portal as cascade-test data.
+ *
  * Cleanup later with the same script + the --remove flag.
  */
 
@@ -64,53 +72,70 @@ interface FixtureRow {
   notes: string;
 }
 
-// Small, deliberately distinctive set. Values are obviously synthetic
-// (whole numbers; threshold-mid range) so they're recognisable in the
-// admin portal as test data, not real measurements.
+// Deliberately uses `uranium-238` (a real seeded radioactive Contaminant
+// with WHO/CA-QC/EU thresholds) rather than `radon` — `radon` exists as
+// an O&M ObservedProperty but NOT as a Contaminant, so a row with
+// `contaminantId: "radon"` would be an orphan that mobile's stat
+// mapping can't resolve to a category. Different values per row so an
+// operator inspecting the dashboard can identify which fixture got
+// returned (warning vs safe status under WHO's 1.0 Bq/L limit).
 const FIXTURES: FixtureRow[] = [
   // State-scoped: applies to every QC city without its own row.
-  // Confirms the city → state cascade leg.
+  // Confirms the city → state cascade leg. Value 0.9 sits above the
+  // 0.8 warningRatio of WHO's 1.0 limit → renders as "warning".
   {
     city: null,
     state: "QC",
     country: "CA",
-    contaminantId: "radon",
-    value: 100,
-    unit: "Bq/m³",
-    notes: "Cascade coverage fixture: QC state-level row.",
+    contaminantId: "uranium-238",
+    value: 0.9,
+    unit: "Bq/L",
+    notes: "Cascade coverage fixture: QC state-level row (warning status).",
   },
   // Country-scoped: applies to every CA city without state-level data.
-  // Confirms the city → state → country cascade leg.
+  // Confirms the city → state → country cascade leg. Value 0.3 is below
+  // warning threshold → renders as "safe".
   {
     city: null,
     state: null,
     country: "CA",
-    contaminantId: "radon",
-    value: 80,
-    unit: "Bq/m³",
-    notes: "Cascade coverage fixture: CA country-level row.",
+    contaminantId: "uranium-238",
+    value: 0.3,
+    unit: "Bq/L",
+    notes: "Cascade coverage fixture: CA country-level row (safe status).",
   },
 ];
 
 async function findFixtureRows(): Promise<{ id: string }[]> {
   const found: { id: string }[] = [];
   let lastKey: Record<string, unknown> | undefined;
-  do {
-    const result = await docClient.send(
-      new ScanCommand({
-        TableName: TABLE_NAME,
-        FilterExpression: "#src = :src",
-        ExpressionAttributeNames: { "#src": "source" },
-        ExpressionAttributeValues: { ":src": FIXTURE_SOURCE },
-        ProjectionExpression: "id",
-        ExclusiveStartKey: lastKey as Record<string, never> | undefined,
-      }),
-    );
-    for (const item of result.Items ?? []) {
-      if (typeof item.id === "string") found.push({ id: item.id });
+  try {
+    do {
+      const result = await docClient.send(
+        new ScanCommand({
+          TableName: TABLE_NAME,
+          FilterExpression: "#src = :src",
+          ExpressionAttributeNames: { "#src": "source" },
+          ExpressionAttributeValues: { ":src": FIXTURE_SOURCE },
+          ProjectionExpression: "id",
+          ExclusiveStartKey: lastKey as Record<string, never> | undefined,
+        }),
+      );
+      for (const item of result.Items ?? []) {
+        if (typeof item.id === "string") found.push({ id: item.id });
+      }
+      lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (lastKey);
+  } catch (err: unknown) {
+    // Mirror wipe-all-data.ts:104–110 — a fresh sandbox where the
+    // schema hasn't deployed yet means there are no fixtures to find.
+    // Skip cleanly rather than crashing on ResourceNotFoundException.
+    if (err instanceof Error && err.name === "ResourceNotFoundException") {
+      console.log(`Table ${TABLE_NAME} not found (skipping fixture lookup).`);
+      return [];
     }
-    lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastKey);
+    throw err;
+  }
   return found;
 }
 

--- a/packages/backend/scripts/seed-cascade-test-rows.ts
+++ b/packages/backend/scripts/seed-cascade-test-rows.ts
@@ -1,0 +1,207 @@
+/**
+ * Cascade-coverage seed (#123).
+ *
+ * The main seed (`seed-dynamodb-direct.ts`) populates city-anchored
+ * `LocationMeasurement` rows from Risks.xlsx, which exercises the
+ * city → state cascade once a no-data Quebec city is searched. It does
+ * NOT populate state- or country-anchored rows, so the country-scope
+ * leg of the cascade is unverified end-to-end.
+ *
+ * This script writes a small fixed set of state- and country-anchored
+ * rows so an operator can manually verify the full cascade. Rows are
+ * tagged with `source = "cascade-coverage-fixture"` for easy
+ * identification and cleanup. Idempotent: deletes any existing
+ * fixture rows before inserting.
+ *
+ * Run with:
+ *   TABLE_SUFFIX=<env>-NONE AWS_PROFILE=rayane \
+ *     npx tsx scripts/seed-cascade-test-rows.ts
+ *
+ * After running, search any Canadian city in the mobile app:
+ *   - `Sorel-Tracy, QC` → "Showing QC data" (state cascade)
+ *   - any non-QC, non-ON Canadian city → "Showing CA data" (country cascade)
+ *
+ * Cleanup later with the same script + the --remove flag.
+ */
+
+import {
+  DynamoDBClient,
+  BatchWriteItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { marshall } from "@aws-sdk/util-dynamodb";
+import { randomUUID } from "crypto";
+
+const REGION = "ca-central-1";
+const FIXTURE_SOURCE = "cascade-coverage-fixture";
+
+const TABLE_SUFFIX = process.env.TABLE_SUFFIX;
+if (!TABLE_SUFFIX) {
+  console.error(
+    "\nERROR: TABLE_SUFFIX env var is required. There is no safe default.\n" +
+      "Set it to the AppSync data suffix for the environment you intend to seed.\n" +
+      "  staging: TABLE_SUFFIX=dwz5zs2ghrc5xplczomoh4fzke-NONE\n" +
+      "  main:    TABLE_SUFFIX=uusoeozunzdy5biliji7vxbjcy-NONE  (PRODUCTION — confirm twice)\n",
+  );
+  process.exit(1);
+}
+
+const REMOVE_MODE = process.argv.includes("--remove");
+const TABLE_NAME = `LocationMeasurement-${TABLE_SUFFIX}`;
+const client = new DynamoDBClient({ region: REGION });
+const docClient = DynamoDBDocumentClient.from(client);
+
+interface FixtureRow {
+  city: string | null;
+  state: string | null;
+  country: string;
+  contaminantId: string;
+  value: number;
+  unit?: string;
+  notes: string;
+}
+
+// Small, deliberately distinctive set. Values are obviously synthetic
+// (whole numbers; threshold-mid range) so they're recognisable in the
+// admin portal as test data, not real measurements.
+const FIXTURES: FixtureRow[] = [
+  // State-scoped: applies to every QC city without its own row.
+  // Confirms the city → state cascade leg.
+  {
+    city: null,
+    state: "QC",
+    country: "CA",
+    contaminantId: "radon",
+    value: 100,
+    unit: "Bq/m³",
+    notes: "Cascade coverage fixture: QC state-level row.",
+  },
+  // Country-scoped: applies to every CA city without state-level data.
+  // Confirms the city → state → country cascade leg.
+  {
+    city: null,
+    state: null,
+    country: "CA",
+    contaminantId: "radon",
+    value: 80,
+    unit: "Bq/m³",
+    notes: "Cascade coverage fixture: CA country-level row.",
+  },
+];
+
+async function findFixtureRows(): Promise<{ id: string }[]> {
+  const found: { id: string }[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const result = await docClient.send(
+      new ScanCommand({
+        TableName: TABLE_NAME,
+        FilterExpression: "#src = :src",
+        ExpressionAttributeNames: { "#src": "source" },
+        ExpressionAttributeValues: { ":src": FIXTURE_SOURCE },
+        ProjectionExpression: "id",
+        ExclusiveStartKey: lastKey as Record<string, never> | undefined,
+      }),
+    );
+    for (const item of result.Items ?? []) {
+      if (typeof item.id === "string") found.push({ id: item.id });
+    }
+    lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastKey);
+  return found;
+}
+
+async function deleteRows(ids: { id: string }[]): Promise<number> {
+  if (ids.length === 0) return 0;
+  // BatchWriteItem caps at 25 per request.
+  let deleted = 0;
+  for (let i = 0; i < ids.length; i += 25) {
+    const chunk = ids.slice(i, i + 25);
+    await client.send(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [TABLE_NAME]: chunk.map(({ id }) => ({
+            DeleteRequest: { Key: marshall({ id }) },
+          })),
+        },
+      }),
+    );
+    deleted += chunk.length;
+  }
+  return deleted;
+}
+
+async function insertFixtures(): Promise<number> {
+  const now = new Date().toISOString();
+  // Build items with the city/state attributes OMITTED (not set to null)
+  // when the row is anchored above that level. The DynamoDB GSI on
+  // `city` requires String type; writing a typed NULL is rejected with
+  // "Type mismatch for Index Key city Expected: S Actual: NULL". Sparse
+  // index = absent key, not null key. AppSync VTL strips nulls before
+  // PutItem; we have to do the same here.
+  const items = FIXTURES.map((row) => {
+    const item: Record<string, unknown> = {
+      id: randomUUID(),
+      country: row.country,
+      contaminantId: row.contaminantId,
+      value: row.value,
+      measuredAt: now,
+      source: FIXTURE_SOURCE,
+      notes: row.notes,
+      silentImport: true, // Don't fan out push notifications for fixture data.
+      createdAt: now,
+      updatedAt: now,
+      __typename: "LocationMeasurement",
+    };
+    if (row.city !== null) item.city = row.city;
+    if (row.state !== null) item.state = row.state;
+    return item;
+  });
+
+  for (let i = 0; i < items.length; i += 25) {
+    const chunk = items.slice(i, i + 25);
+    await client.send(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [TABLE_NAME]: chunk.map((item) => ({
+            PutRequest: { Item: marshall(item, { removeUndefinedValues: true }) },
+          })),
+        },
+      }),
+    );
+  }
+  return items.length;
+}
+
+async function main() {
+  console.log(`Target table: ${TABLE_NAME}`);
+  console.log(`Mode: ${REMOVE_MODE ? "REMOVE fixtures" : "INSERT fixtures (idempotent)"}`);
+
+  const existing = await findFixtureRows();
+  console.log(`Existing fixture rows: ${existing.length}`);
+
+  if (existing.length > 0) {
+    const removed = await deleteRows(existing);
+    console.log(`Removed ${removed} existing fixture row(s).`);
+  }
+
+  if (REMOVE_MODE) {
+    console.log("Done (remove mode).");
+    return;
+  }
+
+  const inserted = await insertFixtures();
+  console.log(`Inserted ${inserted} cascade fixture row(s):`);
+  for (const f of FIXTURES) {
+    const scope = f.city ? "city" : f.state ? "state" : "country";
+    console.log(`  - ${scope}: city=${f.city ?? "(null)"} state=${f.state ?? "(null)"} country=${f.country} contaminantId=${f.contaminantId}`);
+  }
+}
+
+main().catch((err) => {
+  console.error("Cascade fixture script failed:", err);
+  process.exit(1);
+});

--- a/packages/backend/scripts/seed-dynamodb-direct.ts
+++ b/packages/backend/scripts/seed-dynamodb-direct.ts
@@ -16,7 +16,21 @@ import propertyThresholdsData from "./property-thresholds.json";
 import measurementsData from "./seed-measurements.json";
 
 const REGION = "ca-central-1";
-const TABLE_SUFFIX = process.env.TABLE_SUFFIX || "uusoeozunzdy5biliji7vxbjcy-NONE";
+
+// Refuse to run without an explicit TABLE_SUFFIX. The previous default
+// pointed at production; running this script without setting the env
+// var would have re-seeded main rather than the intended environment.
+// Force the caller to spell out which environment they're targeting.
+const TABLE_SUFFIX = process.env.TABLE_SUFFIX;
+if (!TABLE_SUFFIX) {
+  console.error(
+    "\nERROR: TABLE_SUFFIX env var is required. There is no safe default.\n" +
+      "Set it to the AppSync data suffix for the environment you intend to seed.\n" +
+      "  staging: TABLE_SUFFIX=dwz5zs2ghrc5xplczomoh4fzke-NONE\n" +
+      "  main:    TABLE_SUFFIX=uusoeozunzdy5biliji7vxbjcy-NONE  (PRODUCTION — confirm twice)\n",
+  );
+  process.exit(1);
+}
 
 const TABLES = {
   Jurisdiction: `Jurisdiction-${TABLE_SUFFIX}`,

--- a/packages/backend/scripts/wipe-all-data.ts
+++ b/packages/backend/scripts/wipe-all-data.ts
@@ -12,7 +12,21 @@ import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 
 const REGION = "ca-central-1";
-const TABLE_SUFFIX = process.env.TABLE_SUFFIX || "uusoeozunzdy5biliji7vxbjcy-NONE";
+
+// Refuse to run without an explicit TABLE_SUFFIX. The previous default
+// pointed at production (`uusoeozunzdy5biliji7vxbjcy-NONE`); anyone who
+// ran reseed-all.sh without realising would have wiped main. Force the
+// caller to spell out which environment they're targeting.
+const TABLE_SUFFIX = process.env.TABLE_SUFFIX;
+if (!TABLE_SUFFIX) {
+  console.error(
+    "\nERROR: TABLE_SUFFIX env var is required. There is no safe default.\n" +
+      "Set it to the AppSync data suffix for the environment you intend to wipe.\n" +
+      "  staging: TABLE_SUFFIX=dwz5zs2ghrc5xplczomoh4fzke-NONE\n" +
+      "  main:    TABLE_SUFFIX=uusoeozunzdy5biliji7vxbjcy-NONE  (PRODUCTION — confirm twice)\n",
+  );
+  process.exit(1);
+}
 
 const TABLES_TO_WIPE = [
   "Jurisdiction",

--- a/scripts/sync-amplify-outputs.sh
+++ b/scripts/sync-amplify-outputs.sh
@@ -11,6 +11,9 @@ ROOT_OUTPUTS="$ROOT_DIR/amplify_outputs.json"
 MOBILE_OUTPUTS="$ROOT_DIR/apps/mobile/amplify_outputs.json"
 WEB_OUTPUTS="$ROOT_DIR/apps/web/amplify_outputs.json"
 
+BACKEND_STAGING_OUTPUTS="$ROOT_DIR/packages/backend/amplify_outputs.staging.json"
+MOBILE_STAGING_OUTPUTS="$ROOT_DIR/apps/mobile/amplify_outputs.staging.json"
+
 if [ -f "$BACKEND_OUTPUTS" ]; then
   cp "$BACKEND_OUTPUTS" "$ROOT_OUTPUTS"
   cp "$BACKEND_OUTPUTS" "$MOBILE_OUTPUTS"
@@ -23,4 +26,18 @@ elif [ -f "$ROOT_OUTPUTS" ]; then
 else
   echo "⚠ No amplify_outputs.json found. Run 'yarn backend:sandbox' to generate one."
   exit 0
+fi
+
+# Staging outputs power the hidden in-app env switcher (envOverride === "staging").
+# The mobile app imports this file at build time, so it MUST exist or the bundle
+# fails to compile. If we can't find a real staging file, fall back to the prod
+# file as a placeholder so the build still works — the toggle will simply route
+# back to prod until the dev runs `yarn fetch:outputs:staging`.
+if [ -f "$BACKEND_STAGING_OUTPUTS" ]; then
+  cp "$BACKEND_STAGING_OUTPUTS" "$MOBILE_STAGING_OUTPUTS"
+  echo "✓ Synced amplify_outputs.staging.json from backend to mobile"
+elif [ ! -f "$MOBILE_STAGING_OUTPUTS" ]; then
+  cp "$MOBILE_OUTPUTS" "$MOBILE_STAGING_OUTPUTS"
+  echo "⚠ No staging amplify_outputs found — copied prod as placeholder."
+  echo "  Run 'yarn fetch:outputs:staging' to populate the real staging config."
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -11138,6 +11138,7 @@ __metadata:
     expo-notifications: "npm:~0.32.16"
     expo-splash-screen: "npm:~31.0.10"
     expo-system-ui: "npm:~6.0.7"
+    expo-updates: "npm:~29.0.17"
     i18next: "npm:^23.14.0"
     intl-pluralrules: "npm:^2.0.1"
     jest: "npm:~29.7.0"
@@ -17153,6 +17154,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:4.1.0":
+  version: 4.1.0
+  resolution: "arg@npm:4.1.0"
+  checksum: 10c0/a453e07f25370c7910df9b8a8eecb1a0c71e902a3843339ff9391ea4b4dac6871cd99a1a11e38642cf6d0723c7ab7f15f5824f1ccb862f3317a9c05c56a251c7
+  languageName: node
+  linkType: hard
+
 "arg@npm:^5.0.2":
   version: 5.0.2
   resolution: "arg@npm:5.0.2"
@@ -20958,6 +20966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-eas-client@npm:~1.0.8":
+  version: 1.0.8
+  resolution: "expo-eas-client@npm:1.0.8"
+  checksum: 10c0/c291351db616f6163900b5ef6294240068e2d7b916dde1aee5b82353375f63cdfe4523f63ff72903c6ee81e5f1be2a20555f0c024d6fb11b5de1507c7c2d8b09
+  languageName: node
+  linkType: hard
+
 "expo-file-system@npm:~19.0.21":
   version: 19.0.21
   resolution: "expo-file-system@npm:19.0.21"
@@ -21044,6 +21059,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-manifests@npm:~1.0.11":
+  version: 1.0.11
+  resolution: "expo-manifests@npm:1.0.11"
+  dependencies:
+    "@expo/config": "npm:~12.0.13"
+    expo-json-utils: "npm:~0.15.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/184f3ce01f9f0099ef08433c33a42ca1f865045bfcde00a6bb7f8c51825288b5b4d9f2150fc4e57aea9f6aff34093f49157f4d78fdd0d79157a199a03cdb4243
+  languageName: node
+  linkType: hard
+
 "expo-modules-autolinking@npm:3.0.24":
   version: 3.0.24
   resolution: "expo-modules-autolinking@npm:3.0.24"
@@ -21108,6 +21135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-structured-headers@npm:~5.0.0":
+  version: 5.0.0
+  resolution: "expo-structured-headers@npm:5.0.0"
+  checksum: 10c0/bbe0f9cb91ca5fd8482fd15723bfe279b26f34a37360af2ce9a510434351e50d889e429037915be9ede493893b99eb8e7f0be56bfcebaebb5d9a25443b1fa419
+  languageName: node
+  linkType: hard
+
 "expo-system-ui@npm:~6.0.7":
   version: 6.0.9
   resolution: "expo-system-ui@npm:6.0.9"
@@ -21131,6 +21165,34 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10c0/d2ccf8325c1c8092fac6cfa521291943dce92f56a633bcc60abe1db54c88da601d6b0174aa1e824db6d3508486ccccafa16e39f05b7014dd70442ba91340b02e
+  languageName: node
+  linkType: hard
+
+"expo-updates@npm:~29.0.17":
+  version: 29.0.17
+  resolution: "expo-updates@npm:29.0.17"
+  dependencies:
+    "@expo/code-signing-certificates": "npm:^0.0.6"
+    "@expo/plist": "npm:^0.4.8"
+    "@expo/spawn-async": "npm:^1.7.2"
+    arg: "npm:4.1.0"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.4"
+    expo-eas-client: "npm:~1.0.8"
+    expo-manifests: "npm:~1.0.11"
+    expo-structured-headers: "npm:~5.0.0"
+    expo-updates-interface: "npm:~2.0.0"
+    getenv: "npm:^2.0.0"
+    glob: "npm:^13.0.0"
+    ignore: "npm:^5.3.1"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  bin:
+    expo-updates: bin/cli.js
+  checksum: 10c0/b6af869928b025dc1e70e1cb0d628553640646b68b349770b5fea1724624ab8b5f300b6ddf15a045918e3f4f8746f3f68e65d98345c47f609dd9dd4af1363d7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Promotes staging to main. Ten changesets, each independently merged to staging and validated.

## What's in this release

### Mobile auth & onboarding
- **#284 / #285 — FORCE_CHANGE_PASSWORD handling.** Mobile app handles Cognito's `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED` challenge — admin-invited users complete their initial password change in-app instead of dead-ending on a generic error. Mirrors the admin portal's existing pattern. Verified end-to-end on staging (`walter.vargaspena+forcechange@gmail.com` flipped from `FORCE_CHANGE_PASSWORD` → `CONFIRMED`).
- **#290 — hidden staging-backend toggle.** Long-press a hidden trigger on the auth screens to switch the mobile app between production and staging Amplify backends without rebuilding. Lets us point a TestFlight/prod build at staging for QA.

### Cascade (city → state → country) — the original April-11 bug
- **#287 — admin: state/country-anchored measurements in Location Measurements page.** Surfaces rows where city is blank (state-scoped) or city + state are blank (country-scoped) so editors can see and manage cascade-source data.
- **#289 — admin: cascade-anchored sections show filtered count, not source-array count.** Fixes a contradictory display where the section header showed the unfiltered total while the table rendered the filtered subset.
- **#283 — wipe/seed safety guards + cascade-coverage fixtures.** Removes the production-defaulted `TABLE_SUFFIX` footgun from seed/wipe scripts (both refuse to run without an explicit env var). Adds an idempotent cascade-coverage fixture script (uranium-238 state-anchored QC + country-anchored CA rows). Dev-only — no runtime impact.

### Warning banners (admin + mobile)
- **#292 — P0/P1 banner bugs from QA review.** Closes the high-severity findings from the multi-agent QA pass on the new banners feature.
- **#293 — admin polish.** Admin Status column derives `displayStatus` from `isActive && now ∈ [startsAt, expiresAt)` (so expired banners no longer read "Active"), severity uses lucide icons + shadcn `Select`, native `window.confirm` replaced with an in-app focus-trapped `Dialog`, and severity carries an icon (not just color) for a11y.
- **#294 — render admin warning banners outside the no-data branch (mobile).** Banners now show on the dashboard regardless of whether city data is present, so admin warnings reach users in the empty/loading states too.

### Mobile native delivery (EAS Update OTA)
- **EAS Update wiring** for staging + production OTA delivery (`.github/workflows/mobile-deploy.yml`, `apps/mobile/eas.json`, `apps/mobile/app.json`, `README.md`).
- **#291 — generate `amplify_outputs.json` in the OTA job.** Metro needs the Amplify config at bundle time; the OTA workflow now runs `yarn sync:amplify` before bundling.

## Diff stat
- 27 files changed, 5,520 insertions(+), 249 deletions(-)
- Mobile + admin + backend scripts. No web landing or backend data-plane changes.

## Test plan

### Pre-merge checks (passed)
- [x] Mobile jest 222/222
- [x] Mobile tsc + lint clean
- [x] Admin tsc + lint clean (CI on #287, #289, #292, #293, #294)
- [x] Backend tsc clean
- [x] Lambda jest (`process-notifications`, `on-location-measurement-update`)

### Validated on staging
- [x] FORCE_CHANGE_PASSWORD flow on staging mobile-web (`https://staging.d2z5ddqhlc1q5.amplifyapp.com/`)
- [x] Cascade fix live for Sorel-Tracy / Halifax (sent to Rayane for sign-off; he is signed in and testing)
- [x] Admin banners: status badges (active/scheduled/expired/inactive), severity Select with icons, in-app delete dialog
- [x] Admin Location Measurements page renders state- and country-anchored rows with correct section counts
- [x] Hidden staging toggle ships in mobile auth screens (no UI surfaced unless triggered)

### Post-merge (production)
- [ ] `https://app.mapyourhealth.info/` smoke-check: known cities (Beverly Hills, Montreal) render dashboard data
- [ ] `https://admin.mapyourhealth.info/` smoke-check: banners page status column reflects time windows; Location Measurements shows anchored sections
- [ ] EAS Update OTA delivery hits production native app for the next mobile release
- [ ] Admin warning banner visible on dashboard for cities without data (regression target for #294)

## Notes
- **Rayane is testing the cascade fix on staging.** Holding any cascade-specific follow-ups until he signs off; this promotion ships the supporting unblocks (mobile auth + native OTA + admin tooling + banners) without waiting on his reply since they're independently valuable.
- Issue #239 (Montreal analytics) couldn't be reproduced on staging — full data flow works end-to-end, dashboard updates within seconds via `observeQuery`. Will close after sign-off if the same holds on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
