### PR TITLE
docs(admin/guide): add concise capabilities overview covering every admin section

### DIFF
--- a/apps/admin/src/app/(admin)/guide/page.tsx
+++ b/apps/admin/src/app/(admin)/guide/page.tsx
@@ -12,7 +12,9 @@ import {
   Database,
   FileSpreadsheet,
   GitBranch,
+  LayoutGrid,
   Lightbulb,
+  Smartphone,
   VolumeX,
 } from "lucide-react";
 import {
@@ -29,6 +31,193 @@ const crossCuttingTopics = [
   { id: "best-practices", title: "Best Practices" },
 ];
 
+/** One row per admin route. `bulk` reflects what you can do today via
+ *  the form / file upload (Yes = file upload, Export only = JSON export
+ *  with no matching import path). `mobile` is what end users feel when
+ *  you change something here. Keep entries scan-friendly. */
+type CapabilityRow = {
+  section: string;
+  route: string;
+  whatYouCanDo: string;
+  bulk: "Yes" | "No" | "Export only";
+  mobile: string;
+};
+
+const capabilityRows: CapabilityRow[] = [
+  {
+    section: "Dashboard",
+    route: "/",
+    whatYouCanDo: "Read-only platform stats; entry point to the rest of admin.",
+    bulk: "No",
+    mobile: "—",
+  },
+  {
+    section: "Analytics",
+    route: "/analytics",
+    whatYouCanDo: "Aggregate usage and city-traffic analytics.",
+    bulk: "No",
+    mobile: "—",
+  },
+  {
+    section: "Contaminants",
+    route: "/stats",
+    whatYouCanDo:
+      "Define what gets measured (174 contaminants — name EN/FR, category, unit, higherIsBad).",
+    bulk: "Export only",
+    mobile: "Drives names + categorization on Water/Air drill-down",
+  },
+  {
+    section: "Thresholds",
+    route: "/thresholds",
+    whatYouCanDo:
+      "Per-jurisdiction limit + warningRatio for each contaminant (WHO, US-NY, CA-QC, …).",
+    bulk: "No",
+    mobile: "Powers safe / warning / danger status colors",
+  },
+  {
+    section: "Jurisdictions",
+    route: "/jurisdictions",
+    whatYouCanDo: "Add or rename regulatory regions (countries, states, EU, WHO).",
+    bulk: "No",
+    mobile: "Drives WHO vs. local column on water table",
+  },
+  {
+    section: "Categories",
+    route: "/categories",
+    whatYouCanDo: "Top-level dashboard groupings (Water, Air, …): name, icon, color, isActive.",
+    bulk: "No",
+    mobile: "Dashboard category cards",
+  },
+  {
+    section: "Sub-Categories",
+    route: "/subcategories",
+    whatYouCanDo:
+      "Group contaminants under a category (Fertilizers, Pesticides, Heavy Metals, …).",
+    bulk: "No",
+    mobile: "Sub-category rows under each category card",
+  },
+  {
+    section: "Location Stats",
+    route: "/zip-codes",
+    whatYouCanDo:
+      "List of cities that have measurements; click Manage to edit measurements one by one.",
+    bulk: "No",
+    mobile: "Source of the per-city contaminant table",
+  },
+  {
+    section: "Import Data",
+    route: "/import",
+    whatYouCanDo:
+      "Upload CSV / JSON / Excel of LocationMeasurement rows for Water Quality and Air Pollution.",
+    bulk: "Yes",
+    mobile: "Populates the city's contaminant table after import",
+  },
+  {
+    section: "Warning Banners",
+    route: "/banners",
+    whatYouCanDo:
+      "Post per-location, time-windowed advisories with severity (boil-water, tick alert, etc.).",
+    bulk: "No",
+    mobile: "Banner at the top of the dashboard for that location",
+  },
+  {
+    section: "Landing Page",
+    route: "/landing-page",
+    whatYouCanDo: "Edit the marketing landing page (hero copy, logo, CTA, theme preview).",
+    bulk: "No",
+    mobile: "—  (web landing only)",
+  },
+  {
+    section: "Hazard Reports",
+    route: "/reports",
+    whatYouCanDo: "Review and moderate user-submitted hazard reports.",
+    bulk: "No",
+    mobile: '"Report Hazard" button writes here',
+  },
+  {
+    section: "Subscribers",
+    route: "/subscribers",
+    whatYouCanDo: "View newsletter signups captured by the landing page.",
+    bulk: "No",
+    mobile: "—",
+  },
+  {
+    section: "Pollution Sources",
+    route: "/pollution-sources",
+    whatYouCanDo:
+      "Plot industrial sites / landfills / spills on a map with severity, impact radius, status.",
+    bulk: "No",
+    mobile: "Not surfaced — consumer card removed in #309",
+  },
+  {
+    section: "Testing Guide",
+    route: "/testing",
+    whatYouCanDo: "Internal QA reference: staging URLs, test accounts, smoke checklist.",
+    bulk: "No",
+    mobile: "—",
+  },
+  {
+    section: "Guide",
+    route: "/guide",
+    whatYouCanDo: "This page — what each admin section does and how it reaches mobile.",
+    bulk: "No",
+    mobile: "—",
+  },
+  {
+    section: "Settings",
+    route: "/settings",
+    whatYouCanDo:
+      "App-wide feature toggles (Coming Soon Gate) + destructive Wipe / Reseed actions.",
+    bulk: "No",
+    mobile: "Coming Soon Gate flips the unauthenticated mobile entry",
+  },
+  {
+    section: "Properties",
+    route: "/properties",
+    whatYouCanDo:
+      "Define observed-property catalog (radon, lyme_disease, …): zone / endemic / numeric / incidence / binary.",
+    bulk: "Export only",
+    mobile: "—  (admin-curated catalog)",
+  },
+  {
+    section: "Property Thresholds",
+    route: "/property-thresholds",
+    whatYouCanDo:
+      "Per-jurisdiction rules per property (zone-mapping JSON, endemic-is-danger flag, incidence cutoffs).",
+    bulk: "No",
+    mobile: "—  (admin-curated catalog)",
+  },
+  {
+    section: "Observations",
+    route: "/observations",
+    whatYouCanDo:
+      "Per-location observation (radon zone for a county, Lyme endemic status for a province, …).",
+    bulk: "No",
+    mobile: "Not surfaced — consumer card removed in #309",
+  },
+];
+
+const dataPatterns = [
+  {
+    pattern: "Time-bounded advisory",
+    examples: "Boil-water notice, tick-season warning, post-spill plant alert.",
+    where: "/banners",
+    bulk: "No (one banner per location, per advisory).",
+  },
+  {
+    pattern: "Per-city water/air measurements",
+    examples: "Lead, nitrate, atrazine, radon-in-air for a specific city.",
+    where: "/import (bulk) or /zip-codes (per-record)",
+    bulk: "Yes — Water Quality + Air Pollution tabs accept CSV / JSON / Excel.",
+  },
+  {
+    pattern: "Reference catalog",
+    examples: "EPA radon zones, INSPQ Lyme endemic status, landfill location + impact radius.",
+    where: "/observations (per-record) or /pollution-sources (map-pin)",
+    bulk: "No bulk path today — coordinate before loading large datasets.",
+  },
+];
+
 export default function GuidePage() {
   return (
     <div className="space-y-8">
@@ -39,6 +228,107 @@ export default function GuidePage() {
           mobile users will experience your changes.
         </p>
       </div>
+
+      {/* Capabilities at a glance — every admin route in one scan-friendly table. */}
+      <Card id="capabilities-overview" className="scroll-mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <LayoutGrid className="h-5 w-5" />
+            Capabilities at a glance
+          </CardTitle>
+          <CardDescription>
+            Every admin section in one row: what you can do, whether bulk
+            upload exists, and how a mobile user feels your change.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Section</th>
+                  <th className="py-2 pr-4 font-medium">Route</th>
+                  <th className="py-2 pr-4 font-medium">What you can do</th>
+                  <th className="py-2 pr-4 font-medium">Bulk</th>
+                  <th className="py-2 font-medium">Mobile surface</th>
+                </tr>
+              </thead>
+              <tbody>
+                {capabilityRows.map((row) => (
+                  <tr key={row.route} className="border-b last:border-0 align-top">
+                    <td className="py-2 pr-4 font-medium whitespace-nowrap">
+                      {row.section}
+                    </td>
+                    <td className="py-2 pr-4 whitespace-nowrap">
+                      <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                        {row.route}
+                      </code>
+                    </td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {row.whatYouCanDo}
+                    </td>
+                    <td className="py-2 pr-4 whitespace-nowrap">
+                      <span
+                        className={
+                          row.bulk === "Yes"
+                            ? "text-green-700 dark:text-green-400 font-medium"
+                            : row.bulk === "Export only"
+                              ? "text-amber-700 dark:text-amber-400"
+                              : "text-muted-foreground"
+                        }
+                      >
+                        {row.bulk}
+                      </span>
+                    </td>
+                    <td className="py-2 text-muted-foreground">{row.mobile}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Three patterns — answers "where do I add X?" */}
+      <Card id="data-patterns" className="scroll-mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Smartphone className="h-5 w-5" />
+            Where do I add this kind of data?
+          </CardTitle>
+          <CardDescription>
+            Pick the pattern that matches your data, then jump to the section.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Pattern</th>
+                  <th className="py-2 pr-4 font-medium">Examples</th>
+                  <th className="py-2 pr-4 font-medium">Where</th>
+                  <th className="py-2 font-medium">Bulk</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dataPatterns.map((row) => (
+                  <tr key={row.pattern} className="border-b last:border-0 align-top">
+                    <td className="py-2 pr-4 font-medium">{row.pattern}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">{row.examples}</td>
+                    <td className="py-2 pr-4">
+                      <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                        {row.where}
+                      </code>
+                    </td>
+                    <td className="py-2 text-muted-foreground">{row.bulk}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Table of contents */}
       <Card>


### PR DESCRIPTION
## Summary

Adds two scan-friendly cards at the top of \`/guide\` so a new admin (or Rayane) can quickly understand what every admin section does and where their data should land.

### 1. Capabilities at a glance

One row per admin route. Twenty rows total. Columns: **Section** / **Route** / **What you can do** / **Bulk** / **Mobile surface**.

The Bulk column is color-coded:
- **Green \"Yes\"** — file upload exists today (only \`/import\` for water/air measurements right now)
- **Amber \"Export only\"** — JSON export available, no matching import path (\`/stats\`, \`/properties\`)
- **Muted \"No\"** — single-record entry only (the rest)

The Mobile surface column tells you exactly what end users feel when you change something here (e.g. \"Banner at the top of the dashboard for that location\", \"Coming Soon Gate flips the unauthenticated mobile entry\", \"Not surfaced — consumer card removed in #309\").

### 2. Where do I add this kind of data?

Three rows matching the three patterns admin supports:

| Pattern | Where |
|---|---|
| Time-bounded advisory (boil-water, tick alert) | \`/banners\` |
| Per-city measurement (lead, nitrate, radon-in-air) | \`/import\` (bulk) or \`/zip-codes\` (per-record) |
| Reference catalog (radon zones, endemic status, landfills) | \`/observations\` or \`/pollution-sources\` (no bulk path today) |

Helps Rayane answer \"my dataset has shape X — where does it go?\" without an engineering DM.

## What this does NOT change

- Existing per-section detail cards stay below for deep-dive.
- No model schema changes. No mobile changes.
- The \`/guide\` redesign work-in-progress mentioned in earlier sessions (the new \`AdminSectionCard\` / \`FieldTable\` components) is untouched.

## Pre-merge checks

- [x] \`npx tsc --noEmit\` (admin) — clean.
- [x] \`npm run lint\` (admin) — no new warnings on \`guide/page.tsx\`.

## Test plan after staging deploy

- [ ] \`https://staging.d26q32gc98goap.amplifyapp.com/guide\` loads.
- [ ] Two new cards render at the top, in order: \"Capabilities at a glance\" then \"Where do I add this kind of data?\".
- [ ] Capabilities table has 20 rows, each with route + description + bulk + mobile surface.
- [ ] Bulk column color-coded (green / amber / muted).
- [ ] Existing detail cards still render below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)