### PR TITLE
fix(mobile): water-quality sub-category filter + per-row units (EPI-18 A/C)

### DIFF
--- a/apps/mobile/app/components/ContaminantTable.test.tsx
+++ b/apps/mobile/app/components/ContaminantTable.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Tests for ContaminantTable
+ *
+ * Pins the per-row unit rendering introduced for EPI-18 sub-bug C.
+ * Pre-fix, the table read `rows[0].unit` once and reused it for every
+ * cell — so a table with Strontium-90 (Bq/L) sorted first would label
+ * Lead's threshold "5 Bq/L" instead of "5 μg/L". The new behavior is to
+ * use each row's own `unit` field; the optional `unit` prop on the table
+ * remains as an explicit override.
+ *
+ * The component pulls in `@/theme/context`, which transitively imports
+ * `@expo-google-fonts/space-grotesk` (broken in jest in this monorepo).
+ * Mock `useAppTheme` directly. Same pattern as LocationScopeBadge.test.tsx.
+ */
+
+import { render } from "@testing-library/react-native"
+
+jest.mock("@/theme/context", () => ({
+  useAppTheme: () => ({
+    theme: {
+      colors: {
+        text: "#000",
+        textDim: "#666",
+        background: "#fff",
+        tint: "#0284C7",
+        palette: {
+          neutral100: "#F5F5F5",
+          neutral200: "#E5E5E5",
+          neutral300: "#D4D4D4",
+        },
+      },
+    },
+    themed: (style: unknown) => style,
+  }),
+}))
+
+// Avoid pulling in the auto-generated health-effects table. If a row has
+// no contaminantId, the info button is never rendered and this lookup
+// never runs — but keep the mock for safety.
+jest.mock("@/data/contaminantHealthEffects", () => ({
+  hasHealthEffectsData: () => false,
+}))
+
+// eslint-disable-next-line import/first
+import { ContaminantTable, type ContaminantTableRow } from "./ContaminantTable"
+
+const baseRow = {
+  contaminantId: undefined,
+  localJurisdictionName: "QUEBEC",
+  status: "danger" as const,
+  isUnregulated: false,
+}
+
+describe("ContaminantTable", () => {
+  describe("EPI-18 sub-bug C: per-row unit rendering", () => {
+    it("renders each row's own unit, even when units differ across rows", () => {
+      const rows: ContaminantTableRow[] = [
+        // Tritium sorts first — pre-fix, its Bq/L unit was reused for
+        // every other row. The fix uses each row's `unit`.
+        {
+          ...baseRow,
+          name: "Tritium",
+          value: 7000,
+          unit: "Bq/L",
+          whoLimit: 10000,
+          localLimit: 7000,
+        },
+        { ...baseRow, name: "Lead", value: 5, unit: "μg/L", whoLimit: 10, localLimit: 5 },
+      ]
+
+      const { queryByText } = render(<ContaminantTable rows={rows} />)
+
+      // Tritium row should still read in Bq/L — the original behavior
+      // for radioactives was correct.
+      expect(queryByText("10000 Bq/L")).toBeTruthy()
+      expect(queryByText("7000 Bq/L")).toBeTruthy()
+
+      // Lead row must read in μg/L. Pre-fix, this would have rendered
+      // as "10 Bq/L" / "5 Bq/L" because Tritium's unit leaked across.
+      expect(queryByText("10 μg/L")).toBeTruthy()
+      expect(queryByText("5 μg/L")).toBeTruthy()
+
+      // Lead's thresholds must NOT carry Tritium's unit label.
+      expect(queryByText("10 Bq/L")).toBeNull()
+      expect(queryByText("5 Bq/L")).toBeNull()
+    })
+
+    it("respects the explicit `unit` prop as a global override", () => {
+      const rows: ContaminantTableRow[] = [
+        { ...baseRow, name: "Lead", value: 5, unit: "μg/L", whoLimit: 10, localLimit: 5 },
+      ]
+
+      const { queryByText } = render(<ContaminantTable rows={rows} unit="ng/L" />)
+
+      // The override wins over the row's own unit.
+      expect(queryByText("10 ng/L")).toBeTruthy()
+      expect(queryByText("5 ng/L")).toBeTruthy()
+      expect(queryByText("10 μg/L")).toBeNull()
+    })
+
+    it("formats absent thresholds without a unit", () => {
+      const rows: ContaminantTableRow[] = [
+        {
+          ...baseRow,
+          name: "Glyphosate",
+          value: 280,
+          unit: "μg/L",
+          whoLimit: null,
+          localLimit: null,
+        },
+      ]
+
+      const { queryByText } = render(<ContaminantTable rows={rows} />)
+
+      // Local cell renders "N/A" when localLimit is null; WHO cell
+      // renders "NO STANDARD". Neither should append a unit.
+      expect(queryByText("N/A")).toBeTruthy()
+      expect(queryByText("NO STANDARD")).toBeTruthy()
+    })
+  })
+})

