### PR TITLE
fix(banners): trivial QA fixes — a11y, datetime, i18n

### DIFF
--- a/apps/admin/src/app/(admin)/banners/page.tsx
+++ b/apps/admin/src/app/(admin)/banners/page.tsx
@@ -94,6 +94,15 @@ interface FormData {
   isActive: boolean;
 }
 
+// Format a Date as `YYYY-MM-DDTHH:mm` in the user's LOCAL timezone, suitable
+// for an <input type="datetime-local">. Using `toISOString()` would emit UTC
+// wall-clock and the input would parse it back as local time, shifting the
+// stored timestamp by the user's UTC offset on every save.
+const formatLocalDateTime = (date: Date) => {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
 const defaultFormData: FormData = {
   title: "",
   titleFr: "",
@@ -103,7 +112,7 @@ const defaultFormData: FormData = {
   city: "",
   state: "",
   country: "",
-  startsAt: new Date().toISOString().slice(0, 16),
+  startsAt: formatLocalDateTime(new Date()),
   expiresAt: "",
   isActive: true,
 };
@@ -172,10 +181,10 @@ export default function BannersPage() {
       state: banner.state || "",
       country: banner.country || "",
       startsAt: banner.startsAt
-        ? new Date(banner.startsAt).toISOString().slice(0, 16)
+        ? formatLocalDateTime(new Date(banner.startsAt))
         : "",
       expiresAt: banner.expiresAt
-        ? new Date(banner.expiresAt).toISOString().slice(0, 16)
+        ? formatLocalDateTime(new Date(banner.expiresAt))
         : "",
       isActive: banner.isActive ?? true,
     });
@@ -185,8 +194,8 @@ export default function BannersPage() {
   const handleSave = async () => {
     const result = bannerFormSchema.safeParse(formData);
     if (!result.success) {
-      const firstError = result.error.issues[0]?.message;
-      toast.error(firstError || "Please fix the form errors");
+      const messages = result.error.issues.map((i) => i.message).join(". ");
+      toast.error(messages || "Please fix the form errors");
       return;
     }
 
@@ -299,6 +308,8 @@ export default function BannersPage() {
                   <Label htmlFor="title">Title (English) *</Label>
                   <Input
                     id="title"
+                    required
+                    aria-required="true"
                     placeholder="e.g., Boil Water Advisory"
                     value={formData.title}
                     onChange={(e) =>
@@ -323,6 +334,8 @@ export default function BannersPage() {
                 <Label htmlFor="description">Description (English) *</Label>
                 <Textarea
                   id="description"
+                  required
+                  aria-required="true"
                   placeholder="Describe the warning..."
                   value={formData.description}
                   onChange={(e) =>
@@ -349,6 +362,8 @@ export default function BannersPage() {
                 <Label htmlFor="severity">Severity *</Label>
                 <select
                   id="severity"
+                  required
+                  aria-required="true"
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   value={formData.severity}
                   onChange={(e) =>
@@ -412,6 +427,8 @@ export default function BannersPage() {
                   <Input
                     id="startsAt"
                     type="datetime-local"
+                    required
+                    aria-required="true"
                     value={formData.startsAt}
                     onChange={(e) =>
                       setFormData({ ...formData, startsAt: e.target.value })
@@ -474,7 +491,9 @@ export default function BannersPage() {
         <CardHeader>
           <CardTitle>All Banners</CardTitle>
           <CardDescription>
-            {banners.length} banner{banners.length !== 1 ? "s" : ""} configured
+            {isLoading
+              ? "Loading…"
+              : `${banners.length} banner${banners.length !== 1 ? "s" : ""} configured`}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -487,6 +506,7 @@ export default function BannersPage() {
               No banners yet. Click &quot;Add Banner&quot; to create one.
             </div>
           ) : (
+            <div className="overflow-x-auto">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -548,6 +568,7 @@ export default function BannersPage() {
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label={`Edit banner: ${banner.title}`}
                           onClick={() => openEditDialog(banner)}
                         >
                           <Pencil className="h-4 w-4" />
@@ -555,6 +576,7 @@ export default function BannersPage() {
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label={`Delete banner: ${banner.title}`}
                           onClick={() => handleDelete(banner)}
                         >
                           <Trash2 className="h-4 w-4 text-red-500" />
@@ -565,6 +587,7 @@ export default function BannersPage() {
                 ))}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/apps/mobile/app/components/AdminWarningBanner.tsx
+++ b/apps/mobile/app/components/AdminWarningBanner.tsx
@@ -112,10 +112,10 @@ export function AdminWarningBanner(props: AdminWarningBannerProps) {
         <View style={$textContainer}>
           <Text style={themedStyles.labelText}>
             {severity === "critical"
-              ? i18n.t("warningBanner.critical")
+              ? i18n.t("warningBanner:critical")
               : severity === "warning"
-                ? i18n.t("warningBanner.warning")
-                : i18n.t("warningBanner.info")}
+                ? i18n.t("warningBanner:warning")
+                : i18n.t("warningBanner:info")}
           </Text>
           <Text style={themedStyles.titleText}>{title}</Text>
           <Text style={themedStyles.descriptionText}>{description}</Text>


### PR DESCRIPTION
## Summary

Trivial-tier follow-ups from a multi-agent review of the Warning Banners admin section (`/banners` on admin staging). Three sub-agents covered: functional CRUD, UX/a11y, and admin↔mobile end-to-end.

## Fixes (effort = S, risk = low)

| Finding | Fix | File |
|---------|-----|------|
| **P0** Edit/Delete row buttons have no accessible name (icons only) | `aria-label="Edit banner: …" / Delete banner: …"` | `apps/admin/src/app/(admin)/banners/page.tsx` |
| **P1** Editing or simply opening the create dialog stamped `startsAt`/`expiresAt` with the user's UTC offset doubled (a 6 PM banner became 10 PM after a no-op edit, broken on every save) | New `formatLocalDateTime(date)` helper builds `YYYY-MM-DDTHH:mm` from local components; replaces `toISOString().slice(0, 16)` on the create-default and edit-prefill | `banners/page.tsx` |
| **P1** Mobile `AdminWarningBanner` rendered the raw i18n key (e.g. `WARNINGBANNER.WARNING`) because the call used `.` instead of i18next's namespace separator `:` | `i18n.t("warningBanner:critical/warning/info")` | `apps/mobile/app/components/AdminWarningBanner.tsx` |
| **P1** Required fields had no `aria-required` / `required` (only a `*` in the label string) | Added to Title, Description, Severity, Starts At | `banners/page.tsx` |
| **P1** Only the first Zod error was surfaced; rest were hidden until each was fixed in turn | `result.error.issues.map(i => i.message).join('. ')` | `banners/page.tsx:185-191` |
| **P2** Action column was clipped off-screen at <840 px viewport (Card had `overflow: visible`) | Wrap `<Table>` in `<div className="overflow-x-auto">` | `banners/page.tsx` |
| **P2** Loading state showed "0 banners configured" before data arrived | Show "Loading…" while `isLoading` | `banners/page.tsx` |

## Deferred (non-trivial — to be filed as separate issues)

- `<AdminWarningBanner>` is gated by `cityData` on `DashboardScreen` — banners targeting cities without measurement data are invisible (product behavior change).
- Admin `Status` column reflects only `isActive` — shows expired banners as "Active" (visible UX change).
- Replace `window.confirm` with shadcn `AlertDialog` (~30 lines).
- Replace native `<select>` with shadcn `Select` (~25 lines).
- Switch validation to `react-hook-form` + `<FormField>` + `<FormMessage>` for inline errors (larger refactor).
- Skip-to-content link & deduplicate `<main>` landmark (admin layout work, not banners-specific).
- Add severity icon to badge (design call).
- Bump action button hit target from 36 px to 44 px.

## Test plan

- [x] `npx eslint` clean on both files
- [x] `npx tsc --noEmit` clean for `apps/admin` and `apps/mobile`
- [x] `useWarningBanners` Jest suite (25 tests) passes
- [ ] Smoke test on staging admin: create banner → reload → time round-trips correctly; edit banner (toggle isActive only) → reload → time stays put
- [ ] Smoke test on staging mobile web: search "Toronto, ON, CA" → admin-created warning banner shows "SPECIAL WARNING" label (not raw i18n key)
- [ ] Tab through banner row → Edit and Delete buttons announce their banner title

🤖 Generated with [Claude Code](https://claude.com/claude-code)