### PR TITLE
fix(dashboard): show × Clear in empty/error states and bump light-mode contrast

### DIFF
--- a/apps/mobile/app/components/LocationHeader.tsx
+++ b/apps/mobile/app/components/LocationHeader.tsx
@@ -77,13 +77,16 @@ export function LocationHeader(props: LocationHeaderProps) {
     paddingHorizontal: 12,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: `${theme.colors.tint}40`, // ~25% alpha hairline
-    backgroundColor: `${theme.colors.tint}1A`, // ~10% alpha tint wash
+    // Light-mode tint (primary500 ≈ #9db835) is too pale at low alpha to read
+    // against the off-white screen background, so the chip and outline run a
+    // bit stronger to clear WCAG AA at default page contrast.
+    borderColor: `${theme.colors.tint}66`, // ~40% alpha hairline
+    backgroundColor: `${theme.colors.tint}26`, // ~15% alpha tint wash
   }
 
   const $clearButtonHover: ViewStyle = {
-    backgroundColor: `${theme.colors.tint}33`, // ~20% alpha on hover
-    borderColor: `${theme.colors.tint}80`, // ~50% alpha hairline
+    backgroundColor: `${theme.colors.tint}40`, // ~25% alpha on hover
+    borderColor: `${theme.colors.tint}99`, // ~60% alpha hairline
   }
 
   const $clearButtonWeb: ViewStyle | null =
@@ -114,18 +117,21 @@ export function LocationHeader(props: LocationHeaderProps) {
     transform: [{ scale: 0.97 }],
   }
 
+  // Glyph and label use the theme text color so contrast clears WCAG AA in
+  // both light and dark modes; the chip's tint background and border carry
+  // the "tinted action" identity instead.
   const $clearGlyph: TextStyle = {
     fontSize: 15,
     lineHeight: 15,
     fontWeight: "400",
-    color: theme.colors.tint,
+    color: theme.colors.text,
   }
 
   const $clearLabel: TextStyle = {
     fontSize: 13,
     fontWeight: "500",
     letterSpacing: 0.4,
-    color: theme.colors.tint,
+    color: theme.colors.text,
     // Slight optical alignment with the glyph
     lineHeight: 15,
   }

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -710,6 +710,17 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        <LocationHeader
+          locationName={
+            currentLocation
+              ? [currentLocation.city, currentLocation.state].filter(Boolean).join(", ") ||
+                currentLocation.country ||
+                "Unknown"
+              : "Unknown"
+          }
+          secondaryText={currentLocation?.country === "CA" ? "Canada" : "United States"}
+          onClear={handleClearLocation}
+        />
         {adminBannersJsx}
         <View style={$emptyStateContainer}>
           <MaterialCommunityIcons name="wifi-off" size={64} color={theme.colors.textDim} />
@@ -761,6 +772,17 @@ View details: ${shareUrl}`
             onLocationErrorDismiss={clearLocationError}
           />
         </View>
+        <LocationHeader
+          locationName={
+            currentLocation
+              ? [currentLocation.city, currentLocation.state].filter(Boolean).join(", ") ||
+                currentLocation.country ||
+                "Unknown"
+              : "Unknown"
+          }
+          secondaryText={currentLocation?.country === "CA" ? "Canada" : "United States"}
+          onClear={handleClearLocation}
+        />
         {adminBannersJsx}
         {/* Pollution Sources Card — admin-gated via AppConfig flag and gated on
             a real location to avoid landing on an empty PollutionSourcesScreen


### PR DESCRIPTION
## Summary
- Follow-up to #305. The × Clear pill was only wired into the happy-path branch of `DashboardScreen`. Users landing on a city without seeded data (empty-state branch) or hitting a fetch error (error branch) saw no clear control — the exact case the feature was meant to address. `LocationHeader` is now rendered in both early-return branches with the same `onClear={handleClearLocation}` wiring.
- Bumped light-mode contrast on the chip. The lime tint (`primary500 ≈ #9db835`) at 10% alpha barely separated from `neutral200` page bg, and the 13px label was tint-on-tint at ~2.4:1 — below WCAG AA. The glyph and label now use `theme.colors.text` (≥11:1 in both modes); the chip keeps its tinted-action identity via a stronger background (~15%) and border (~40% alpha).

## Test plan
- [ ] Staging Amplify mobile-web build succeeds for the merge commit, then hard-reload.
- [ ] Visit a city *without* seeded data (e.g. `?city=Saskatoon&state=SK&country=CA`). Confirm the **× Clear** pill renders in the LocationHeader and tapping it strips `?city=…` from the URL and returns to the search-only state.
- [ ] Force the error branch (offline mode in DevTools, then visit an uncached city URL). Confirm the **× Clear** pill renders and works.
- [ ] Regression: visit `?city=Sorel-Tracy&state=QC&country=CA`. Confirm the pill still renders and clears (this branch was already wired).
- [ ] In light mode (default), confirm the "× Clear" label is comfortably legible against the chip and the chip is visibly distinct from the page background.
- [ ] Switch to dark mode; confirm the chip remains readable and matches the rest of the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)