### PR TITLE
feat(mobile): hidden staging-backend toggle on auth screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Amplify
 .amplify/
 amplify_outputs.json
+# Backend's staging copy is local-only — the canonical bundled copy lives at
+# apps/mobile/amplify_outputs.staging.json and IS tracked so prod builds can
+# ship it to power the in-app staging-backend switcher.
+packages/backend/amplify_outputs.staging.json
 
 # Yarn
 .yarn/*

--- a/apps/mobile/amplify_outputs.staging.json
+++ b/apps/mobile/amplify_outputs.staging.json
@@ -1,0 +1,3910 @@
+{
+  "auth": {
+    "user_pool_id": "ca-central-1_tPykL7wal",
+    "aws_region": "ca-central-1",
+    "user_pool_client_id": "b8t7edjsr19dp7gv89lsqfi7p",
+    "identity_pool_id": "ca-central-1:f5175153-0f02-488d-80fb-c89f24cd8089",
+    "mfa_methods": [],
+    "standard_required_attributes": [
+      "email"
+    ],
+    "username_attributes": [
+      "email"
+    ],
+    "user_verification_types": [
+      "email"
+    ],
+    "groups": [
+      {
+        "admin": {
+          "precedence": 0
+        }
+      }
+    ],
+    "mfa_configuration": "NONE",
+    "password_policy": {
+      "min_length": 8,
+      "require_lowercase": true,
+      "require_numbers": true,
+      "require_symbols": true,
+      "require_uppercase": true
+    },
+    "unauthenticated_identities_enabled": true
+  },
+  "data": {
+    "url": "https://p3k3ocutbvg2njqmjuvww7o2ou.appsync-api.ca-central-1.amazonaws.com/graphql",
+    "aws_region": "ca-central-1",
+    "default_authorization_type": "AMAZON_COGNITO_USER_POOLS",
+    "authorization_types": [
+      "AWS_IAM"
+    ],
+    "model_introspection": {
+      "version": 1,
+      "models": {
+        "HealthRecord": {
+          "name": "HealthRecord",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "date": {
+              "name": "date",
+              "isArray": false,
+              "type": "AWSDate",
+              "isRequired": true,
+              "attributes": []
+            },
+            "type": {
+              "name": "type",
+              "isArray": false,
+              "type": {
+                "enum": "HealthRecordType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "HealthRecords",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "identityClaim": "cognito:username",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Category": {
+          "name": "Category",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "categoryId": {
+              "name": "categoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "icon": {
+              "name": "icon",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "color": {
+              "name": "color",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sortOrder": {
+              "name": "sortOrder",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "links": {
+              "name": "links",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "showStandardsTable": {
+              "name": "showStandardsTable",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Categories",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "categoriesByCategoryId",
+                "queryField": "listCategoryByCategoryId",
+                "fields": [
+                  "categoryId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "SubCategory": {
+          "name": "SubCategory",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "subCategoryId": {
+              "name": "subCategoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "categoryId": {
+              "name": "categoryId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "icon": {
+              "name": "icon",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "color": {
+              "name": "color",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sortOrder": {
+              "name": "sortOrder",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "links": {
+              "name": "links",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "SubCategories",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "subCategoriesBySubCategoryId",
+                "queryField": "listSubCategoryBySubCategoryId",
+                "fields": [
+                  "subCategoryId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "subCategoriesByCategoryId",
+                "queryField": "listSubCategoryByCategoryId",
+                "fields": [
+                  "categoryId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Contaminant": {
+          "name": "Contaminant",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "ContaminantCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "studies": {
+              "name": "studies",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "higherIsBad": {
+              "name": "higherIsBad",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Contaminants",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantsByContaminantId",
+                "queryField": "listContaminantByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "ContaminantThreshold": {
+          "name": "ContaminantThreshold",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "limitValue": {
+              "name": "limitValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "warningRatio": {
+              "name": "warningRatio",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "ContaminantThresholdStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "ContaminantThresholds",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantThresholdsByContaminantId",
+                "queryField": "listContaminantThresholdByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "contaminantThresholdsByJurisdictionCode",
+                "queryField": "listContaminantThresholdByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Jurisdiction": {
+          "name": "Jurisdiction",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "code": {
+              "name": "code",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "region": {
+              "name": "region",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "parentCode": {
+              "name": "parentCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isDefault": {
+              "name": "isDefault",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Jurisdictions",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "jurisdictionsByCode",
+                "queryField": "listJurisdictionByCode",
+                "fields": [
+                  "code"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "jurisdictionsByCountry",
+                "queryField": "listJurisdictionByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "Location": {
+          "name": "Location",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Locations",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCity",
+                "queryField": "listLocationByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCounty",
+                "queryField": "listLocationByCounty",
+                "fields": [
+                  "county"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByState",
+                "queryField": "listLocationByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByCountry",
+                "queryField": "listLocationByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationsByJurisdictionCode",
+                "queryField": "listLocationByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationMeasurement": {
+          "name": "LocationMeasurement",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "measuredAt": {
+              "name": "measuredAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sourceUrl": {
+              "name": "sourceUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "silentImport": {
+              "name": "silentImport",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationMeasurements",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByCity",
+                "queryField": "listLocationMeasurementByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByState",
+                "queryField": "listLocationMeasurementByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByCountry",
+                "queryField": "listLocationMeasurementByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationMeasurementsByContaminantId",
+                "queryField": "listLocationMeasurementByContaminantId",
+                "fields": [
+                  "contaminantId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "UserSubscription": {
+          "name": "UserSubscription",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "enablePush": {
+              "name": "enablePush",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "enableEmail": {
+              "name": "enableEmail",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnDanger": {
+              "name": "alertOnDanger",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnWarning": {
+              "name": "alertOnWarning",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "alertOnAnyChange": {
+              "name": "alertOnAnyChange",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "watchContaminants": {
+              "name": "watchContaminants",
+              "isArray": true,
+              "type": "String",
+              "isRequired": false,
+              "attributes": [],
+              "isArrayNullable": true
+            },
+            "notifyWhenDataAvailable": {
+              "name": "notifyWhenDataAvailable",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "expoPushToken": {
+              "name": "expoPushToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "UserSubscriptions",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByCity",
+                "queryField": "listUserSubscriptionByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByState",
+                "queryField": "listUserSubscriptionByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "userSubscriptionsByCountry",
+                "queryField": "listUserSubscriptionByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "identityClaim": "cognito:username",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "NotificationLog": {
+          "name": "NotificationLog",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "subscriptionId": {
+              "name": "subscriptionId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "userId": {
+              "name": "userId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "type": {
+              "name": "type",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "title": {
+              "name": "title",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "body": {
+              "name": "body",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sentAt": {
+              "name": "sentAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "deliveredAt": {
+              "name": "deliveredAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "triggerType": {
+              "name": "triggerType",
+              "isArray": false,
+              "type": {
+                "enum": "NotificationLogTriggerType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "contaminantId": {
+              "name": "contaminantId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "NotificationLogs",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "notificationLogsByUserId",
+                "queryField": "listNotificationLogByUserId",
+                "fields": [
+                  "userId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "notificationLogsByCity",
+                "queryField": "listNotificationLogByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "HazardReport": {
+          "name": "HazardReport",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "HazardReportCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "location": {
+              "name": "location",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "HazardReportStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "adminNotes": {
+              "name": "adminNotes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "HazardReports",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "operations": [
+                      "create",
+                      "read"
+                    ],
+                    "identityClaim": "cognito:username"
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationVisit": {
+          "name": "LocationVisit",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "visitedAt": {
+              "name": "visitedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationVisits",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "WarningBanner": {
+          "name": "WarningBanner",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "title": {
+              "name": "title",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "titleFr": {
+              "name": "titleFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "severity": {
+              "name": "severity",
+              "isArray": false,
+              "type": {
+                "enum": "WarningBannerSeverity"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "startsAt": {
+              "name": "startsAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "expiresAt": {
+              "name": "expiresAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isActive": {
+              "name": "isActive",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdBy": {
+              "name": "createdBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "WarningBanners",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "AppConfig": {
+          "name": "AppConfig",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "configKey": {
+              "name": "configKey",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "isEnabled": {
+              "name": "isEnabled",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "value": {
+              "name": "value",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "AppConfigs",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "appConfigsByConfigKey",
+                "queryField": "listAppConfigByConfigKey",
+                "fields": [
+                  "configKey"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LandingPageContent": {
+          "name": "LandingPageContent",
+          "fields": {
+            "locale": {
+              "name": "locale",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "content": {
+              "name": "content",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": true,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LandingPageContents",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "locale"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "locale",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LandingTheme": {
+          "name": "LandingTheme",
+          "fields": {
+            "key": {
+              "name": "key",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "tokens": {
+              "name": "tokens",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": true,
+              "attributes": []
+            },
+            "updatedBy": {
+              "name": "updatedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LandingThemes",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "key"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "key",
+            "sortKeyFieldNames": []
+          }
+        },
+        "PollutionSource": {
+          "name": "PollutionSource",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sourceId": {
+              "name": "sourceId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "sourceType": {
+              "name": "sourceType",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceSourceType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "impactRadius": {
+              "name": "impactRadius",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": true,
+              "attributes": []
+            },
+            "address": {
+              "name": "address",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "primaryContaminants": {
+              "name": "primaryContaminants",
+              "isArray": true,
+              "type": "String",
+              "isRequired": false,
+              "attributes": [],
+              "isArrayNullable": true
+            },
+            "severityLevel": {
+              "name": "severityLevel",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceSeverityLevel"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "PollutionSourceStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "reportedAt": {
+              "name": "reportedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "reportedBy": {
+              "name": "reportedBy",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "PollutionSources",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByCity",
+                "queryField": "listPollutionSourceByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByState",
+                "queryField": "listPollutionSourceByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "pollutionSourcesByCountry",
+                "queryField": "listPollutionSourceByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "NewsletterSubscriber": {
+          "name": "NewsletterSubscriber",
+          "fields": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "AWSEmail",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zip": {
+              "name": "zip",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "confirmed": {
+              "name": "confirmed",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "confirmationCode": {
+              "name": "confirmationCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "NewsletterSubscribers",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "fields": [
+                  "email"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "newsletterSubscribersBySource",
+                "queryField": "listNewsletterSubscriberBySource",
+                "fields": [
+                  "source"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "newsletterSubscribersByConfirmationCode",
+                "queryField": "listNewsletterSubscriberByConfirmationCode",
+                "fields": [
+                  "confirmationCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "create"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "read",
+                      "update",
+                      "delete"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": true,
+            "primaryKeyFieldName": "email",
+            "sortKeyFieldNames": []
+          }
+        },
+        "ObservedProperty": {
+          "name": "ObservedProperty",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "nameFr": {
+              "name": "nameFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "category": {
+              "name": "category",
+              "isArray": false,
+              "type": {
+                "enum": "ObservedPropertyCategory"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "observationType": {
+              "name": "observationType",
+              "isArray": false,
+              "type": {
+                "enum": "ObservedPropertyObservationType"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "unit": {
+              "name": "unit",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "descriptionFr": {
+              "name": "descriptionFr",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "higherIsBad": {
+              "name": "higherIsBad",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "metadata": {
+              "name": "metadata",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "ObservedProperties",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "observedPropertiesByPropertyId",
+                "queryField": "listObservedPropertyByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "observedPropertiesByCategory",
+                "queryField": "listObservedPropertyByCategory",
+                "fields": [
+                  "category"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "PropertyThreshold": {
+          "name": "PropertyThreshold",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "limitValue": {
+              "name": "limitValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "warningValue": {
+              "name": "warningValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zoneMapping": {
+              "name": "zoneMapping",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "endemicIsDanger": {
+              "name": "endemicIsDanger",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceWarningThreshold": {
+              "name": "incidenceWarningThreshold",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceDangerThreshold": {
+              "name": "incidenceDangerThreshold",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": {
+                "enum": "PropertyThresholdStatus"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "PropertyThresholds",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "propertyThresholdsByPropertyId",
+                "queryField": "listPropertyThresholdByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "propertyThresholdsByJurisdictionCode",
+                "queryField": "listPropertyThresholdByJurisdictionCode",
+                "fields": [
+                  "jurisdictionCode"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        },
+        "LocationObservation": {
+          "name": "LocationObservation",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "propertyId": {
+              "name": "propertyId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "numericValue": {
+              "name": "numericValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "zoneValue": {
+              "name": "zoneValue",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "endemicValue": {
+              "name": "endemicValue",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "incidenceValue": {
+              "name": "incidenceValue",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "binaryValue": {
+              "name": "binaryValue",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "observedAt": {
+              "name": "observedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": true,
+              "attributes": []
+            },
+            "validUntil": {
+              "name": "validUntil",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "source": {
+              "name": "source",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "sourceUrl": {
+              "name": "sourceUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "notes": {
+              "name": "notes",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "rawData": {
+              "name": "rawData",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "LocationObservations",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByCity",
+                "queryField": "listLocationObservationByCity",
+                "fields": [
+                  "city"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByState",
+                "queryField": "listLocationObservationByState",
+                "fields": [
+                  "state"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByCountry",
+                "queryField": "listLocationObservationByCountry",
+                "fields": [
+                  "country"
+                ]
+              }
+            },
+            {
+              "type": "key",
+              "properties": {
+                "name": "locationObservationsByPropertyId",
+                "queryField": "listLocationObservationByPropertyId",
+                "fields": [
+                  "propertyId"
+                ]
+              }
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "allow": "public",
+                    "provider": "iam",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  },
+                  {
+                    "groupClaim": "cognito:groups",
+                    "provider": "userPools",
+                    "allow": "groups",
+                    "operations": [
+                      "create",
+                      "update",
+                      "delete",
+                      "read"
+                    ],
+                    "groups": [
+                      "admin"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        }
+      },
+      "enums": {
+        "ManageDataAction": {
+          "name": "ManageDataAction",
+          "values": [
+            "wipeContaminants",
+            "wipeLocations",
+            "wipeAll",
+            "reseedAll"
+          ]
+        },
+        "HealthRecordType": {
+          "name": "HealthRecordType",
+          "values": [
+            "WEIGHT",
+            "BLOOD_PRESSURE",
+            "HEART_RATE",
+            "BLOOD_SUGAR",
+            "STEPS",
+            "SLEEP",
+            "OTHER"
+          ]
+        },
+        "ContaminantCategory": {
+          "name": "ContaminantCategory",
+          "values": [
+            "fertilizer",
+            "pesticide",
+            "radioactive",
+            "disinfectant",
+            "inorganic",
+            "organic",
+            "microbiological"
+          ]
+        },
+        "ContaminantThresholdStatus": {
+          "name": "ContaminantThresholdStatus",
+          "values": [
+            "regulated",
+            "banned",
+            "not_approved",
+            "not_controlled"
+          ]
+        },
+        "NotificationLogType": {
+          "name": "NotificationLogType",
+          "values": [
+            "push",
+            "email"
+          ]
+        },
+        "NotificationLogStatus": {
+          "name": "NotificationLogStatus",
+          "values": [
+            "pending",
+            "sent",
+            "failed",
+            "delivered"
+          ]
+        },
+        "NotificationLogTriggerType": {
+          "name": "NotificationLogTriggerType",
+          "values": [
+            "data_update",
+            "data_available",
+            "status_change",
+            "manual_alert"
+          ]
+        },
+        "HazardReportCategory": {
+          "name": "HazardReportCategory",
+          "values": [
+            "water",
+            "air",
+            "health",
+            "disaster"
+          ]
+        },
+        "HazardReportStatus": {
+          "name": "HazardReportStatus",
+          "values": [
+            "pending",
+            "reviewed",
+            "resolved",
+            "dismissed"
+          ]
+        },
+        "WarningBannerSeverity": {
+          "name": "WarningBannerSeverity",
+          "values": [
+            "critical",
+            "warning",
+            "info"
+          ]
+        },
+        "PollutionSourceSourceType": {
+          "name": "PollutionSourceSourceType",
+          "values": [
+            "industrial",
+            "agricultural",
+            "waste_site",
+            "spill",
+            "mining",
+            "transportation",
+            "construction",
+            "other"
+          ]
+        },
+        "PollutionSourceSeverityLevel": {
+          "name": "PollutionSourceSeverityLevel",
+          "values": [
+            "low",
+            "moderate",
+            "high",
+            "critical"
+          ]
+        },
+        "PollutionSourceStatus": {
+          "name": "PollutionSourceStatus",
+          "values": [
+            "active",
+            "monitored",
+            "remediated",
+            "closed"
+          ]
+        },
+        "ObservedPropertyCategory": {
+          "name": "ObservedPropertyCategory",
+          "values": [
+            "water_quality",
+            "air_quality",
+            "disease",
+            "radiation",
+            "soil",
+            "noise",
+            "climate",
+            "infrastructure"
+          ]
+        },
+        "ObservedPropertyObservationType": {
+          "name": "ObservedPropertyObservationType",
+          "values": [
+            "numeric",
+            "zone",
+            "endemic",
+            "incidence",
+            "binary"
+          ]
+        },
+        "PropertyThresholdStatus": {
+          "name": "PropertyThresholdStatus",
+          "values": [
+            "active",
+            "historical",
+            "not_applicable"
+          ]
+        }
+      },
+      "nonModels": {
+        "PlacesPrediction": {
+          "name": "PlacesPrediction",
+          "fields": {
+            "place_id": {
+              "name": "place_id",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "main_text": {
+              "name": "main_text",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "secondary_text": {
+              "name": "secondary_text",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "PlacesAutocompleteResponse": {
+          "name": "PlacesAutocompleteResponse",
+          "fields": {
+            "status": {
+              "name": "status",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "predictions": {
+              "name": "predictions",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lat": {
+              "name": "lat",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lng": {
+              "name": "lng",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "cached": {
+              "name": "cached",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ResolveLocationResponse": {
+          "name": "ResolveLocationResponse",
+          "fields": {
+            "city": {
+              "name": "city",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "state": {
+              "name": "state",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "county": {
+              "name": "county",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "jurisdictionCode": {
+              "name": "jurisdictionCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+            },
+            "hasData": {
+              "name": "hasData",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "isNew": {
+              "name": "isNew",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ManageDataResponse": {
+          "name": "ManageDataResponse",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "action": {
+              "name": "action",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "details": {
+              "name": "details",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "tablesAffected": {
+              "name": "tablesAffected",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            },
+            "recordCount": {
+              "name": "recordCount",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": true,
+              "attributes": []
+            },
+            "error": {
+              "name": "error",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "DeleteAccountDataReturnType": {
+          "name": "DeleteAccountDataReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "deletedCounts": {
+              "name": "deletedCounts",
+              "isArray": false,
+              "type": "AWSJSON",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "SubscribeToNewsletterReturnType": {
+          "name": "SubscribeToNewsletterReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ConfirmNewsletterReturnType": {
+          "name": "ConfirmNewsletterReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        },
+        "ResendConfirmationReturnType": {
+          "name": "ResendConfirmationReturnType",
+          "fields": {
+            "success": {
+              "name": "success",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": true,
+              "attributes": []
+            },
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            }
+          }
+        }
+      },
+      "queries": {
+        "placesAutocomplete": {
+          "name": "placesAutocomplete",
+          "isArray": false,
+          "type": {
+            "nonModel": "PlacesAutocompleteResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "query": {
+              "name": "query",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "sessionToken": {
+              "name": "sessionToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        }
+      },
+      "mutations": {
+        "resolveLocation": {
+          "name": "resolveLocation",
+          "isArray": false,
+          "type": {
+            "nonModel": "ResolveLocationResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "placeId": {
+              "name": "placeId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "sessionToken": {
+              "name": "sessionToken",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "latitude": {
+              "name": "latitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false
+            },
+            "longitude": {
+              "name": "longitude",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false
+            }
+          }
+        },
+        "deleteAccountData": {
+          "name": "deleteAccountData",
+          "isArray": false,
+          "type": {
+            "nonModel": "DeleteAccountDataReturnType"
+          },
+          "isRequired": false
+        },
+        "manageData": {
+          "name": "manageData",
+          "isArray": false,
+          "type": {
+            "nonModel": "ManageDataResponse"
+          },
+          "isRequired": false,
+          "arguments": {
+            "action": {
+              "name": "action",
+              "isArray": false,
+              "type": {
+                "enum": "ManageDataAction"
+              },
+              "isRequired": false
+            }
+          }
+        },
+        "subscribeToNewsletter": {
+          "name": "subscribeToNewsletter",
+          "isArray": false,
+          "type": {
+            "nonModel": "SubscribeToNewsletterReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "country": {
+              "name": "country",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "zip": {
+              "name": "zip",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "callbackURL": {
+              "name": "callbackURL",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            },
+            "lang": {
+              "name": "lang",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        },
+        "confirmNewsletter": {
+          "name": "confirmNewsletter",
+          "isArray": false,
+          "type": {
+            "nonModel": "ConfirmNewsletterReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "confirmationCode": {
+              "name": "confirmationCode",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            }
+          }
+        },
+        "resendConfirmation": {
+          "name": "resendConfirmation",
+          "isArray": false,
+          "type": {
+            "nonModel": "ResendConfirmationReturnType"
+          },
+          "isRequired": false,
+          "arguments": {
+            "email": {
+              "name": "email",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "lang": {
+              "name": "lang",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": "1.4",
+  "analytics": {
+    "amazon_pinpoint": {
+      "app_id": "b24826e79d90457ba3b3a33374632a5c",
+      "aws_region": "ca-central-1"
+    }
+  }
+}

--- a/apps/mobile/app/app.tsx
+++ b/apps/mobile/app/app.tsx
@@ -19,10 +19,17 @@ if (__DEV__) {
 import "./utils/gestureHandler"
 
 import { Amplify } from "aws-amplify"
-import outputs from "../amplify_outputs.json" // eslint-disable-line import/no-unresolved
+import prodOutputs from "../amplify_outputs.json" // eslint-disable-line import/no-unresolved
+import stagingOutputs from "../amplify_outputs.staging.json" // eslint-disable-line import/no-unresolved
+
+import { getEnvOverride } from "./utils/envOverride"
+
+const envOverride = getEnvOverride()
+const outputs = envOverride === "staging" ? stagingOutputs : prodOutputs
 
 if (__DEV__) {
   console.log("=== AMPLIFY CONFIG ===")
+  console.log("Env override:", envOverride)
   console.log("Region:", outputs.auth?.aws_region)
   console.log("GraphQL URL:", outputs.data?.url)
 }

--- a/apps/mobile/app/components/EnvBadge.tsx
+++ b/apps/mobile/app/components/EnvBadge.tsx
@@ -1,0 +1,40 @@
+import { TextStyle, ViewStyle } from "react-native"
+
+import { useAppTheme } from "@/theme/context"
+import type { ThemedStyle } from "@/theme/types"
+import { getEnvOverride } from "@/utils/envOverride"
+
+import { Text } from "./Text"
+
+/**
+ * Renders a small "STAGING" chip when the in-app env override is active.
+ * Reads MMKV synchronously on render, which is fine because the override
+ * only changes via a full bundle reload.
+ */
+export function EnvBadge() {
+  const { themed } = useAppTheme()
+
+  if (getEnvOverride() !== "staging") return null
+
+  return (
+    <Text
+      text="STAGING BACKEND"
+      style={themed($badge)}
+      size="xxs"
+      weight="semiBold"
+      testID="env-badge"
+    />
+  )
+}
+
+const $badge: ThemedStyle<ViewStyle & TextStyle> = ({ colors, spacing }) => ({
+  alignSelf: "center",
+  backgroundColor: colors.palette.statusWarningBg,
+  borderRadius: 6,
+  color: colors.palette.offlineText,
+  letterSpacing: 1,
+  marginBottom: spacing.sm,
+  overflow: "hidden",
+  paddingHorizontal: spacing.sm,
+  paddingVertical: spacing.xxs,
+})

