### PR TITLE
fix(dashboard): render warning banners on cities without measurement data

### DIFF
--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -579,6 +579,18 @@ View details: ${shareUrl}`
     marginTop: 8,
   }
 
+  // Admin warning banners — rendered in every branch (populated, empty-data,
+  // error) so emergency advisories reach users for cities that haven't been
+  // seeded with measurement data yet, not just on populated dashboards.
+  const adminBannersJsx =
+    adminBanners.length > 0
+      ? adminBanners.map((banner) => (
+          <View key={banner.id} style={$warningBannerContainer}>
+            <AdminWarningBanner banner={banner} />
+          </View>
+        ))
+      : null
+
   // Empty state for guests - prompt to search for a location
   if (!currentLocation) {
     return (
@@ -674,6 +686,7 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        {adminBannersJsx}
         <View style={$emptyStateContainer}>
           <MaterialCommunityIcons name="wifi-off" size={64} color={theme.colors.textDim} />
           <Text style={$emptyStateTitle}>Unable to load data</Text>
@@ -724,6 +737,7 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        {adminBannersJsx}
         {/* Pollution Sources Card — gated on a real location to avoid landing on
             an empty PollutionSourcesScreen when no city/state is set. */}
         {currentLocation && renderPollutionSourcesCard()}
@@ -900,12 +914,7 @@ View details: ${shareUrl}`
       </View>
 
       {/* Admin Warning Banners */}
-      {adminBanners.length > 0 &&
-        adminBanners.map((banner) => (
-          <View key={banner.id} style={$warningBannerContainer}>
-            <AdminWarningBanner banner={banner} />
-          </View>
-        ))}
+      {adminBannersJsx}
 
       {/* Category Cards */}
       <View style={$categoriesContainer}>


### PR DESCRIPTION
## Summary

Closes the C-Gating finding from #292's QA review.

`<AdminWarningBanner>` was only mounted in the populated dashboard branch (line 902). When a city had no `LocationMeasurement` records, the screen short-circuited to the "No data for X yet" empty state and the banners were never rendered — even though the `useWarningBanners` hook returned them correctly.

Net effect: admins posting an emergency advisory (e.g. boil-water alert) for a smaller town that hasn't been seeded with measurement data would silently fail to deliver to mobile users. Filing as a P1.

## Fix

Lift the banner render into a single `adminBannersJsx` block declared before the early returns. Reuse in:
- the populated branch (no behavior change there)
- the **no-data** branch (closes the gap)
- the **error** branch (so warnings reach users even when the safety-data fetch fails)

The "no current location" and "loading" branches still don't render banners — the user hasn't picked a location yet (so location-specific filters wouldn't have fired) and the loading state is transient.

## Test plan

- [x] `npx eslint apps/mobile/app/screens/DashboardScreen.tsx` clean
- [x] `npx tsc --noEmit` clean
- [x] `useWarningBanners` Jest suite (25 tests) passes
- [ ] On staging mobile web: create a global active warning banner → search a city with no data (e.g. a small town not in the seed set) → banner appears at the top of the empty-state screen
- [ ] Search the same city; force a network error (devtools offline) → banner appears at the top of the error-state screen
- [ ] Banner already showed on populated dashboards (Toronto, NY) before this PR — confirm no regression there

## Why "above the empty-state message" is the right placement

Mirrors the populated branch where banners sit above the category cards: the user lands on a screen, the most urgent information surfaces first. An "advisory" rendered below "No data yet" would be visually deprioritized exactly when it matters most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)