--- a/apps/mobile/app/components/ContaminantTable.tsx
+++ b/apps/mobile/app/components/ContaminantTable.tsx
@@ -49,8 +49,6 @@ export function ContaminantTable(props: ContaminantTableProps) {
   const { rows, unit, onWhoHeaderPress, onLocalHeaderPress } = props
   const { theme } = useAppTheme()
 
-  const displayUnit = unit || (rows.length > 0 ? rows[0].unit : "")
-
   const $container: ViewStyle = {
     marginTop: 16,
   }
@@ -143,13 +141,20 @@ export function ContaminantTable(props: ContaminantTableProps) {
 
   const localJurisdictionLabel = rows.length > 0 ? rows[0].localJurisdictionName : "LOCAL"
 
+  // EPI-18 sub-bug C: render each row's own unit instead of the first
+  // row's unit (or the optional `unit` prop). The previous behavior caused
+  // every cell to render with "Bq/L" — the first row's unit, since radioactive
+  // contaminants tend to sort first — so Lead and Mercury (μg/L) showed up
+  // labeled in becquerels.
   const formatValue = (
     value: number | null,
+    rowUnit: string,
     options?: { isUnregulated?: boolean; isLocal?: boolean },
   ): string => {
     if (options?.isUnregulated) return "UNREGULATED"
     if (value === null) return options?.isLocal ? "N/A" : "NO STANDARD"
-    return `${value} ${displayUnit}`
+    const effectiveUnit = unit || rowUnit
+    return `${value} ${effectiveUnit}`
   }
 
   return (
@@ -200,12 +205,15 @@ export function ContaminantTable(props: ContaminantTableProps) {
             <Text
               style={row.localLimit === null || row.isUnregulated ? $unregulatedText : $valueText}
             >
-              {formatValue(row.localLimit, { isUnregulated: row.isUnregulated, isLocal: true })}
+              {formatValue(row.localLimit, row.unit, {
+                isUnregulated: row.isUnregulated,
+                isLocal: true,
+              })}
             </Text>
           </View>
           <View style={$valueCell}>
             <Text style={row.whoLimit === null ? $unregulatedText : $valueText}>
-              {formatValue(row.whoLimit)}
+              {formatValue(row.whoLimit, row.unit)}
             </Text>
           </View>
           <View style={$statusCell}>

--- a/apps/mobile/app/hooks/useLocationData.test.ts
+++ b/apps/mobile/app/hooks/useLocationData.test.ts
@@ -484,3 +484,49 @@ describe("useLocationData", () => {
     })
   })
 })