--- a/apps/mobile/app/components/EnvSwitchDialog.tsx
+++ b/apps/mobile/app/components/EnvSwitchDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react"
+import { DevSettings, Modal, Pressable, StyleSheet, View } from "react-native"
+import * as Updates from "expo-updates"
+import { signOut } from "aws-amplify/auth"
+import { Divider, IconButton } from "react-native-paper"
+
+import { useAppTheme } from "@/theme/context"
+import type { AppEnv } from "@/utils/envOverride"
+import { getEnvOverride, setEnvOverride } from "@/utils/envOverride"
+
+import { Button } from "./Button"
+import { infoModalStyles as styles } from "./infoModalStyles"
+import { Text } from "./Text"
+
+interface EnvSwitchDialogProps {
+  visible: boolean
+  onClose: () => void
+}
+
+const ENV_LABEL: Record<AppEnv, string> = {
+  prod: "PROD",
+  staging: "STAGING",
+}
+
+export function EnvSwitchDialog({ visible, onClose }: EnvSwitchDialogProps) {
+  const { theme } = useAppTheme()
+  const [isSwitching, setIsSwitching] = useState(false)
+
+  const current = getEnvOverride()
+  const target: AppEnv = current === "staging" ? "prod" : "staging"
+
+  async function handleConfirm() {
+    setIsSwitching(true)
+    try {
+      try {
+        await signOut()
+      } catch {
+        // user may not be signed in — best effort.
+      }
+      setEnvOverride(target)
+      if (__DEV__) {
+        DevSettings.reload()
+      } else {
+        await Updates.reloadAsync()
+      }
+    } finally {
+      setIsSwitching(false)
+    }
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable
+          style={[styles.container, { backgroundColor: theme.colors.background }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={styles.header}>
+            <Text
+              style={[styles.title, { color: theme.colors.text }]}
+              text="Switch backend environment?"
+            />
+            <IconButton icon="close" size={24} onPress={onClose} disabled={isSwitching} />
+          </View>
+
+          <Divider />
+
+          <View style={styles.content}>
+            <View style={styles.section}>
+              <Text
+                style={[styles.sectionTitle, { color: theme.colors.tint }]}
+                text={`Currently: ${ENV_LABEL[current]}  →  ${ENV_LABEL[target]}`}
+              />
+              <Text
+                style={[styles.body, { color: theme.colors.text }]}
+                text={
+                  target === "staging"
+                    ? "The app will restart and connect to the STAGING backend. Sign in with staging credentials. Production data will not be visible until you switch back."
+                    : "The app will restart and connect to the PRODUCTION backend. Sign in with your normal credentials."
+                }
+              />
+            </View>
+
+            <Button
+              text={isSwitching ? "Restarting..." : `Switch to ${ENV_LABEL[target]} & restart`}
+              preset="reversed"
+              onPress={handleConfirm}
+              disabled={isSwitching}
+              testID="env-switch-confirm-button"
+            />
+            <View style={localStyles.cancelSpacing} />
+            <Button
+              text="Cancel"
+              preset="default"
+              onPress={onClose}
+              disabled={isSwitching}
+              testID="env-switch-cancel-button"
+            />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const localStyles = StyleSheet.create({
+  cancelSpacing: {
+    height: 8,
+  },
+})

--- a/apps/mobile/app/components/SecretEnvTrigger.tsx
+++ b/apps/mobile/app/components/SecretEnvTrigger.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useCallback, useRef } from "react"
+import { Pressable, StyleProp, ViewStyle } from "react-native"
+
+const REQUIRED_TAPS = 5
+const WINDOW_MS = 3000
+
+interface SecretEnvTriggerProps {
+  children: ReactNode
+  onTrigger: () => void
+  style?: StyleProp<ViewStyle>
+  testID?: string
+}
+
+/**
+ * Counts taps on its child and fires `onTrigger` once REQUIRED_TAPS happen
+ * within WINDOW_MS. Resets on success or after a quiet window. Has no visible
+ * UI of its own — it inherits whatever the children draw.
+ *
+ * Used to gate the hidden staging-backend switch behind a 5-tap gesture so
+ * end-users can't trip it accidentally.
+ */
+export function SecretEnvTrigger({ children, onTrigger, style, testID }: SecretEnvTriggerProps) {
+  const tapCount = useRef(0)
+  const firstTapAt = useRef(0)
+
+  const handlePress = useCallback(() => {
+    const now = Date.now()
+    if (tapCount.current === 0 || now - firstTapAt.current > WINDOW_MS) {
+      tapCount.current = 1
+      firstTapAt.current = now
+      return
+    }
+    tapCount.current += 1
+    if (tapCount.current >= REQUIRED_TAPS) {
+      tapCount.current = 0
+      firstTapAt.current = 0
+      onTrigger()
+    }
+  }, [onTrigger])
+
+  return (
+    <Pressable onPress={handlePress} style={style} testID={testID}>
+      {children}
+    </Pressable>
+  )
+}

--- a/apps/mobile/app/screens/ComingSoonScreen.tsx
+++ b/apps/mobile/app/screens/ComingSoonScreen.tsx
@@ -5,11 +5,14 @@
  * Authenticated users bypass this screen entirely via the navigator.
  */
 
-import { FC } from "react"
+import { FC, useState } from "react"
 import { TextStyle, View, ViewStyle } from "react-native"
 
 import { AnimatedLogo } from "@/components/AnimatedLogo"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { useAppTheme } from "@/theme/context"
 import type { ThemedStyle } from "@/theme/types"
@@ -18,11 +21,22 @@ interface ComingSoonScreenProps {}
 
 export const ComingSoonScreen: FC<ComingSoonScreenProps> = function ComingSoonScreen() {
   const { themed } = useAppTheme()
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
 
   return (
     <Screen preset="fixed" safeAreaEdges={["top", "bottom"]} contentContainerStyle={themed($root)}>
       <View style={themed($topSection)}>
-        <AnimatedLogo size={140} style={themed($logo)} />
+        <EnvBadge />
+        {/* Hidden 5-tap gesture on the logo opens the staging-backend switcher.
+            Critical for QA on prod-feature-gated builds where the rest of the
+            app is hidden behind this screen. */}
+        <SecretEnvTrigger
+          onTrigger={() => setEnvDialogOpen(true)}
+          style={themed($logo)}
+          testID="coming-soon-secret-env-trigger"
+        >
+          <AnimatedLogo size={140} />
+        </SecretEnvTrigger>
         <Text tx="comingSoonScreen:heading" preset="heading" style={themed($heading)} />
         <Text tx="comingSoonScreen:preparing" style={themed($preparing)} size="md" />
       </View>
@@ -30,6 +44,8 @@ export const ComingSoonScreen: FC<ComingSoonScreenProps> = function ComingSoonSc
       <View style={themed($bottomSection)}>
         <Text tx="comingSoonScreen:description" style={themed($description)} size="sm" />
       </View>
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/screens/LoginScreen.tsx
+++ b/apps/mobile/app/screens/LoginScreen.tsx
@@ -17,9 +17,12 @@ import {
 import { confirmSignIn, signIn } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Header } from "@/components/Header"
 import { Icon, PressableIcon } from "@/components/Icon"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { TextField, type TextFieldAccessoryProps } from "@/components/TextField"
 import { useAuth } from "@/context/AuthContext"
@@ -60,6 +63,7 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
   // NEW_PASSWORD_REQUIRED (after Cognito raises the
   // CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED challenge).
   const [authStep, setAuthStep] = useState<AuthStep>("SIGN_IN")
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isNewPasswordHidden, setIsNewPasswordHidden] = useState(true)
@@ -277,10 +281,18 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
         safeAreaEdges={[]}
       />
 
-      {/* Welcome Icon */}
-      <View style={themed($iconContainer)}>
+      <EnvBadge />
+
+      {/* Welcome Icon — hidden 5-tap gesture opens the staging-backend switcher.
+          Mounted above the authStep branch so the same trigger covers both the
+          SIGN_IN form and the NEW_PASSWORD_REQUIRED admin gate. */}
+      <SecretEnvTrigger
+        onTrigger={() => setEnvDialogOpen(true)}
+        style={themed($iconContainer)}
+        testID="login-secret-env-trigger"
+      >
         <Icon icon="lock" size={32} color={colors.tint} />
-      </View>
+      </SecretEnvTrigger>
 
       {authStep === "NEW_PASSWORD_REQUIRED" ? (
         <>
@@ -464,6 +476,8 @@ export const LoginScreen: FC<LoginScreenProps> = ({ navigation, route }) => {
           </Pressable>
         </View>
       )}
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/screens/SignupScreen.tsx
+++ b/apps/mobile/app/screens/SignupScreen.tsx
@@ -16,10 +16,13 @@ import {
 import { signUp } from "aws-amplify/auth"
 
 import { Button } from "@/components/Button"
+import { EnvBadge } from "@/components/EnvBadge"
+import { EnvSwitchDialog } from "@/components/EnvSwitchDialog"
 import { Header } from "@/components/Header"
 import { PressableIcon } from "@/components/Icon"
 import { PasswordRequirements, isPasswordValid } from "@/components/PasswordRequirements"
 import { Screen } from "@/components/Screen"
+import { SecretEnvTrigger } from "@/components/SecretEnvTrigger"
 import { Text } from "@/components/Text"
 import { TextField, type TextFieldAccessoryProps } from "@/components/TextField"
 import { usePendingAction, type PendingAction } from "@/context/PendingActionContext"
@@ -55,6 +58,7 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
   const [passwordError, setPasswordError] = useState("")
   const [generalError, setGeneralError] = useState("")
   const [showLoginLink, setShowLoginLink] = useState(false)
+  const [envDialogOpen, setEnvDialogOpen] = useState(false)
 
   const { pendingAction } = usePendingAction()
 
@@ -150,7 +154,12 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
     >
       <Header title="" leftIcon="back" onLeftPress={() => navigation.goBack()} safeAreaEdges={[]} />
 
-      <Text text="Create Account" preset="heading" style={themed($heading)} />
+      <EnvBadge />
+
+      {/* Hidden 5-tap gesture on the heading opens the staging-backend switcher. */}
+      <SecretEnvTrigger onTrigger={() => setEnvDialogOpen(true)} testID="signup-secret-env-trigger">
+        <Text text="Create Account" preset="heading" style={themed($heading)} />
+      </SecretEnvTrigger>
       {pendingAction && (
         <Text
           text={getContextMessage(pendingAction)}
@@ -249,6 +258,8 @@ export const SignupScreen: FC<SignupScreenProps> = ({ navigation }) => {
         preset="default"
         onPress={() => navigation.navigate("Login")}
       />
+
+      <EnvSwitchDialog visible={envDialogOpen} onClose={() => setEnvDialogOpen(false)} />
     </Screen>
   )
 }

--- a/apps/mobile/app/utils/envOverride.ts
+++ b/apps/mobile/app/utils/envOverride.ts
@@ -1,0 +1,22 @@
+import { storage } from "./storage"
+
+export type AppEnv = "prod" | "staging"
+
+export const ENV_OVERRIDE_KEY = "envOverride"
+
+/**
+ * Read synchronously at module load (before Amplify.configure) — MMKV is sync,
+ * so the picked outputs are available on the first JS tick.
+ */
+export function getEnvOverride(): AppEnv {
+  const value = storage.getString(ENV_OVERRIDE_KEY)
+  return value === "staging" ? "staging" : "prod"
+}
+
+export function setEnvOverride(env: AppEnv): void {
+  if (env === "prod") {
+    storage.delete(ENV_OVERRIDE_KEY)
+  } else {
+    storage.set(ENV_OVERRIDE_KEY, env)
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,6 +9,7 @@
     "sandbox": "ampx sandbox",
     "deploy": "ampx pipeline-deploy --branch main --app-id d3jl0ykn4qgj9r",
     "fetch:outputs": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch main --app-id d3jl0ykn4qgj9r --profile rayane && cp amplify_outputs.json ../../apps/mobile/ && cp amplify_outputs.json ../../apps/admin/ && cp amplify_outputs.json ../../",
+    "fetch:outputs:staging": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch staging --app-id d3jl0ykn4qgj9r --profile rayane --out-dir ./.tmp-staging && mv ./.tmp-staging/amplify_outputs.json ./amplify_outputs.staging.json && rm -rf ./.tmp-staging && cp amplify_outputs.staging.json ../../apps/mobile/",
     "lint:check": "echo 'No lint configured'",
     "compile": "tsc --noEmit",
     "clean": "rm -rf dist .amplify",

--- a/scripts/sync-amplify-outputs.sh
+++ b/scripts/sync-amplify-outputs.sh
@@ -11,6 +11,9 @@ ROOT_OUTPUTS="$ROOT_DIR/amplify_outputs.json"
 MOBILE_OUTPUTS="$ROOT_DIR/apps/mobile/amplify_outputs.json"
 WEB_OUTPUTS="$ROOT_DIR/apps/web/amplify_outputs.json"
 
+BACKEND_STAGING_OUTPUTS="$ROOT_DIR/packages/backend/amplify_outputs.staging.json"
+MOBILE_STAGING_OUTPUTS="$ROOT_DIR/apps/mobile/amplify_outputs.staging.json"
+
 if [ -f "$BACKEND_OUTPUTS" ]; then
   cp "$BACKEND_OUTPUTS" "$ROOT_OUTPUTS"
   cp "$BACKEND_OUTPUTS" "$MOBILE_OUTPUTS"
@@ -23,4 +26,18 @@ elif [ -f "$ROOT_OUTPUTS" ]; then
 else
   echo "⚠ No amplify_outputs.json found. Run 'yarn backend:sandbox' to generate one."
   exit 0
+fi
+
+# Staging outputs power the hidden in-app env switcher (envOverride === "staging").
+# The mobile app imports this file at build time, so it MUST exist or the bundle
+# fails to compile. If we can't find a real staging file, fall back to the prod
+# file as a placeholder so the build still works — the toggle will simply route
+# back to prod until the dev runs `yarn fetch:outputs:staging`.
+if [ -f "$BACKEND_STAGING_OUTPUTS" ]; then
+  cp "$BACKEND_STAGING_OUTPUTS" "$MOBILE_STAGING_OUTPUTS"
+  echo "✓ Synced amplify_outputs.staging.json from backend to mobile"
+elif [ ! -f "$MOBILE_STAGING_OUTPUTS" ]; then
+  cp "$MOBILE_OUTPUTS" "$MOBILE_STAGING_OUTPUTS"
+  echo "⚠ No staging amplify_outputs found — copied prod as placeholder."
+  echo "  Run 'yarn fetch:outputs:staging' to populate the real staging config."
 fi


### PR DESCRIPTION
## Summary

- Bundles both prod and staging `amplify_outputs.json` in the mobile app and picks one at boot from an MMKV flag, before `Amplify.configure()` runs.
- Hidden 5-tap gesture (within 3 s) on the lock icon (Login / admin force-change-password gate), the **Create Account** heading (Signup), and the **AnimatedLogo** (ComingSoon feature gate) opens a confirmation dialog.
- Confirming signs the user out (best-effort), persists the flag, and triggers `Updates.reloadAsync()` (or `DevSettings.reload()` in dev) for a clean Amplify reset. A yellow **STAGING BACKEND** badge renders on auth screens whenever the override is active.
- Same gesture toggles back to prod.

## Why

Stakeholders need to verify staging changes on a normal production build without installing a separate internal binary. Behind the gesture so end-users can't trip it accidentally.

## Files

- `apps/mobile/app/utils/envOverride.ts` — sync MMKV getter/setter
- `apps/mobile/app/components/{SecretEnvTrigger,EnvSwitchDialog,EnvBadge}.tsx`
- `apps/mobile/app/app.tsx` — read MMKV before Amplify.configure
- `apps/mobile/app/screens/{LoginScreen,SignupScreen,ComingSoonScreen}.tsx` — wire the trigger
- `apps/mobile/amplify_outputs.staging.json` — bundled staging config (committed)
- `scripts/sync-amplify-outputs.sh` + `packages/backend/package.json` — `yarn fetch:outputs:staging` and sync handling
- `.gitignore` — local backend staging copy stays untracked; mobile bundled copy is tracked

## Test plan

- [ ] Login: tap the lock icon 5× within 3 s — dialog opens with `Currently: PROD → STAGING`.
- [ ] Signup: tap **Create Account** 5× — same dialog.
- [ ] ComingSoon (unauthenticated feature gate): tap the logo 5× — same dialog.
- [ ] Login admin gate (`NEW_PASSWORD_REQUIRED`): lock icon stays mounted, gesture still works.
- [ ] Confirm switch → app reloads → `STAGING BACKEND` badge visible on Login/Signup/ComingSoon, dev console logs the staging AppSync URL, sign-in works against staging Cognito.
- [ ] Tap 5× again on staging → confirm → reloads back to prod, badge gone.
- [ ] 4 taps + pause → counter resets, no dialog. Cancel button → no MMKV write.
- [ ] `npx eslint apps/mobile/app`, `npx tsc --noEmit`, `npm test` — all clean (222/222 tests passing locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)