### PR TITLE
fix(mobile): prefetch place resolution to remove location-selection freeze

### DIFF
--- a/apps/mobile/app/components/PlacesSearchBar.test.tsx
+++ b/apps/mobile/app/components/PlacesSearchBar.test.tsx
@@ -4,7 +4,7 @@
 
 import { NavigationContainer } from "@react-navigation/native"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 
 import { PlacesSearchBar } from "./PlacesSearchBar"
 import { ThemeProvider } from "../theme/context"
@@ -30,6 +30,7 @@ jest.mock("@expo-google-fonts/space-grotesk", () => ({
 const mockSearch = jest.fn()
 const mockClearSuggestions = jest.fn()
 const mockResolvePlace = jest.fn()
+const mockPrefetchPlace = jest.fn()
 
 jest.mock("../hooks/useLocationSearch", () => ({
   useLocationSearch: () => ({
@@ -40,6 +41,7 @@ jest.mock("../hooks/useLocationSearch", () => ({
     search: mockSearch,
     clearSuggestions: mockClearSuggestions,
     resolvePlace: mockResolvePlace,
+    prefetchPlace: mockPrefetchPlace,
   }),
 }))
 
@@ -431,6 +433,181 @@ describe("PlacesSearchBar", () => {
       await waitFor(() => {
         expect(getByText("Search is taking too long. Please try again.")).toBeTruthy()
       })
+    })
+  })
+
+  describe("prefetch on press-in", () => {
+    it("calls prefetchPlace on press-in for suggestions with a placeId", async () => {
+      mockSuggestions = [
+        {
+          type: "address" as const,
+          displayText: "123 Main St",
+          secondaryText: "Springfield, IL",
+          placeId: "place123",
+        },
+      ]
+
+      const { getByPlaceholderText, getByLabelText, rerender } = render(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      const input = getByPlaceholderText("Search city or location...")
+      fireEvent.changeText(input, "123 Main")
+
+      rerender(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(getByLabelText("Select 123 Main St")).toBeTruthy()
+      })
+
+      fireEvent(getByLabelText("Select 123 Main St"), "pressIn")
+
+      expect(mockPrefetchPlace).toHaveBeenCalledWith("place123")
+    })
+
+    it("does not call prefetchPlace for suggestions without a placeId", async () => {
+      mockSuggestions = createMockSuggestions()
+
+      const { getByPlaceholderText, getByLabelText, rerender } = render(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      const input = getByPlaceholderText("Search city or location...")
+      fireEvent.changeText(input, "New")
+
+      rerender(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(getByLabelText("Select New York, NY")).toBeTruthy()
+      })
+
+      fireEvent(getByLabelText("Select New York, NY"), "pressIn")
+
+      expect(mockPrefetchPlace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("resolving feedback", () => {
+    it("shows the suggestion text in the input while resolvePlace is pending", async () => {
+      mockSuggestions = [
+        {
+          type: "address" as const,
+          displayText: "123 Main St",
+          secondaryText: "Springfield, IL",
+          placeId: "place123",
+        },
+      ]
+
+      // Controlled promise so the resolve stays pending until we say so.
+      let resolveFn: (value: unknown) => void = () => {}
+      mockResolvePlace.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFn = resolve
+          }),
+      )
+
+      const { getByPlaceholderText, getByLabelText, rerender } = render(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      const input = getByPlaceholderText("Search city or location...")
+      fireEvent.changeText(input, "123 Main")
+
+      rerender(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(getByLabelText("Select 123 Main St")).toBeTruthy()
+      })
+
+      fireEvent.press(getByLabelText("Select 123 Main St"))
+
+      // While the resolve is pending, the input should show the selection text
+      // so the user gets immediate feedback and the screen does not feel frozen.
+      await waitFor(() => {
+        expect(input.props.value).toBe("123 Main St")
+      })
+
+      // Resolve the pending promise — input should clear and onLocationSelect should fire.
+      await act(async () => {
+        resolveFn({
+          city: "Springfield",
+          state: "IL",
+          country: "US",
+          jurisdictionCode: "US-IL",
+          hasData: true,
+          isNew: false,
+        })
+      })
+
+      await waitFor(() => {
+        expect(mockOnLocationSelect).toHaveBeenCalledWith("Springfield", "IL", "US", "123 Main St")
+      })
+
+      expect(input.props.value).toBe("")
+    })
+
+    it("clears resolving label and re-enters editing when resolve fails", async () => {
+      mockSuggestions = [
+        {
+          type: "address" as const,
+          displayText: "Bad Place",
+          secondaryText: "Nowhere",
+          placeId: "place-bad",
+        },
+      ]
+
+      mockResolvePlace.mockResolvedValue(null)
+
+      const { getByPlaceholderText, getByLabelText, rerender } = render(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      const input = getByPlaceholderText("Search city or location...")
+      fireEvent.changeText(input, "Bad")
+
+      rerender(
+        <TestWrapper>
+          <PlacesSearchBar onLocationSelect={mockOnLocationSelect} />
+        </TestWrapper>,
+      )
+
+      await waitFor(() => {
+        expect(getByLabelText("Select Bad Place")).toBeTruthy()
+      })
+
+      fireEvent.press(getByLabelText("Select Bad Place"))
+
+      await waitFor(() => {
+        expect(mockResolvePlace).toHaveBeenCalledWith("place-bad")
+      })
+
+      // After failure, original suggestion text should be back in the input
+      // (existing behavior) and onLocationSelect should NOT have fired.
+      await waitFor(() => {
+        expect(input.props.value).toBe("Bad Place")
+      })
+      expect(mockOnLocationSelect).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/mobile/app/components/PlacesSearchBar.tsx
+++ b/apps/mobile/app/components/PlacesSearchBar.tsx
@@ -98,15 +98,20 @@ export function PlacesSearchBar(props: PlacesSearchBarProps) {
   const [showSuggestions, setShowSuggestions] = useState(false)
   // Track whether user is actively editing (to hide selected location display)
   const [isEditing, setIsEditing] = useState(false)
+  // While resolvePlace is in flight after a tap, show the suggestion label so
+  // the user gets immediate feedback instead of an empty/frozen-feeling input.
+  const [resolvingLabel, setResolvingLabel] = useState<string | null>(null)
 
-  // Display value: show input when editing, otherwise show selected location
-  const displayValue = isEditing
-    ? inputValue
-    : selectedLocation?.city
-      ? `${selectedLocation.city}, ${selectedLocation.state}`
-      : ""
+  // Display value: resolving label > active input > selected location
+  const displayValue =
+    resolvingLabel ??
+    (isEditing
+      ? inputValue
+      : selectedLocation?.city
+        ? `${selectedLocation.city}, ${selectedLocation.state}`
+        : "")
 
-  const { suggestions, isSearching, search, clearSuggestions, resolvePlace, error } =
+  const { suggestions, isSearching, search, clearSuggestions, resolvePlace, prefetchPlace, error } =
     useLocationSearch()
 
   /**
@@ -127,6 +132,17 @@ export function PlacesSearchBar(props: PlacesSearchBarProps) {
     [search, clearSuggestions],
   )
 
+  // Fire a background resolve on press-in so the result is ready (or in flight)
+  // by the time the user releases the press.
+  const handleSuggestionPrefetch = useCallback(
+    (suggestion: SearchSuggestion) => {
+      if (suggestion.placeId) {
+        prefetchPlace(suggestion.placeId)
+      }
+    },
+    [prefetchPlace],
+  )
+
   const handleSuggestionSelect = useCallback(
     async (suggestion: SearchSuggestion) => {
       setShowSuggestions(false)
@@ -136,8 +152,11 @@ export function PlacesSearchBar(props: PlacesSearchBarProps) {
       setInputValue("")
 
       if (suggestion.placeId) {
-        // Resolve the Google Places result to city/state/country
+        // Show the suggestion text in the input while we wait so the tap
+        // does not feel like a freeze.
+        setResolvingLabel(suggestion.displayText)
         const resolved = await resolvePlace(suggestion.placeId)
+        setResolvingLabel(null)
         if (resolved) {
           onLocationSelect(resolved.city, resolved.state, resolved.country, suggestion.displayText)
         } else {
@@ -318,6 +337,7 @@ export function PlacesSearchBar(props: PlacesSearchBarProps) {
         suggestions={suggestions}
         visible={showSuggestions}
         onSelect={handleSuggestionSelect}
+        onPrefetch={handleSuggestionPrefetch}
         onDismiss={handleDismiss}
         isLoading={isSearching}
         error={error}

--- a/apps/mobile/app/components/SearchSuggestionsDropdown.tsx
+++ b/apps/mobile/app/components/SearchSuggestionsDropdown.tsx
@@ -29,6 +29,12 @@ interface SearchSuggestionsDropdownProps {
   visible: boolean
   /** Callback when a suggestion is selected */
   onSelect: (suggestion: SearchSuggestion) => void
+  /**
+   * Optional callback fired the moment the user presses on a suggestion
+   * (touch-down on native, mouse-down on web), before they release. Lets
+   * the parent prefetch the resolution so the eventual select feels instant.
+   */
+  onPrefetch?: (suggestion: SearchSuggestion) => void
   /** Callback when the dropdown should be dismissed (unused, kept for API compatibility) */
   onDismiss?: () => void
   /** Whether search is in progress — shows skeleton loaders */
@@ -68,10 +74,12 @@ function getIconForType(
 function WebSuggestionItem({
   item,
   onSelect,
+  onPrefetch,
   theme,
 }: {
   item: SearchSuggestion
   onSelect: (item: SearchSuggestion) => void
+  onPrefetch?: (item: SearchSuggestion) => void
   theme: ReturnType<typeof useAppTheme>["theme"]
 }) {
   const buttonStyle: React.CSSProperties = {
@@ -104,6 +112,7 @@ function WebSuggestionItem({
     <button
       type="button"
       onClick={() => onSelect(item)}
+      onMouseDown={() => onPrefetch?.(item)}
       aria-label={`Select ${item.displayText}`}
       style={buttonStyle}
       onMouseEnter={(e) => {
@@ -151,6 +160,7 @@ export function SearchSuggestionsDropdown(props: SearchSuggestionsDropdownProps)
     suggestions,
     visible,
     onSelect,
+    onPrefetch,
     isLoading = false,
     error = null,
     headerText = null,
@@ -223,6 +233,7 @@ export function SearchSuggestionsDropdown(props: SearchSuggestionsDropdownProps)
       return (
         <Pressable
           onPress={() => onSelect(item)}
+          onPressIn={() => onPrefetch?.(item)}
           style={({ pressed }) => [
             $itemContainer,
             pressed && { backgroundColor: theme.colors.palette.neutral200 },
@@ -246,7 +257,7 @@ export function SearchSuggestionsDropdown(props: SearchSuggestionsDropdownProps)
         </Pressable>
       )
     },
-    [theme, onSelect],
+    [theme, onSelect, onPrefetch],
   )
 
   const keyExtractor = useCallback(
@@ -370,6 +381,7 @@ export function SearchSuggestionsDropdown(props: SearchSuggestionsDropdownProps)
                 key={keyExtractor(item, index)}
                 item={item}
                 onSelect={onSelect}
+                onPrefetch={onPrefetch}
                 theme={theme}
               />
             ))

--- a/apps/mobile/app/hooks/useLocationSearch.test.ts
+++ b/apps/mobile/app/hooks/useLocationSearch.test.ts
@@ -353,6 +353,139 @@ describe("useLocationSearch", () => {
     })
   })
 
+  describe("prefetchPlace", () => {
+    it("kicks off resolution in the background", async () => {
+      mockResolveLocationByPlaceId.mockResolvedValue({
+        city: "New York",
+        state: "NY",
+        country: "US",
+        jurisdictionCode: "US-NY",
+        hasData: true,
+        isNew: false,
+      })
+
+      const { result } = renderHook(() => useLocationSearch())
+
+      act(() => {
+        result.current.prefetchPlace("place-ny")
+      })
+
+      await waitFor(() => {
+        expect(mockResolveLocationByPlaceId).toHaveBeenCalledWith("place-ny", expect.any(String))
+      })
+    })
+
+    it("resolvePlace reuses the prefetched result without re-calling the API", async () => {
+      mockResolveLocationByPlaceId.mockResolvedValue({
+        city: "New York",
+        state: "NY",
+        country: "US",
+        jurisdictionCode: "US-NY",
+        hasData: true,
+        isNew: false,
+      })
+
+      const { result } = renderHook(() => useLocationSearch())
+
+      act(() => {
+        result.current.prefetchPlace("place-ny")
+      })
+
+      let resolved: Awaited<ReturnType<typeof result.current.resolvePlace>>
+      await act(async () => {
+        resolved = await result.current.resolvePlace("place-ny")
+      })
+
+      expect(mockResolveLocationByPlaceId).toHaveBeenCalledTimes(1)
+      expect(resolved!).not.toBeNull()
+      expect(resolved!.city).toBe("New York")
+    })
+
+    it("triggers a separate resolve for each unique placeId", async () => {
+      mockResolveLocationByPlaceId
+        .mockResolvedValueOnce({
+          city: "New York",
+          state: "NY",
+          country: "US",
+          jurisdictionCode: "US-NY",
+          hasData: true,
+          isNew: false,
+        })
+        .mockResolvedValueOnce({
+          city: "Newark",
+          state: "NJ",
+          country: "US",
+          jurisdictionCode: "US",
+          hasData: false,
+          isNew: true,
+        })
+
+      const { result } = renderHook(() => useLocationSearch())
+
+      act(() => {
+        result.current.prefetchPlace("place-ny")
+        result.current.prefetchPlace("place-newark")
+      })
+
+      await waitFor(() => {
+        expect(mockResolveLocationByPlaceId).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it("clears the cache entry on failure so a retry can succeed", async () => {
+      mockResolveLocationByPlaceId
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce({
+          city: "Toronto",
+          state: "ON",
+          country: "CA",
+          jurisdictionCode: "CA-ON",
+          hasData: true,
+          isNew: false,
+        })
+
+      const { result } = renderHook(() => useLocationSearch())
+
+      let firstResolved: Awaited<ReturnType<typeof result.current.resolvePlace>>
+      await act(async () => {
+        result.current.prefetchPlace("place-toronto")
+        firstResolved = await result.current.resolvePlace("place-toronto")
+      })
+      expect(firstResolved).toBeNull()
+
+      let secondResolved: Awaited<ReturnType<typeof result.current.resolvePlace>>
+      await act(async () => {
+        secondResolved = await result.current.resolvePlace("place-toronto")
+      })
+
+      expect(secondResolved).not.toBeNull()
+      expect(secondResolved!.city).toBe("Toronto")
+      expect(mockResolveLocationByPlaceId).toHaveBeenCalledTimes(2)
+    })
+
+    it("dedupes concurrent resolvePlace calls for the same placeId", async () => {
+      mockResolveLocationByPlaceId.mockResolvedValue({
+        city: "New York",
+        state: "NY",
+        country: "US",
+        jurisdictionCode: "US-NY",
+        hasData: true,
+        isNew: false,
+      })
+
+      const { result } = renderHook(() => useLocationSearch())
+
+      await act(async () => {
+        await Promise.all([
+          result.current.resolvePlace("place-ny"),
+          result.current.resolvePlace("place-ny"),
+        ])
+      })
+
+      expect(mockResolveLocationByPlaceId).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe("resolveAddressToNearestCity (backward compat)", () => {
     it("delegates to resolvePlace and returns legacy format", async () => {
       mockResolveLocationByPlaceId.mockResolvedValue({

--- a/apps/mobile/app/hooks/useLocationSearch.ts
+++ b/apps/mobile/app/hooks/useLocationSearch.ts
@@ -62,6 +62,12 @@ interface UseLocationSearchResult {
   /** Resolve a Google Places placeId to a location with jurisdiction and data availability */
   resolvePlace: (placeId: string) => Promise<ResolvedLocation | null>
   /**
+   * Kick off a resolve in the background and cache the result so a later
+   * resolvePlace call for the same placeId returns instantly. Safe to call
+   * speculatively (e.g. on press-in) — failures are not cached, so retries work.
+   */
+  prefetchPlace: (placeId: string) => void
+  /**
    * @deprecated No longer supported — Google Places is the primary search.
    * Returns empty array for backward compatibility.
    */
@@ -218,36 +224,64 @@ export function useLocationSearch(): UseLocationSearchResult {
     }
   }, [])
 
-  // Resolve a Google Places placeId via the resolveLocation mutation
-  const resolvePlace = useCallback(async (placeId: string): Promise<ResolvedLocation | null> => {
-    try {
-      const result: ResolveLocationResponse = await resolveLocationByPlaceId(
-        placeId,
-        sessionTokenRef.current,
-      )
+  // Cache of in-flight and successfully-resolved promises, keyed by placeId.
+  // Failures clear their entry so a later call can retry. Lets us prefetch
+  // on press-in and reuse the result on the actual select, removing the
+  // "tap → wait → navigate" freeze.
+  const resolveCacheRef = useRef<Map<string, Promise<ResolvedLocation | null>>>(new Map())
 
-      // Regenerate session token after completing a search session
-      sessionTokenRef.current = generateSessionToken()
+  const doResolve = useCallback((placeId: string): Promise<ResolvedLocation | null> => {
+    const cached = resolveCacheRef.current.get(placeId)
+    if (cached) return cached
 
-      if (result.error || !result.city || !result.state || !result.country) {
-        console.error("[Places] Error resolving location:", result.error)
+    const promise = (async (): Promise<ResolvedLocation | null> => {
+      try {
+        const result: ResolveLocationResponse = await resolveLocationByPlaceId(
+          placeId,
+          sessionTokenRef.current,
+        )
+
+        // Regenerate session token after completing a search session
+        sessionTokenRef.current = generateSessionToken()
+
+        if (result.error || !result.city || !result.state || !result.country) {
+          console.error("[Places] Error resolving location:", result.error)
+          resolveCacheRef.current.delete(placeId)
+          return null
+        }
+
+        return {
+          city: result.city,
+          state: result.state,
+          country: result.country,
+          county: result.county,
+          jurisdictionCode: result.jurisdictionCode,
+          hasData: result.hasData,
+          isNew: result.isNew,
+        }
+      } catch (error) {
+        console.error("[Places] Error resolving place:", error)
+        resolveCacheRef.current.delete(placeId)
         return null
       }
+    })()
 
-      return {
-        city: result.city,
-        state: result.state,
-        country: result.country,
-        county: result.county,
-        jurisdictionCode: result.jurisdictionCode,
-        hasData: result.hasData,
-        isNew: result.isNew,
-      }
-    } catch (error) {
-      console.error("[Places] Error resolving place:", error)
-      return null
-    }
+    resolveCacheRef.current.set(placeId, promise)
+    return promise
   }, [])
+
+  const resolvePlace = useCallback(
+    (placeId: string): Promise<ResolvedLocation | null> => doResolve(placeId),
+    [doResolve],
+  )
+
+  const prefetchPlace = useCallback(
+    (placeId: string): void => {
+      // Fire and forget — caller does not need the result.
+      void doResolve(placeId)
+    },
+    [doResolve],
+  )
 
   // Backward-compatible wrapper: delegates to resolvePlace
   const resolveAddressToNearestCity = useCallback(
@@ -292,6 +326,7 @@ export function useLocationSearch(): UseLocationSearchResult {
     search,
     clearSuggestions,
     resolvePlace,
+    prefetchPlace,
     resolveAddressToNearestCity,
     getCitiesForState,
   }


### PR DESCRIPTION
## Summary
- Selecting a location used to freeze the UI for 400–1500ms while `resolvePlace` ran before navigation, with no feedback.
- `useLocationSearch` now exposes `prefetchPlace(placeId)` backed by a shared promise cache; `resolvePlace` reuses cached/in-flight promises (failures clear the entry so retries work).
- `SearchSuggestionsDropdown` fires the prefetch on `onPressIn` (native) / `onMouseDown` (web), giving the resolve a head start before the user lifts their finger.
- `PlacesSearchBar` shows the suggestion label in the input while a resolve is pending, so even a cold cache no longer feels like a freeze.

## Tests
- Hook (`useLocationSearch.test.ts`) — 5 new tests: prefetch fires API call, cache reuse, distinct placeIds each resolve, failure clears cache for retry, concurrent dedupe.
- Component (`PlacesSearchBar.test.tsx`) — 4 new tests: prefetch on press-in with placeId, no prefetch without placeId, resolving label visible while pending, label cleared on failure.
- Full mobile suite: 231/231 passing. Lint + tsc clean.

## Test plan
- [ ] Smoke-test on https://staging.d2z5ddqhlc1q5.amplifyapp.com — search a city, tap a suggestion, confirm input briefly shows the suggestion text and navigation feels responsive.
- [ ] Tap a suggestion that does not exist in jurisdictions / fails resolve — confirm the input restores to the suggestion text and the user can retry.
- [ ] Rapid-tap multiple suggestions in succession — no duplicate Place Details calls (network panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)