+
+describe("filterStatsBySubCategory (EPI-18 sub-bug A)", () => {
+  // Re-import to get the helper without going through the hook.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { filterStatsBySubCategory } = require("./useLocationData")
+
+  type Item = {
+    stat: { statId: string; value: number; status: string; lastUpdated: string }
+    definition: { id: string; category: string }
+  }
+
+  const items: Item[] = [
+    {
+      stat: { statId: "nitrate", value: 10000, status: "warning", lastUpdated: "" },
+      definition: { id: "nitrate", category: "fertilizer" },
+    },
+    {
+      stat: { statId: "atrazine", value: 5, status: "danger", lastUpdated: "" },
+      definition: { id: "atrazine", category: "pesticide" },
+    },
+    {
+      stat: { statId: "lead", value: 5, status: "danger", lastUpdated: "" },
+      definition: { id: "lead", category: "inorganic" },
+    },
+  ]
+
+  it("filters to a single sub-category when subCategoryId is provided", () => {
+    const result = filterStatsBySubCategory(items, "fertilizer")
+    expect(result.map((i: Item) => i.stat.statId)).toEqual(["nitrate"])
+  })
+
+  it("returns the input unchanged when subCategoryId is undefined", () => {
+    const result = filterStatsBySubCategory(items, undefined)
+    expect(result).toBe(items)
+  })
+
+  it("returns the input unchanged when subCategoryId is an empty string", () => {
+    const result = filterStatsBySubCategory(items, "")
+    expect(result).toBe(items)
+  })
+
+  it("returns an empty array when no contaminant matches", () => {
+    const result = filterStatsBySubCategory(items, "microbiological")
+    expect(result).toEqual([])
+  })
+})

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -440,3 +440,25 @@ export function getRiskStatsForCategory(
     ({ stat }) => stat.status === "danger" || stat.status === "warning",
   )
 }
+
+/**
+ * Filter a stats array to a single sub-category (Fertilizers, Pesticides,
+ * Heavy Metals & Inorganics, etc.) by matching the contaminant's own
+ * `category` field against the sub-category id from the route.
+ *
+ * Used when CategoryDetailScreen is opened from a sub-category tap on the
+ * dashboard so that "Fertilizers" surfaces only fertilizer contaminants
+ * instead of every water contaminant. EPI-18 sub-bug A.
+ *
+ * `subCategoryId` is the value carried in the route param — lowercased and
+ * singular, matching the storage shape of `Contaminant.category` (e.g.
+ * "fertilizer", "pesticide", "radioactive", "inorganic", "organic",
+ * "disinfectant", "microbiological").
+ */
+export function filterStatsBySubCategory<T extends { definition: { category?: string | null } }>(
+  stats: T[],
+  subCategoryId: string | undefined,
+): T[] {
+  if (!subCategoryId) return stats
+  return stats.filter(({ definition }) => definition.category === subCategoryId)
+}

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -33,7 +33,11 @@ import {
   getLocalStandardsLink,
 } from "@/data/categoryConfig"
 import { StatCategory } from "@/data/types/safety"
-import { useLocationData, getRiskStatsForCategory } from "@/hooks/useLocationData"
+import {
+  useLocationData,
+  getRiskStatsForCategory,
+  filterStatsBySubCategory,
+} from "@/hooks/useLocationData"
 import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { useAppTheme } from "@/theme/context"
 import { trackEvent } from "@/utils/analytics"
@@ -86,11 +90,15 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
     }
   }, [refresh])
 
-  // Get risk stats for this category (only warning/danger, no safe stats)
-  const stats = useMemo(
-    () => (cityData ? getRiskStatsForCategory(cityData, category, statDefinitions) : []),
-    [cityData, category, statDefinitions],
-  )
+  // Get risk stats for this category (only warning/danger, no safe stats).
+  // When the user landed here by tapping a sub-category on the dashboard,
+  // `subCategoryId` is set in the route params — narrow the rows to the
+  // contaminants that actually belong to that sub-category (EPI-18 sub-bug A).
+  const stats = useMemo(() => {
+    if (!cityData) return []
+    const all = getRiskStatsForCategory(cityData, category, statDefinitions)
+    return filterStatsBySubCategory(all, subCategoryId)
+  }, [cityData, category, statDefinitions, subCategoryId])
 
   // Get category display info - try dynamic first, then fallback to hardcoded
   const categoryId = String(category)


