### PR TITLE
fix(ci): generate amplify_outputs.json in EAS OTA job

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -168,6 +168,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -183,9 +190,19 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Sync amplify_outputs.json
-        run: yarn sync:amplify
-        continue-on-error: true
+      # Generate the prod amplify_outputs.json from the live Amplify backend.
+      # The mobile app imports it at module load (apps/mobile/app/app.tsx) and
+      # bundling fails without it. Mirrors the equivalent step in amplify.yml.
+      # The staging override file (apps/mobile/amplify_outputs.staging.json)
+      # is committed and already present in the checkout.
+      - name: Generate amplify_outputs.json (prod)
+        working-directory: packages/backend
+        run: |
+          AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs \
+            --branch main \
+            --app-id d3jl0ykn4qgj9r
+          cp amplify_outputs.json ../../apps/mobile/amplify_outputs.json
+          cp amplify_outputs.json ../../amplify_outputs.json
 
       - name: Publish update
         working-directory: apps/mobile


### PR DESCRIPTION
## Summary

The \`Publish EAS Update\` job in \`mobile-deploy.yml\` has been broken since it was added in 7ab353c — its Metro bundle step fails to resolve \`apps/mobile/amplify_outputs.json\` because the file is gitignored and the existing \`yarn sync:amplify\` step is a no-op on a fresh CI checkout (no source file to copy from).

This was confirmed by the run history:
- PR #285's first OTA run: ❌ failure
- PR #290's run (just merged): ❌ failure with the same error

Both failed inside Metro:
\`\`\`
Error: Unable to resolve module ../amplify_outputs.json from app/app.tsx
\`\`\`

## Fix

Mirror what \`amplify.yml\` already does for Amplify-side builds:
1. Add \`aws-actions/configure-aws-credentials@v4\` so the job has access to ca-central-1.
2. Replace the no-op \`yarn sync:amplify\` step with an explicit \`ampx generate outputs --branch main --app-id d3jl0ykn4qgj9r\` from \`packages/backend\`, then copy the result into \`apps/mobile/\` (and the repo root, for parity with the script).

The staging override file \`apps/mobile/amplify_outputs.staging.json\` is already committed (added in #290), so it doesn't need regeneration here.

## Why \`--branch main\` even on staging pushes

The mobile feature shipped in #290 bundles **prod outputs as the default** and **staging outputs as the hidden-toggle override**. This applies regardless of which EAS channel the binary lives on — the toggle is the only switching mechanism.

## Test plan

- [ ] After merge to \`staging\`, watch \`mobile-deploy.yml\` run on the merge commit.
- [ ] Confirm the new \`Generate amplify_outputs.json (prod)\` step succeeds (logs should print the generated config).
- [ ] Confirm the \`Publish update\` step bundles cleanly and pushes the OTA to the \`staging\` EAS channel (\`eas update:list --branch staging\`).
- [ ] Once staging is verified, promote to \`main\` so production OTAs start working too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)