### PR TITLE
chore(admin): mark orphan pages from #309 + refresh /guide

### DIFF
--- a/apps/admin/src/app/(admin)/guide/page.tsx
+++ b/apps/admin/src/app/(admin)/guide/page.tsx
@@ -77,14 +77,16 @@ const capabilityRows: CapabilityRow[] = [
   {
     section: "Jurisdictions",
     route: "/jurisdictions",
-    whatYouCanDo: "Add or rename regulatory regions (countries, states, EU, WHO).",
+    whatYouCanDo:
+      "Add or rename regulatory regions (countries, states, EU, WHO).",
     bulk: "No",
     mobile: "Drives WHO vs. local column on water table",
   },
   {
     section: "Categories",
     route: "/categories",
-    whatYouCanDo: "Top-level dashboard groupings (Water, Air, …): name, icon, color, isActive.",
+    whatYouCanDo:
+      "Top-level dashboard groupings (Water, Air, …): name, icon, color, isActive.",
     bulk: "No",
     mobile: "Dashboard category cards",
   },
@@ -123,7 +125,8 @@ const capabilityRows: CapabilityRow[] = [
   {
     section: "Landing Page",
     route: "/landing-page",
-    whatYouCanDo: "Edit the marketing landing page (hero copy, logo, CTA, theme preview).",
+    whatYouCanDo:
+      "Edit the marketing landing page (hero copy, logo, CTA, theme preview).",
     bulk: "No",
     mobile: "—  (web landing only)",
   },
@@ -147,19 +150,22 @@ const capabilityRows: CapabilityRow[] = [
     whatYouCanDo:
       "Plot industrial sites / landfills / spills on a map with severity, impact radius, status.",
     bulk: "No",
-    mobile: "Not surfaced — consumer card removed in #309",
+    mobile:
+      "Orphan — consumer card removed in #309. Decision pending on EPI-25.",
   },
   {
     section: "Testing Guide",
     route: "/testing",
-    whatYouCanDo: "Internal QA reference: staging URLs, test accounts, smoke checklist.",
+    whatYouCanDo:
+      "Internal QA reference: staging URLs, test accounts, smoke checklist.",
     bulk: "No",
     mobile: "—",
   },
   {
     section: "Guide",
     route: "/guide",
-    whatYouCanDo: "This page — what each admin section does and how it reaches mobile.",
+    whatYouCanDo:
+      "This page — what each admin section does and how it reaches mobile.",
     bulk: "No",
     mobile: "—",
   },
@@ -177,7 +183,7 @@ const capabilityRows: CapabilityRow[] = [
     whatYouCanDo:
       "Define observed-property catalog (radon, lyme_disease, …): zone / endemic / numeric / incidence / binary.",
     bulk: "Export only",
-    mobile: "—  (admin-curated catalog)",
+    mobile: "Orphan — no mobile consumer. Decision pending on EPI-25.",
   },
   {
     section: "Property Thresholds",
@@ -185,7 +191,7 @@ const capabilityRows: CapabilityRow[] = [
     whatYouCanDo:
       "Per-jurisdiction rules per property (zone-mapping JSON, endemic-is-danger flag, incidence cutoffs).",
     bulk: "No",
-    mobile: "—  (admin-curated catalog)",
+    mobile: "Orphan — no mobile consumer. Decision pending on EPI-25.",
   },
   {
     section: "Observations",
@@ -193,7 +199,8 @@ const capabilityRows: CapabilityRow[] = [
     whatYouCanDo:
       "Per-location observation (radon zone for a county, Lyme endemic status for a province, …).",
     bulk: "No",
-    mobile: "Not surfaced — consumer card removed in #309",
+    mobile:
+      "Orphan — consumer card removed in #309. Decision pending on EPI-25.",
   },
 ];
 
@@ -211,10 +218,11 @@ const dataPatterns = [
     bulk: "Yes — Water Quality + Air Pollution tabs accept CSV / JSON / Excel.",
   },
   {
-    pattern: "Reference catalog",
-    examples: "EPA radon zones, INSPQ Lyme endemic status, landfill location + impact radius.",
+    pattern: "Reference catalog (orphan — see EPI-25)",
+    examples:
+      "EPA radon zones, INSPQ Lyme endemic status, landfill location + impact radius.",
     where: "/observations (per-record) or /pollution-sources (map-pin)",
-    bulk: "No bulk path today — coordinate before loading large datasets.",
+    bulk: "No bulk path today, and the mobile consumer cards were removed in #309 — do not enter data here until EPI-25 closes.",
   },
 ];
 
@@ -237,8 +245,8 @@ export default function GuidePage() {
             Capabilities at a glance
           </CardTitle>
           <CardDescription>
-            Every admin section in one row: what you can do, whether bulk
-            upload exists, and how a mobile user feels your change.
+            Every admin section in one row: what you can do, whether bulk upload
+            exists, and how a mobile user feels your change.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -255,7 +263,10 @@ export default function GuidePage() {
               </thead>
               <tbody>
                 {capabilityRows.map((row) => (
-                  <tr key={row.route} className="border-b last:border-0 align-top">
+                  <tr
+                    key={row.route}
+                    className="border-b last:border-0 align-top"
+                  >
                     <td className="py-2 pr-4 font-medium whitespace-nowrap">
                       {row.section}
                     </td>
@@ -313,9 +324,14 @@ export default function GuidePage() {
               </thead>
               <tbody>
                 {dataPatterns.map((row) => (
-                  <tr key={row.pattern} className="border-b last:border-0 align-top">
+                  <tr
+                    key={row.pattern}
+                    className="border-b last:border-0 align-top"
+                  >
                     <td className="py-2 pr-4 font-medium">{row.pattern}</td>
-                    <td className="py-2 pr-4 text-muted-foreground">{row.examples}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {row.examples}
+                    </td>
                     <td className="py-2 pr-4">
                       <code className="px-1 py-0.5 bg-muted rounded text-xs">
                         {row.where}
@@ -432,9 +448,7 @@ export default function GuidePage() {
               be headers.
             </p>
             <pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm">
-              <code>
-                city,state,country,contaminantId,value,source
-              </code>
+              <code>city,state,country,contaminantId,value,source</code>
             </pre>
           </div>
 
@@ -460,9 +474,9 @@ export default function GuidePage() {
           <div>
             <h3 className="font-semibold mb-2">Excel Format</h3>
             <p className="text-sm text-muted-foreground mb-2">
-              Upload an Excel file (<code className="px-1 py-0.5 bg-muted rounded">.xlsx</code>)
-              with the same column structure as CSV. The first sheet will be
-              read.
+              Upload an Excel file (
+              <code className="px-1 py-0.5 bg-muted rounded">.xlsx</code>) with
+              the same column structure as CSV. The first sheet will be read.
             </p>
           </div>
 
@@ -470,30 +484,42 @@ export default function GuidePage() {
             <h3 className="font-semibold mb-2">Required Fields</h3>
             <ul className="text-sm space-y-1 list-disc ml-6 text-muted-foreground">
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">city</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  city
+                </code>{" "}
                 — City name (e.g., &quot;Beverly Hills&quot;)
               </li>
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">state</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  state
+                </code>{" "}
                 — State or province code (e.g., &quot;CA&quot;, &quot;QC&quot;)
               </li>
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">country</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  country
+                </code>{" "}
                 — Country code (e.g., &quot;US&quot;, &quot;CA&quot;)
               </li>
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">contaminantId</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  contaminantId
+                </code>{" "}
                 — ID of the contaminant (e.g.,{" "}
                 <code className="px-1 py-0.5 bg-muted rounded">lead</code>,{" "}
                 <code className="px-1 py-0.5 bg-muted rounded">nitrate</code>,{" "}
                 <code className="px-1 py-0.5 bg-muted rounded">radon</code>)
               </li>
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">value</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  value
+                </code>{" "}
                 — Numeric measurement value
               </li>
               <li>
-                <code className="px-1 py-0.5 bg-muted rounded text-foreground">source</code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded text-foreground">
+                  source
+                </code>{" "}
                 — Data source attribution (optional, e.g., &quot;EPA Report
                 2026&quot;)
               </li>
@@ -521,8 +547,7 @@ export default function GuidePage() {
               tracked by the system. There are 172+ contaminant types, each with
               a unique ID, name, unit of measurement, and category (e.g., Water,
               Air, Health, Disaster). Managed from the{" "}
-              <code className="px-1 py-0.5 bg-muted rounded">/stats</code>{" "}
-              page.
+              <code className="px-1 py-0.5 bg-muted rounded">/stats</code> page.
             </p>
           </div>
 
@@ -680,9 +705,7 @@ export default function GuidePage() {
             </div>
 
             <div>
-              <h3 className="font-semibold mb-1">
-                Location → Measurements
-              </h3>
+              <h3 className="font-semibold mb-1">Location → Measurements</h3>
               <p className="text-muted-foreground">
                 Measurements are recorded against a specific Location and
                 Contaminant. Each measurement has a value, unit, timestamp, and
@@ -745,17 +768,15 @@ export default function GuidePage() {
               </li>
               <li>
                 Use the{" "}
-                <code className="px-1 py-0.5 bg-muted rounded">
-                  measuredAt
-                </code>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">measuredAt</code>{" "}
                 field accurately — it determines the temporal ordering of
                 measurements and which one is considered &quot;current.&quot;
               </li>
               <li>
                 Include a meaningful{" "}
                 <code className="px-1 py-0.5 bg-muted rounded">source</code>{" "}
-                value for traceability (e.g., &quot;EPA Annual Report
-                2026&quot; rather than just &quot;EPA&quot;).
+                value for traceability (e.g., &quot;EPA Annual Report 2026&quot;
+                rather than just &quot;EPA&quot;).
               </li>
               <li>
                 When updating measurements, import the corrected data with
@@ -779,18 +800,15 @@ export default function GuidePage() {
                 <span className="font-medium text-foreground">
                   Mismatched location fields
                 </span>{" "}
-                — The{" "}
-                <code className="px-1 py-0.5 bg-muted rounded">city</code>,{" "}
-                <code className="px-1 py-0.5 bg-muted rounded">state</code>,
+                — The <code className="px-1 py-0.5 bg-muted rounded">city</code>
+                , <code className="px-1 py-0.5 bg-muted rounded">state</code>,
                 and{" "}
-                <code className="px-1 py-0.5 bg-muted rounded">country</code>{" "}
-                in your import file must match existing Location records. Check
-                for typos and case sensitivity.
+                <code className="px-1 py-0.5 bg-muted rounded">country</code> in
+                your import file must match existing Location records. Check for
+                typos and case sensitivity.
               </li>
               <li>
-                <span className="font-medium text-foreground">
-                  Wrong units
-                </span>{" "}
+                <span className="font-medium text-foreground">Wrong units</span>{" "}
                 — Ensure the unit matches what the contaminant expects. For
                 example, lead is measured in ppb, not mg/L. Using wrong units
                 will produce incorrect safety assessments.

--- a/apps/admin/src/app/(admin)/observations/page.tsx
+++ b/apps/admin/src/app/(admin)/observations/page.tsx
@@ -42,6 +42,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Plus, Pencil, Trash2, Loader2, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
+import { OrphanBanner } from "@/components/orphan-banner";
 import {
   observationTypeNames,
   observedPropertyCategoryColors,
@@ -96,7 +97,10 @@ export default function ObservationsPage() {
       ]);
 
       if (observationsResult.errors) {
-        console.error("Error fetching observations:", observationsResult.errors);
+        console.error(
+          "Error fetching observations:",
+          observationsResult.errors,
+        );
         toast.error("Failed to fetch observations");
       } else {
         setObservations(observationsResult.data || []);
@@ -248,7 +252,7 @@ export default function ObservationsPage() {
         .join(", ") || "this location";
     if (
       !confirm(
-        `Are you sure you want to delete the "${propertyName}" observation for ${locationLabel}?`
+        `Are you sure you want to delete the "${propertyName}" observation for ${locationLabel}?`,
       )
     ) {
       return;
@@ -284,13 +288,14 @@ export default function ObservationsPage() {
       observations
         .filter((o) => filterCountry === "all" || o.country === filterCountry)
         .map((o) => o.state)
-        .filter((s): s is string => Boolean(s))
+        .filter((s): s is string => Boolean(s)),
     ),
   ].sort();
 
   // Filter observations
   const filteredObservations = observations.filter((o) => {
-    if (filterProperty !== "all" && o.propertyId !== filterProperty) return false;
+    if (filterProperty !== "all" && o.propertyId !== filterProperty)
+      return false;
     if (filterCountry !== "all" && o.country !== filterCountry) return false;
     if (filterState !== "all" && o.state !== filterState) return false;
     return true;
@@ -325,6 +330,7 @@ export default function ObservationsPage() {
 
   return (
     <div className="space-y-6">
+      <OrphanBanner pageLabel="location observations" />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">
@@ -428,7 +434,13 @@ export default function ObservationsPage() {
                   <SelectContent>
                     {properties.map((p) => (
                       <SelectItem key={p.id} value={p.propertyId}>
-                        {p.name} ({observationTypeNames[p.observationType as ObservationType]})
+                        {p.name} (
+                        {
+                          observationTypeNames[
+                            p.observationType as ObservationType
+                          ]
+                        }
+                        )
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -718,18 +730,24 @@ export default function ObservationsPage() {
                   // most-specific populated level on the primary line and
                   // the rest of the location chain on the secondary line.
                   const primary =
-                    observation.city || observation.state || observation.country;
+                    observation.city ||
+                    observation.state ||
+                    observation.country;
                   const secondary = observation.city
-                    ? [observation.state, observation.country].filter(Boolean).join(", ")
+                    ? [observation.state, observation.country]
+                        .filter(Boolean)
+                        .join(", ")
                     : observation.state
-                      ? observation.country ?? ""
+                      ? (observation.country ?? "")
                       : "";
                   return (
                     <TableRow key={observation.id}>
                       <TableCell>
                         <div className="font-medium">{primary}</div>
                         {secondary && (
-                          <div className="text-sm text-muted-foreground">{secondary}</div>
+                          <div className="text-sm text-muted-foreground">
+                            {secondary}
+                          </div>
                         )}
                       </TableCell>
                       <TableCell>
@@ -757,7 +775,9 @@ export default function ObservationsPage() {
                       </TableCell>
                       <TableCell>
                         {observation.observedAt
-                          ? new Date(observation.observedAt).toLocaleDateString()
+                          ? new Date(
+                              observation.observedAt,
+                            ).toLocaleDateString()
                           : "—"}
                       </TableCell>
                       <TableCell>

--- a/apps/admin/src/app/(admin)/pollution-sources/page.tsx
+++ b/apps/admin/src/app/(admin)/pollution-sources/page.tsx
@@ -4,12 +4,7 @@ import { useEffect, useState } from "react";
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -18,14 +13,26 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Loader2, MapPin, AlertTriangle, CheckCircle } from "lucide-react";
+import {
+  Plus,
+  Loader2,
+  MapPin,
+  AlertTriangle,
+  CheckCircle,
+} from "lucide-react";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
+import { OrphanBanner } from "@/components/orphan-banner";
 
 // Dynamic import for map component to avoid SSR issues
 const PollutionSourceMap = dynamic(
   () => import("@/components/pollution-sources/PollutionSourceMap"),
-  { ssr: false, loading: () => <div className="h-full animate-pulse bg-gray-100 rounded-lg" /> }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full animate-pulse bg-gray-100 rounded-lg" />
+    ),
+  },
 );
 
 type PollutionSource = Schema["PollutionSource"]["type"];
@@ -42,7 +49,9 @@ export default function PollutionSourcesPage() {
   const [contaminants, setContaminants] = useState<Contaminant[]>([]);
   const [filteredSources, setFilteredSources] = useState<PollutionSource[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [selectedSource, setSelectedSource] = useState<PollutionSource | null>(null);
+  const [selectedSource, setSelectedSource] = useState<PollutionSource | null>(
+    null,
+  );
   const [isCreatingSource, setIsCreatingSource] = useState(false);
   const [mapViewport, setMapViewport] = useState<MapViewport>({
     latitude: 45.5088,
@@ -70,7 +79,10 @@ export default function PollutionSourcesPage() {
       ]);
 
       if (sourcesResult.errors) {
-        console.error("Error fetching pollution sources:", sourcesResult.errors);
+        console.error(
+          "Error fetching pollution sources:",
+          sourcesResult.errors,
+        );
         toast.error("Failed to fetch pollution sources");
       } else {
         setSources(sourcesResult.data || []);
@@ -78,7 +90,10 @@ export default function PollutionSourcesPage() {
       }
 
       if (contaminantsResult.errors) {
-        console.error("Error fetching contaminants:", contaminantsResult.errors);
+        console.error(
+          "Error fetching contaminants:",
+          contaminantsResult.errors,
+        );
       } else {
         setContaminants(contaminantsResult.data || []);
       }
@@ -111,7 +126,9 @@ export default function PollutionSourcesPage() {
     }
 
     if (filters.jurisdiction !== "all") {
-      filtered = filtered.filter((s) => s.jurisdictionCode === filters.jurisdiction);
+      filtered = filtered.filter(
+        (s) => s.jurisdictionCode === filters.jurisdiction,
+      );
     }
 
     setFilteredSources(filtered);
@@ -141,7 +158,7 @@ export default function PollutionSourcesPage() {
         reportedAt: new Date().toISOString(),
         primaryContaminants: [],
       };
-      
+
       setSelectedSource(newSource as PollutionSource);
       setIsCreatingSource(false);
     }
@@ -167,11 +184,11 @@ export default function PollutionSourcesPage() {
           id: selectedSource.id,
           ...sourceData,
         });
-        
+
         if (result.errors) {
           throw new Error("Failed to update source");
         }
-        
+
         toast.success("Pollution source updated successfully");
       } else {
         // Create new source. Location hierarchy (#123): country is required;
@@ -203,11 +220,11 @@ export default function PollutionSourcesPage() {
           reportedAt: new Date().toISOString(),
           reportedBy: "admin",
         });
-        
+
         if (result.errors) {
           throw new Error("Failed to create source");
         }
-        
+
         toast.success("Pollution source created successfully");
       }
 
@@ -237,228 +254,250 @@ export default function PollutionSourcesPage() {
 
   const getSeverityColor = (severity: string) => {
     switch (severity) {
-      case "low": return "bg-green-100 text-green-800 border-green-200";
-      case "moderate": return "bg-yellow-100 text-yellow-800 border-yellow-200";
-      case "high": return "bg-orange-100 text-orange-800 border-orange-200";
-      case "critical": return "bg-red-100 text-red-800 border-red-200";
-      default: return "bg-gray-100 text-gray-800 border-gray-200";
+      case "low":
+        return "bg-green-100 text-green-800 border-green-200";
+      case "moderate":
+        return "bg-yellow-100 text-yellow-800 border-yellow-200";
+      case "high":
+        return "bg-orange-100 text-orange-800 border-orange-200";
+      case "critical":
+        return "bg-red-100 text-red-800 border-red-200";
+      default:
+        return "bg-gray-100 text-gray-800 border-gray-200";
     }
   };
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case "active": return <AlertTriangle className="h-4 w-4 text-red-500" />;
-      case "monitored": return <MapPin className="h-4 w-4 text-yellow-500" />;
-      case "remediated": return <CheckCircle className="h-4 w-4 text-green-500" />;
-      case "closed": return <CheckCircle className="h-4 w-4 text-gray-500" />;
-      default: return <MapPin className="h-4 w-4 text-gray-500" />;
+      case "active":
+        return <AlertTriangle className="h-4 w-4 text-red-500" />;
+      case "monitored":
+        return <MapPin className="h-4 w-4 text-yellow-500" />;
+      case "remediated":
+        return <CheckCircle className="h-4 w-4 text-green-500" />;
+      case "closed":
+        return <CheckCircle className="h-4 w-4 text-gray-500" />;
+      default:
+        return <MapPin className="h-4 w-4 text-gray-500" />;
     }
   };
 
   // Get unique values for filter dropdowns (filter out nulls)
-  const uniqueSourceTypes = [...new Set(sources.map(s => s.sourceType).filter(Boolean))] as string[];
-  const uniqueSeverities = [...new Set(sources.map(s => s.severityLevel).filter(Boolean))] as string[];
-  const uniqueStatuses = [...new Set(sources.map(s => s.status).filter(Boolean))] as string[];
+  const uniqueSourceTypes = [
+    ...new Set(sources.map((s) => s.sourceType).filter(Boolean)),
+  ] as string[];
+  const uniqueSeverities = [
+    ...new Set(sources.map((s) => s.severityLevel).filter(Boolean)),
+  ] as string[];
+  const uniqueStatuses = [
+    ...new Set(sources.map((s) => s.status).filter(Boolean)),
+  ] as string[];
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] gap-6 p-6">
-      {/* Left Panel - Filters and Source List */}
-      <div className="w-80 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">
-              Pollution Sources
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              Manage environmental contamination data
-            </p>
+    <div className="flex flex-col h-[calc(100vh-4rem)] p-6 gap-4">
+      <OrphanBanner pageLabel="pollution sources" />
+      <div className="flex flex-1 min-h-0 gap-6">
+        {/* Left Panel - Filters and Source List */}
+        <div className="w-80 flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">
+                Pollution Sources
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                Manage environmental contamination data
+              </p>
+            </div>
           </div>
-        </div>
 
-        {/* Add Source Button */}
-        <Button 
-          onClick={handleCreateSource} 
-          className="w-full"
-          disabled={isCreatingSource}
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          {isCreatingSource ? "Click map to place..." : "Add Pollution Source"}
-        </Button>
+          {/* Add Source Button */}
+          <Button
+            onClick={handleCreateSource}
+            className="w-full"
+            disabled={isCreatingSource}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            {isCreatingSource
+              ? "Click map to place..."
+              : "Add Pollution Source"}
+          </Button>
 
-        {/* Filters */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm">Filters</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">
-                Source Type
-              </label>
-              <Select
-                value={filters.sourceType}
-                onValueChange={(value) =>
-                  setFilters({ ...filters, sourceType: value })
-                }
-              >
-                <SelectTrigger className="h-8">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Types</SelectItem>
-                  {uniqueSourceTypes.map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {type.charAt(0).toUpperCase() + type.slice(1).replace('_', ' ')}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">
-                Severity
-              </label>
-              <Select
-                value={filters.severity}
-                onValueChange={(value) =>
-                  setFilters({ ...filters, severity: value })
-                }
-              >
-                <SelectTrigger className="h-8">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Severities</SelectItem>
-                  {uniqueSeverities.map((severity) => (
-                    <SelectItem key={severity} value={severity}>
-                      {severity.charAt(0).toUpperCase() + severity.slice(1)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">
-                Status
-              </label>
-              <Select
-                value={filters.status}
-                onValueChange={(value) =>
-                  setFilters({ ...filters, status: value })
-                }
-              >
-                <SelectTrigger className="h-8">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Statuses</SelectItem>
-                  {uniqueStatuses.map((status) => (
-                    <SelectItem key={status} value={status}>
-                      {status.charAt(0).toUpperCase() + status.slice(1)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Source List */}
-        <Card className="flex-1 min-h-0">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-sm flex items-center justify-between">
-              Sources
-              <Badge variant="secondary" className="ml-2">
-                {filteredSources.length}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          {/* Filters */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm">Filters</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Source Type
+                </label>
+                <Select
+                  value={filters.sourceType}
+                  onValueChange={(value) =>
+                    setFilters({ ...filters, sourceType: value })
+                  }
+                >
+                  <SelectTrigger className="h-8">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Types</SelectItem>
+                    {uniqueSourceTypes.map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {type.charAt(0).toUpperCase() +
+                          type.slice(1).replace("_", " ")}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            ) : filteredSources.length === 0 ? (
-              <div className="text-center py-8 px-4 text-muted-foreground text-sm">
-                No pollution sources found
+
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Severity
+                </label>
+                <Select
+                  value={filters.severity}
+                  onValueChange={(value) =>
+                    setFilters({ ...filters, severity: value })
+                  }
+                >
+                  <SelectTrigger className="h-8">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Severities</SelectItem>
+                    {uniqueSeverities.map((severity) => (
+                      <SelectItem key={severity} value={severity}>
+                        {severity.charAt(0).toUpperCase() + severity.slice(1)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            ) : (
-              <div className="max-h-full overflow-y-auto">
-                {filteredSources.map((source) => (
-                  <div
-                    key={source.id}
-                    className={`p-3 border-b border-border cursor-pointer hover:bg-muted/50 transition-colors ${
-                      selectedSource?.id === source.id ? "bg-muted" : ""
-                    }`}
-                    onClick={() => handleSourceSelect(source)}
-                  >
-                    <div className="flex items-start gap-2">
-                      {getStatusIcon(source.status ?? "active")}
-                      <div className="flex-1 min-w-0">
-                        <div className="font-medium text-sm truncate">
-                          {source.name}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {/* Cascade scope (#123): city/state may be null
+
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Status
+                </label>
+                <Select
+                  value={filters.status}
+                  onValueChange={(value) =>
+                    setFilters({ ...filters, status: value })
+                  }
+                >
+                  <SelectTrigger className="h-8">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Statuses</SelectItem>
+                    {uniqueStatuses.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {status.charAt(0).toUpperCase() + status.slice(1)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Source List */}
+          <Card className="flex-1 min-h-0">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-sm flex items-center justify-between">
+                Sources
+                <Badge variant="secondary" className="ml-2">
+                  {filteredSources.length}
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : filteredSources.length === 0 ? (
+                <div className="text-center py-8 px-4 text-muted-foreground text-sm">
+                  No pollution sources found
+                </div>
+              ) : (
+                <div className="max-h-full overflow-y-auto">
+                  {filteredSources.map((source) => (
+                    <div
+                      key={source.id}
+                      className={`p-3 border-b border-border cursor-pointer hover:bg-muted/50 transition-colors ${
+                        selectedSource?.id === source.id ? "bg-muted" : ""
+                      }`}
+                      onClick={() => handleSourceSelect(source)}
+                    >
+                      <div className="flex items-start gap-2">
+                        {getStatusIcon(source.status ?? "active")}
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium text-sm truncate">
+                            {source.name}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {/* Cascade scope (#123): city/state may be null
                               on state-/country-anchored records. */}
-                          {[source.city, source.state, source.country]
-                            .filter(Boolean)
-                            .join(", ") || "—"}
-                        </div>
-                        <div className="flex items-center gap-2 mt-1">
-                          <Badge
-                            variant="secondary"
-                            className={`text-xs ${getSeverityColor(source.severityLevel ?? "moderate")}`}
-                          >
-                            {source.severityLevel ?? "moderate"}
-                          </Badge>
-                          <span className="text-xs text-muted-foreground">
-                            {source.impactRadius}m
-                          </span>
+                            {[source.city, source.state, source.country]
+                              .filter(Boolean)
+                              .join(", ") || "—"}
+                          </div>
+                          <div className="flex items-center gap-2 mt-1">
+                            <Badge
+                              variant="secondary"
+                              className={`text-xs ${getSeverityColor(source.severityLevel ?? "moderate")}`}
+                            >
+                              {source.severityLevel ?? "moderate"}
+                            </Badge>
+                            <span className="text-xs text-muted-foreground">
+                              {source.impactRadius}m
+                            </span>
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
 
-      {/* Right Panel - Map and Details */}
-      <div className="flex-1 flex flex-col gap-4">
-        {/* Map Container */}
-        <Card className="flex-1">
-          <CardContent className="p-0 h-full">
-            <PollutionSourceMap
-              sources={filteredSources}
-              selectedSource={selectedSource}
-              viewport={mapViewport}
-              onViewportChange={setMapViewport}
-              onMapClick={handleMapClick}
-              onSourceSelect={handleSourceSelect}
-              onSourceSave={handleSourceSave}
-              onSourceDelete={handleSourceDelete}
-              isCreatingSource={isCreatingSource}
-              contaminants={contaminants}
-            />
-          </CardContent>
-        </Card>
+        {/* Right Panel - Map and Details */}
+        <div className="flex-1 flex flex-col gap-4">
+          {/* Map Container */}
+          <Card className="flex-1">
+            <CardContent className="p-0 h-full">
+              <PollutionSourceMap
+                sources={filteredSources}
+                selectedSource={selectedSource}
+                viewport={mapViewport}
+                onViewportChange={setMapViewport}
+                onMapClick={handleMapClick}
+                onSourceSelect={handleSourceSelect}
+                onSourceSave={handleSourceSave}
+                onSourceDelete={handleSourceDelete}
+                isCreatingSource={isCreatingSource}
+                contaminants={contaminants}
+              />
+            </CardContent>
+          </Card>
 
-        {/* Status Bar */}
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
-          <div>
-            {filteredSources.length} sources visible
-            {filters.sourceType !== "all" || filters.severity !== "all" || 
-             filters.status !== "all" || filters.jurisdiction !== "all" 
-              ? " (filtered)" 
-              : ""}
-          </div>
-          <div>
-            Last updated: {new Date().toLocaleTimeString()}
+          {/* Status Bar */}
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <div>
+              {filteredSources.length} sources visible
+              {filters.sourceType !== "all" ||
+              filters.severity !== "all" ||
+              filters.status !== "all" ||
+              filters.jurisdiction !== "all"
+                ? " (filtered)"
+                : ""}
+            </div>
+            <div>Last updated: {new Date().toLocaleTimeString()}</div>
           </div>
         </div>
       </div>

--- a/apps/admin/src/app/(admin)/properties/page.tsx
+++ b/apps/admin/src/app/(admin)/properties/page.tsx
@@ -42,6 +42,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Plus, Pencil, Trash2, Loader2, Download } from "lucide-react";
 import { toast } from "sonner";
+import { OrphanBanner } from "@/components/orphan-banner";
 import {
   OBSERVED_PROPERTY_CATEGORIES,
   OBSERVATION_TYPES,
@@ -129,8 +130,10 @@ export default function PropertiesPage() {
       propertyId: property.propertyId,
       name: property.name,
       nameFr: property.nameFr || "",
-      category: (property.category as ObservedPropertyCategory) || "water_quality",
-      observationType: (property.observationType as ObservationType) || "numeric",
+      category:
+        (property.category as ObservedPropertyCategory) || "water_quality",
+      observationType:
+        (property.observationType as ObservationType) || "numeric",
       unit: property.unit || "",
       description: property.description || "",
       descriptionFr: property.descriptionFr || "",
@@ -186,7 +189,7 @@ export default function PropertiesPage() {
   const handleDelete = async (property: ObservedProperty) => {
     if (
       !confirm(
-        `Are you sure you want to delete "${property.name}"? This will also affect any thresholds and observations using this property.`
+        `Are you sure you want to delete "${property.name}"? This will also affect any thresholds and observations using this property.`,
       )
     ) {
       return;
@@ -237,6 +240,7 @@ export default function PropertiesPage() {
 
   return (
     <div className="space-y-6">
+      <OrphanBanner pageLabel="observed properties" />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">
@@ -263,173 +267,176 @@ export default function PropertiesPage() {
               </Button>
             </DialogTrigger>
             <DialogContent className="sm:max-w-[600px]">
-            <DialogHeader>
-              <DialogTitle>
-                {editingProperty ? "Edit Property" : "Create Property"}
-              </DialogTitle>
-              <DialogDescription>
-                {editingProperty
-                  ? "Update the property details below."
-                  : "Add a new observed property."}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="propertyId">Property ID *</Label>
-                  <Input
-                    id="propertyId"
-                    placeholder="e.g., air_quality_index"
-                    value={formData.propertyId}
-                    onChange={(e) =>
-                      setFormData({ ...formData, propertyId: e.target.value })
-                    }
-                    disabled={!!editingProperty}
-                  />
+              <DialogHeader>
+                <DialogTitle>
+                  {editingProperty ? "Edit Property" : "Create Property"}
+                </DialogTitle>
+                <DialogDescription>
+                  {editingProperty
+                    ? "Update the property details below."
+                    : "Add a new observed property."}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="propertyId">Property ID *</Label>
+                    <Input
+                      id="propertyId"
+                      placeholder="e.g., air_quality_index"
+                      value={formData.propertyId}
+                      onChange={(e) =>
+                        setFormData({ ...formData, propertyId: e.target.value })
+                      }
+                      disabled={!!editingProperty}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="unit">Unit</Label>
+                    <Input
+                      id="unit"
+                      placeholder="e.g., μg/L, AQI"
+                      value={formData.unit}
+                      onChange={(e) =>
+                        setFormData({ ...formData, unit: e.target.value })
+                      }
+                    />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="unit">Unit</Label>
-                  <Input
-                    id="unit"
-                    placeholder="e.g., μg/L, AQI"
-                    value={formData.unit}
-                    onChange={(e) =>
-                      setFormData({ ...formData, unit: e.target.value })
-                    }
-                  />
-                </div>
-              </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="name">Name (English) *</Label>
-                  <Input
-                    id="name"
-                    placeholder="e.g., Air Quality Index"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData({ ...formData, name: e.target.value })
-                    }
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name (English) *</Label>
+                    <Input
+                      id="name"
+                      placeholder="e.g., Air Quality Index"
+                      value={formData.name}
+                      onChange={(e) =>
+                        setFormData({ ...formData, name: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="nameFr">Name (French)</Label>
+                    <Input
+                      id="nameFr"
+                      placeholder="e.g., Indice de qualité de l'air"
+                      value={formData.nameFr}
+                      onChange={(e) =>
+                        setFormData({ ...formData, nameFr: e.target.value })
+                      }
+                    />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="nameFr">Name (French)</Label>
-                  <Input
-                    id="nameFr"
-                    placeholder="e.g., Indice de qualité de l'air"
-                    value={formData.nameFr}
-                    onChange={(e) =>
-                      setFormData({ ...formData, nameFr: e.target.value })
-                    }
-                  />
-                </div>
-              </div>
 
-              <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="category">Category *</Label>
+                    <Select
+                      value={formData.category}
+                      onValueChange={(value) =>
+                        setFormData({
+                          ...formData,
+                          category: value as ObservedPropertyCategory,
+                        })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {OBSERVED_PROPERTY_CATEGORIES.map((cat) => (
+                          <SelectItem key={cat} value={cat}>
+                            {observedPropertyCategoryNames[cat]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="observationType">Observation Type *</Label>
+                    <Select
+                      value={formData.observationType}
+                      onValueChange={(value) =>
+                        setFormData({
+                          ...formData,
+                          observationType: value as ObservationType,
+                        })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {OBSERVATION_TYPES.map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {observationTypeNames[type]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
                 <div className="space-y-2">
-                  <Label htmlFor="category">Category *</Label>
-                  <Select
-                    value={formData.category}
-                    onValueChange={(value) =>
+                  <Label htmlFor="description">Description (English)</Label>
+                  <Textarea
+                    id="description"
+                    placeholder="Describe what this property measures..."
+                    value={formData.description}
+                    onChange={(e) =>
+                      setFormData({ ...formData, description: e.target.value })
+                    }
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="descriptionFr">Description (French)</Label>
+                  <Textarea
+                    id="descriptionFr"
+                    placeholder="Description en français..."
+                    value={formData.descriptionFr}
+                    onChange={(e) =>
                       setFormData({
                         ...formData,
-                        category: value as ObservedPropertyCategory,
+                        descriptionFr: e.target.value,
                       })
                     }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {OBSERVED_PROPERTY_CATEGORIES.map((cat) => (
-                        <SelectItem key={cat} value={cat}>
-                          {observedPropertyCategoryNames[cat]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  />
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="observationType">Observation Type *</Label>
-                  <Select
-                    value={formData.observationType}
-                    onValueChange={(value) =>
-                      setFormData({
-                        ...formData,
-                        observationType: value as ObservationType,
-                      })
+
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="higherIsBad"
+                    checked={formData.higherIsBad}
+                    onCheckedChange={(checked) =>
+                      setFormData({ ...formData, higherIsBad: checked })
                     }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {OBSERVATION_TYPES.map((type) => (
-                        <SelectItem key={type} value={type}>
-                          {observationTypeNames[type]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  />
+                  <Label htmlFor="higherIsBad">Higher values are worse</Label>
                 </div>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="description">Description (English)</Label>
-                <Textarea
-                  id="description"
-                  placeholder="Describe what this property measures..."
-                  value={formData.description}
-                  onChange={(e) =>
-                    setFormData({ ...formData, description: e.target.value })
-                  }
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="descriptionFr">Description (French)</Label>
-                <Textarea
-                  id="descriptionFr"
-                  placeholder="Description en français..."
-                  value={formData.descriptionFr}
-                  onChange={(e) =>
-                    setFormData({ ...formData, descriptionFr: e.target.value })
-                  }
-                />
-              </div>
-
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="higherIsBad"
-                  checked={formData.higherIsBad}
-                  onCheckedChange={(checked) =>
-                    setFormData({ ...formData, higherIsBad: checked })
-                  }
-                />
-                <Label htmlFor="higherIsBad">Higher values are worse</Label>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setIsDialogOpen(false)}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button onClick={handleSave} disabled={isSaving}>
-                {isSaving ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : editingProperty ? (
-                  "Update"
-                ) : (
-                  "Create"
-                )}
-              </Button>
-            </DialogFooter>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsDialogOpen(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : editingProperty ? (
+                    "Update"
+                  ) : (
+                    "Create"
+                  )}
+                </Button>
+              </DialogFooter>
             </DialogContent>
           </Dialog>
         </div>

--- a/apps/admin/src/app/(admin)/property-thresholds/page.tsx
+++ b/apps/admin/src/app/(admin)/property-thresholds/page.tsx
@@ -42,6 +42,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Plus, Pencil, Trash2, Loader2, Download } from "lucide-react";
 import { toast } from "sonner";
+import { OrphanBanner } from "@/components/orphan-banner";
 import {
   PROPERTY_THRESHOLD_STATUS_OPTIONS,
   propertyThresholdStatusNames,
@@ -111,7 +112,7 @@ export default function PropertyThresholdsPage() {
       if (jurisdictionsResult.errors) {
         console.error(
           "Error fetching jurisdictions:",
-          jurisdictionsResult.errors
+          jurisdictionsResult.errors,
         );
       } else {
         setJurisdictions(jurisdictionsResult.data || []);
@@ -171,7 +172,11 @@ export default function PropertyThresholdsPage() {
   };
 
   const handleSave = async () => {
-    if (!formData.propertyId || !formData.jurisdictionCode || !formData.status) {
+    if (
+      !formData.propertyId ||
+      !formData.jurisdictionCode ||
+      !formData.status
+    ) {
       toast.error("Please fill in all required fields");
       return;
     }
@@ -194,7 +199,9 @@ export default function PropertyThresholdsPage() {
       const thresholdData = {
         propertyId: formData.propertyId,
         jurisdictionCode: formData.jurisdictionCode,
-        limitValue: formData.limitValue ? parseFloat(formData.limitValue) : null,
+        limitValue: formData.limitValue
+          ? parseFloat(formData.limitValue)
+          : null,
         warningValue: formData.warningValue
           ? parseFloat(formData.warningValue)
           : null,
@@ -238,7 +245,7 @@ export default function PropertyThresholdsPage() {
       threshold.propertyId;
     if (
       !confirm(
-        `Are you sure you want to delete the threshold for "${propertyName}" in ${threshold.jurisdictionCode}?`
+        `Are you sure you want to delete the threshold for "${propertyName}" in ${threshold.jurisdictionCode}?`,
       )
     ) {
       return;
@@ -305,13 +312,17 @@ export default function PropertyThresholdsPage() {
   const filteredThresholds = thresholds.filter((t) => {
     if (filterProperty !== "all" && t.propertyId !== filterProperty)
       return false;
-    if (filterJurisdiction !== "all" && t.jurisdictionCode !== filterJurisdiction)
+    if (
+      filterJurisdiction !== "all" &&
+      t.jurisdictionCode !== filterJurisdiction
+    )
       return false;
     return true;
   });
 
   return (
     <div className="space-y-6">
+      <OrphanBanner pageLabel="property thresholds" />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">
@@ -338,243 +349,250 @@ export default function PropertyThresholdsPage() {
               </Button>
             </DialogTrigger>
             <DialogContent className="sm:max-w-[600px]">
-            <DialogHeader>
-              <DialogTitle>
-                {editingThreshold ? "Edit Threshold" : "Create Threshold"}
-              </DialogTitle>
-              <DialogDescription>
-                {editingThreshold
-                  ? "Update the threshold details below."
-                  : "Add a new jurisdiction-specific threshold."}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="propertyId">Property *</Label>
-                  <Select
-                    value={formData.propertyId}
-                    onValueChange={(value) =>
-                      setFormData({ ...formData, propertyId: value })
-                    }
-                    disabled={!!editingThreshold}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select property" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {properties.map((p) => (
-                        <SelectItem key={p.id} value={p.propertyId}>
-                          {p.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="jurisdictionCode">Jurisdiction *</Label>
-                  <Select
-                    value={formData.jurisdictionCode}
-                    onValueChange={(value) =>
-                      setFormData({ ...formData, jurisdictionCode: value })
-                    }
-                    disabled={!!editingThreshold}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select jurisdiction" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {jurisdictions.map((j) => (
-                        <SelectItem key={j.id} value={j.code}>
-                          {j.name} ({j.code})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              {selectedProperty && (
-                <p className="text-sm text-muted-foreground">
-                  Property type:{" "}
-                  <strong>
-                    {observationTypeNames[
-                      selectedProperty.observationType as ObservationType
-                    ] || selectedProperty.observationType}
-                  </strong>
-                </p>
-              )}
-
-              {/* Numeric thresholds */}
-              {(!selectedProperty ||
-                selectedProperty.observationType === "numeric") && (
+              <DialogHeader>
+                <DialogTitle>
+                  {editingThreshold ? "Edit Threshold" : "Create Threshold"}
+                </DialogTitle>
+                <DialogDescription>
+                  {editingThreshold
+                    ? "Update the threshold details below."
+                    : "Add a new jurisdiction-specific threshold."}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="warningValue">Warning Value</Label>
-                    <Input
-                      id="warningValue"
-                      type="number"
-                      placeholder="e.g., 50"
-                      value={formData.warningValue}
-                      onChange={(e) =>
-                        setFormData({
-                          ...formData,
-                          warningValue: e.target.value,
-                        })
+                    <Label htmlFor="propertyId">Property *</Label>
+                    <Select
+                      value={formData.propertyId}
+                      onValueChange={(value) =>
+                        setFormData({ ...formData, propertyId: value })
                       }
-                    />
+                      disabled={!!editingThreshold}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select property" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {properties.map((p) => (
+                          <SelectItem key={p.id} value={p.propertyId}>
+                            {p.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="limitValue">Danger/Limit Value</Label>
-                    <Input
-                      id="limitValue"
-                      type="number"
-                      placeholder="e.g., 100"
-                      value={formData.limitValue}
-                      onChange={(e) =>
-                        setFormData({ ...formData, limitValue: e.target.value })
+                    <Label htmlFor="jurisdictionCode">Jurisdiction *</Label>
+                    <Select
+                      value={formData.jurisdictionCode}
+                      onValueChange={(value) =>
+                        setFormData({ ...formData, jurisdictionCode: value })
                       }
-                    />
+                      disabled={!!editingThreshold}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select jurisdiction" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {jurisdictions.map((j) => (
+                          <SelectItem key={j.id} value={j.code}>
+                            {j.name} ({j.code})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
                 </div>
-              )}
 
-              {/* Zone mapping */}
-              {(!selectedProperty ||
-                selectedProperty.observationType === "zone") && (
-                <div className="space-y-2">
-                  <Label htmlFor="zoneMapping">Zone Mapping (JSON)</Label>
-                  <Textarea
-                    id="zoneMapping"
-                    placeholder='{"Good": "safe", "Moderate": "warning", "Unhealthy": "danger"}'
-                    value={formData.zoneMapping}
-                    onChange={(e) =>
-                      setFormData({ ...formData, zoneMapping: e.target.value })
-                    }
-                    className="font-mono text-sm"
-                    rows={4}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Maps source zone values to safety levels (safe, warning, danger)
+                {selectedProperty && (
+                  <p className="text-sm text-muted-foreground">
+                    Property type:{" "}
+                    <strong>
+                      {observationTypeNames[
+                        selectedProperty.observationType as ObservationType
+                      ] || selectedProperty.observationType}
+                    </strong>
                   </p>
-                </div>
-              )}
+                )}
 
-              {/* Endemic settings */}
-              {(!selectedProperty ||
-                selectedProperty.observationType === "endemic") && (
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="endemicIsDanger"
-                    checked={formData.endemicIsDanger}
-                    onCheckedChange={(checked) =>
-                      setFormData({ ...formData, endemicIsDanger: checked })
+                {/* Numeric thresholds */}
+                {(!selectedProperty ||
+                  selectedProperty.observationType === "numeric") && (
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="warningValue">Warning Value</Label>
+                      <Input
+                        id="warningValue"
+                        type="number"
+                        placeholder="e.g., 50"
+                        value={formData.warningValue}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            warningValue: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="limitValue">Danger/Limit Value</Label>
+                      <Input
+                        id="limitValue"
+                        type="number"
+                        placeholder="e.g., 100"
+                        value={formData.limitValue}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            limitValue: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {/* Zone mapping */}
+                {(!selectedProperty ||
+                  selectedProperty.observationType === "zone") && (
+                  <div className="space-y-2">
+                    <Label htmlFor="zoneMapping">Zone Mapping (JSON)</Label>
+                    <Textarea
+                      id="zoneMapping"
+                      placeholder='{"Good": "safe", "Moderate": "warning", "Unhealthy": "danger"}'
+                      value={formData.zoneMapping}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          zoneMapping: e.target.value,
+                        })
+                      }
+                      className="font-mono text-sm"
+                      rows={4}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Maps source zone values to safety levels (safe, warning,
+                      danger)
+                    </p>
+                  </div>
+                )}
+
+                {/* Endemic settings */}
+                {(!selectedProperty ||
+                  selectedProperty.observationType === "endemic") && (
+                  <div className="flex items-center space-x-2">
+                    <Switch
+                      id="endemicIsDanger"
+                      checked={formData.endemicIsDanger}
+                      onCheckedChange={(checked) =>
+                        setFormData({ ...formData, endemicIsDanger: checked })
+                      }
+                    />
+                    <Label htmlFor="endemicIsDanger">
+                      Endemic presence is danger level (vs. warning)
+                    </Label>
+                  </div>
+                )}
+
+                {/* Incidence thresholds */}
+                {(!selectedProperty ||
+                  selectedProperty.observationType === "incidence") && (
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="incidenceWarningThreshold">
+                        Incidence Warning Threshold
+                      </Label>
+                      <Input
+                        id="incidenceWarningThreshold"
+                        type="number"
+                        placeholder="e.g., 10 (per 100k)"
+                        value={formData.incidenceWarningThreshold}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            incidenceWarningThreshold: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="incidenceDangerThreshold">
+                        Incidence Danger Threshold
+                      </Label>
+                      <Input
+                        id="incidenceDangerThreshold"
+                        type="number"
+                        placeholder="e.g., 50 (per 100k)"
+                        value={formData.incidenceDangerThreshold}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            incidenceDangerThreshold: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="status">Status *</Label>
+                  <Select
+                    value={formData.status}
+                    onValueChange={(value) =>
+                      setFormData({
+                        ...formData,
+                        status: value as PropertyThresholdStatus,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROPERTY_THRESHOLD_STATUS_OPTIONS.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {propertyThresholdStatusNames[status]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="notes">Notes</Label>
+                  <Textarea
+                    id="notes"
+                    placeholder="Admin notes about this threshold..."
+                    value={formData.notes}
+                    onChange={(e) =>
+                      setFormData({ ...formData, notes: e.target.value })
                     }
                   />
-                  <Label htmlFor="endemicIsDanger">
-                    Endemic presence is danger level (vs. warning)
-                  </Label>
                 </div>
-              )}
-
-              {/* Incidence thresholds */}
-              {(!selectedProperty ||
-                selectedProperty.observationType === "incidence") && (
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="incidenceWarningThreshold">
-                      Incidence Warning Threshold
-                    </Label>
-                    <Input
-                      id="incidenceWarningThreshold"
-                      type="number"
-                      placeholder="e.g., 10 (per 100k)"
-                      value={formData.incidenceWarningThreshold}
-                      onChange={(e) =>
-                        setFormData({
-                          ...formData,
-                          incidenceWarningThreshold: e.target.value,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="incidenceDangerThreshold">
-                      Incidence Danger Threshold
-                    </Label>
-                    <Input
-                      id="incidenceDangerThreshold"
-                      type="number"
-                      placeholder="e.g., 50 (per 100k)"
-                      value={formData.incidenceDangerThreshold}
-                      onChange={(e) =>
-                        setFormData({
-                          ...formData,
-                          incidenceDangerThreshold: e.target.value,
-                        })
-                      }
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div className="space-y-2">
-                <Label htmlFor="status">Status *</Label>
-                <Select
-                  value={formData.status}
-                  onValueChange={(value) =>
-                    setFormData({
-                      ...formData,
-                      status: value as PropertyThresholdStatus,
-                    })
-                  }
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsDialogOpen(false)}
+                  disabled={isSaving}
                 >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PROPERTY_THRESHOLD_STATUS_OPTIONS.map((status) => (
-                      <SelectItem key={status} value={status}>
-                        {propertyThresholdStatusNames[status]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="notes">Notes</Label>
-                <Textarea
-                  id="notes"
-                  placeholder="Admin notes about this threshold..."
-                  value={formData.notes}
-                  onChange={(e) =>
-                    setFormData({ ...formData, notes: e.target.value })
-                  }
-                />
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setIsDialogOpen(false)}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button onClick={handleSave} disabled={isSaving}>
-                {isSaving ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : editingThreshold ? (
-                  "Update"
-                ) : (
-                  "Create"
-                )}
-              </Button>
-            </DialogFooter>
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : editingThreshold ? (
+                    "Update"
+                  ) : (
+                    "Create"
+                  )}
+                </Button>
+              </DialogFooter>
             </DialogContent>
           </Dialog>
         </div>

--- a/apps/admin/src/components/admin-sidebar.tsx
+++ b/apps/admin/src/components/admin-sidebar.tsx
@@ -43,6 +43,16 @@ import {
   FileText,
 } from "lucide-react";
 
+/** Subset of admin routes whose mobile consumer was removed in #309 and
+ *  whose fate is pending on EPI-25. Marked with a yellow "orphan" badge in
+ *  the sidebar so contributors don't waste effort on data that won't ship. */
+const ORPHAN_ROUTES = new Set([
+  "/observations",
+  "/pollution-sources",
+  "/properties",
+  "/property-thresholds",
+]);
+
 const menuItems = [
   {
     title: "Dashboard",
@@ -174,6 +184,14 @@ export function AdminSidebar() {
                     <Link href={item.url}>
                       <item.icon className="h-4 w-4" />
                       <span>{item.title}</span>
+                      {ORPHAN_ROUTES.has(item.url) && (
+                        <span
+                          title="No mobile consumer — see EPI-25"
+                          className="ml-auto rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/60 dark:text-amber-200"
+                        >
+                          Orphan
+                        </span>
+                      )}
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -192,6 +210,14 @@ export function AdminSidebar() {
                     <Link href={item.url}>
                       <item.icon className="h-4 w-4" />
                       <span>{item.title}</span>
+                      {ORPHAN_ROUTES.has(item.url) && (
+                        <span
+                          title="No mobile consumer — see EPI-25"
+                          className="ml-auto rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/60 dark:text-amber-200"
+                        >
+                          Orphan
+                        </span>
+                      )}
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/apps/admin/src/components/orphan-banner.tsx
+++ b/apps/admin/src/components/orphan-banner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+const EPI_25_URL =
+  "https://linear.app/epiphany-apps/issue/EPI-25/decide-fate-of-orphaned-admin-pages-observations-pollution-sources";
+
+interface OrphanBannerProps {
+  /** What this page edits, in admin-friendly terms (e.g., "pollution sources"). */
+  pageLabel: string;
+}
+
+/** Top-of-page banner for admin sections whose mobile consumer was removed
+ *  in PR #309. Surfaces the orphan state inline so contributors don't waste
+ *  effort entering data that doesn't ship. Decision pending on EPI-25. */
+export function OrphanBanner({ pageLabel }: OrphanBannerProps) {
+  return (
+    <div
+      role="status"
+      className="rounded-md border border-amber-300 bg-amber-50 p-4 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="h-5 w-5 flex-shrink-0 mt-0.5" />
+        <div className="space-y-1 text-sm">
+          <p className="font-semibold">No mobile consumer for {pageLabel}.</p>
+          <p>
+            The mobile dashboard card that read this data was removed in PR
+            #309. Edits made here will not appear in the app until the consumer
+            surface is restored.{" "}
+            <a
+              href={EPI_25_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline hover:no-underline"
+            >
+              EPI-25
+            </a>{" "}
+            tracks the decision on whether to restore, archive, or repurpose
+            this page.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR #309 removed the mobile dashboard cards for Pollution Sources and Environmental Health, leaving four admin pages without a mobile consumer surface:

- `/observations`
- `/pollution-sources`
- `/properties`
- `/property-thresholds`

This PR is **visibility-only** — it surfaces the orphan state inline so admin contributors don't waste effort entering data that won't ship. The decision on whether to restore the consumer surface, archive these pages, or repurpose them for internal use is tracked in [EPI-25](https://linear.app/epiphany-apps/issue/EPI-25/decide-fate-of-orphaned-admin-pages-observations-pollution-sources).

## Changes

- New \`OrphanBanner\` component (\`src/components/orphan-banner.tsx\`) — yellow \`role=status\` banner that names the orphan state and links EPI-25.
- \`admin-sidebar.tsx\` — \`ORPHAN_ROUTES\` set drives a small yellow **Orphan** badge next to each affected entry, with a tooltip pointing at EPI-25.
- Each of the four orphan pages — \`<OrphanBanner pageLabel=… />\` injected at the top of the JSX return.
- \`/guide\` — capability-matrix mobile-surface cells refreshed on the four rows; \"Reference catalog\" data-pattern row labeled orphan with a do-not-use-yet caveat.

## What's not in this PR

- No backend changes. The \`Reseed All\` action still repopulates orphan tables — that's tracked separately as **EPI-26** (defensive skip).
- No mobile changes.
- No decision on the orphan pages' fate — that's **EPI-25**.

## Related Linear tickets

This PR ships alongside a batch of audit findings filed today: **EPI-25 → EPI-38** (admin orphans, structural drift, mutation error handling, pagination, dialogs, audit trail, test coverage, FK validation, form UX). EPI-25 is the parent decision; the rest are scoped follow-ups.

## Test plan

- [ ] Visit each of the four pages on staging admin and verify the banner appears at the top.
- [ ] Confirm the **Orphan** badges show in the sidebar next to the four entries (and only those entries).
- [ ] Hover the badge — tooltip reads \"No mobile consumer — see EPI-25.\"
- [ ] Click the EPI-25 link in any banner — opens Linear to the decision ticket.
- [ ] \`/guide\` capability matrix shows the orphan caveat in the Mobile Surface column for the four rows; Reference catalog row in \"Where do I add this kind of data?\" reads orphan + do-not-use.
- [ ] Lint + type check pass (verified locally: \`tsc --noEmit\` clean, \`npm run lint\` only emits pre-existing warnings unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)