### PR DESCRIPTION
## Summary

Fixes the two clean-scope rendering bugs uncovered while reproducing [EPI-18](https://linear.app/epiphany-apps/issue/EPI-18/):

- **Sub-bug A** — `subCategoryId` route param was destructured in `CategoryDetailScreen` but never used as a filter. Tapping "Fertilizers" on the dashboard navigated to a screen showing all 52 water contaminants (radioactives, heavy metals, pesticides, etc.).
- **Sub-bug C** — `ContaminantTable` picked the first row's unit (\`rows[0].unit\`) and reused it for every cell. Radioactive contaminants tend to sort first → every cell was labeled \"Bq/L\" even for Lead/Mercury/Nitrate (μg/L) and PFAS (ng/L).

## What changed

\`apps/mobile/app/hooks/useLocationData.ts\`
- New \`filterStatsBySubCategory\` helper: drops rows whose \`definition.category\` does not match the supplied \`subCategoryId\`. No-op when \`subCategoryId\` is undefined/empty (deep-link \`category/water\` continues to show the full category list).

\`apps/mobile/app/screens/CategoryDetailScreen.tsx\`
- Imports the new helper and applies it after \`getRiskStatsForCategory\`.

\`apps/mobile/app/components/ContaminantTable.tsx\`
- \`formatValue\` now takes the row's own \`unit\` and uses it. The optional \`unit\` prop on the table remains as an explicit override.
- Removed the broken \`displayUnit\` constant.

\`apps/mobile/app/hooks/useLocationData.test.ts\`
- Four new cases for \`filterStatsBySubCategory\`: filters correctly, no-op for undefined/empty, returns empty when nothing matches. **21 tests total, all green.**

## What this does NOT cover

- **Sub-bug B (every row marked danger)** — root cause is the status recomputation in \`useLocationData\` evaluating against the local-jurisdiction threshold (QC's are tighter than WHO's), which is technically correct but UX-misleading per Rayane's feedback. Decision pending: hide \`safe-by-WHO\` rows behind a toggle, visually de-emphasize them, or surface a separate \"exceeds local only\" indicator. Tracked in EPI-18.
- **Sub-bug D (duplicate rows)** — caused by cascade leaking Boucherville's measurements onto Sorel-Tracy. Solved by #312 (cascade-bleed fix). After #312 deploys, Sorel-Tracy resolves to 0 measurements and the duplicate rows disappear naturally.

## Pre-merge checks

- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npx eslint app/hooks/useLocationData.ts app/hooks/useLocationData.test.ts app/screens/CategoryDetailScreen.tsx app/components/ContaminantTable.tsx\` — clean (one prettier nit auto-fixed).
- [x] \`npx jest app/hooks/useLocationData.test.ts\` — **21 / 21** tests pass (4 new).

## Test plan after staging deploy

- [ ] Open \`https://staging.d2z5ddqhlc1q5.amplifyapp.com/?city=Boucherville&state=QC&country=CA\` (Boucherville has city-anchored data so the cascade fix doesn't change its content). Tap Water Quality → Fertilizers. Expect only Nitrate / Nitrite / Nitrilotriacetic acid (or whatever \`Contaminant.category === \"fertilizer\"\` maps to in seed data).
- [ ] Tap Water Quality → Heavy Metals & Inorganics. Expect Lead, Mercury, Cadmium, Copper, Arsenic, Antimony, Barium (Boron is currently mis-seeded as Organic Compounds — separate data-correction follow-up).
- [ ] Inspect any displayed row — Lead should read \"5 μg/L\" (or \"5 µg/L\"), not \"5 Bq/L\". Tritium / Strontium-90 should still read in Bq/L.
- [ ] After #312 also lands, Sorel-Tracy → Water Quality should be empty (no Boucherville bleed, no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)