### PR TITLE
fix(admin): cascade-anchored sections show filtered count, not source-array count

### DIFF
--- a/apps/admin/src/app/(admin)/zip-codes/page.tsx
+++ b/apps/admin/src/app/(admin)/zip-codes/page.tsx
@@ -314,8 +314,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By city</CardTitle>
           <CardDescription>
-            {locationStats.length} cit{locationStats.length !== 1 ? "ies" : "y"}{" "}
+            {filteredLocations.length} cit
+            {filteredLocations.length !== 1 ? "ies" : "y"}{" "}
             with measurements anchored at city level
+            {searchQuery && filteredLocations.length !== locationStats.length
+              ? ` (of ${locationStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -352,7 +356,8 @@ export default function ZipCodesPage() {
                     </TableCell>
                     <TableCell>{location.state}</TableCell>
                     <TableCell>
-                      {location.measurementCount} measurements
+                      {location.measurementCount} measurement
+                      {location.measurementCount !== 1 ? "s" : ""}
                     </TableCell>
                     <TableCell>
                       <Badge
@@ -390,9 +395,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By state / province</CardTitle>
           <CardDescription>
-            {stateStats.length} state-wide record
-            {stateStats.length !== 1 ? "s" : ""} — apply to every city in the
-            state without its own data (#123 cascade fallback)
+            {filteredStateStats.length} state-wide record
+            {filteredStateStats.length !== 1 ? "s" : ""} — apply to every city
+            in the state without its own data (#123 cascade fallback)
+            {searchQuery && filteredStateStats.length !== stateStats.length
+              ? ` (of ${stateStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -427,7 +435,10 @@ export default function ZipCodesPage() {
                       </div>
                     </TableCell>
                     <TableCell>{s.country}</TableCell>
-                    <TableCell>{s.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      {s.measurementCount} measurement
+                      {s.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
                     <TableCell>
                       <Badge
                         variant="secondary"
@@ -451,9 +462,12 @@ export default function ZipCodesPage() {
         <CardHeader>
           <CardTitle>By country</CardTitle>
           <CardDescription>
-            {countryStats.length} country-wide record
-            {countryStats.length !== 1 ? "s" : ""} — apply to every city in the
-            country without its own (or its state&apos;s) data
+            {filteredCountryStats.length} country-wide record
+            {filteredCountryStats.length !== 1 ? "s" : ""} — apply to every city
+            in the country without its own (or its state&apos;s) data
+            {searchQuery && filteredCountryStats.length !== countryStats.length
+              ? ` (of ${countryStats.length} total)`
+              : ""}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -486,7 +500,10 @@ export default function ZipCodesPage() {
                         <span className="font-medium">{c.country}</span>
                       </div>
                     </TableCell>
-                    <TableCell>{c.measurementCount} measurements</TableCell>
+                    <TableCell>
+                      {c.measurementCount} measurement
+                      {c.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
                     <TableCell>
                       <Badge
                         variant="secondary"


### PR DESCRIPTION
## Why

Two bugs spotted while auditing PR #287 on staging:

### Bug 1 — Heading count contradicts the body when search filters everything out

With \"QC\" typed into the search:
- **By country** card heading: \"1 country-wide record — apply to every city in the country without its own (or its state's) data\"
- **By country** card body: \"No country-wide records match your search.\"

Same logic gap exists in all three sections — only visible on the country section because it's the only one with exactly one row that's easy to filter out via a city/state-only query.

### Bug 2 — \"1 measurements\" singular/plural

Per-row count cells in all three sections render \"1 measurements\" instead of \"1 measurement\". Existed in the legacy city section and got duplicated into the two new sections in #287.

## What

- Each section's heading now derives its count from the **filtered** array (`filteredLocations` / `filteredStateStats` / `filteredCountryStats`) — no more contradiction.
- When a search is active and the filter drops rows, the heading appends `\" (of N total)\"` so the user still sees the underlying count without ambiguity.
- All three per-row \"X measurements\" cells now pluralize correctly: \"1 measurement\" / \"N measurements\".

## Test plan

- [x] `cd apps/admin && npx tsc --noEmit` clean
- [x] `cd apps/admin && npm run lint` clean (0 errors; 5 pre-existing warnings retained)
- [ ] On staging admin: search \"QC\" → country section heading reads \"0 country-wide records — apply to ... (of 1 total)\" and body shows the existing \"No country-wide records match your search.\" empty-state. No contradiction.
- [ ] State row \"1 measurement\" (singular) instead of \"1 measurements\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)