### PR TITLE
fix(mobile): split status into whoStatus + localStatus, render dual pills (EPI-18 sub-bug B)

### DIFF
--- a/apps/mobile/app/components/ContaminantTable.test.tsx
+++ b/apps/mobile/app/components/ContaminantTable.test.tsx
@@ -118,4 +118,80 @@ describe("ContaminantTable", () => {
       expect(queryByText("NO STANDARD")).toBeTruthy()
     })
   })
+
+  describe("EPI-18 sub-bug B: dual status pills", () => {
+    it("renders one status indicator per value cell driven by whoStatus / localStatus", () => {
+      // Lead at 5 µg/L: safe vs WHO (limit 10), danger vs QC (limit 5).
+      // Pre-fix the row had a single "danger" pill at the row level that
+      // hid the WHO-vs-local distinction.
+      const rows: ContaminantTableRow[] = [
+        {
+          ...baseRow,
+          name: "Lead",
+          value: 5,
+          unit: "μg/L",
+          whoLimit: 10,
+          localLimit: 5,
+          status: "danger",
+          whoStatus: "safe",
+          localStatus: "danger",
+        },
+      ]
+
+      const { getAllByLabelText } = render(<ContaminantTable rows={rows} />)
+
+      // StatusIndicator sets accessibilityLabel="Status: <status>".
+      // We expect one safe (WHO column) and one danger (Local column).
+      expect(getAllByLabelText("Status: safe").length).toBe(1)
+      expect(getAllByLabelText("Status: danger").length).toBe(1)
+    })
+
+    it("suppresses the WHO pill when no WHO threshold exists", () => {
+      // Glyphosate has a QC limit but no WHO standard ("NO STANDARD"
+      // shown). The WHO column should not render a pill — there is
+      // nothing to compare against.
+      const rows: ContaminantTableRow[] = [
+        {
+          ...baseRow,
+          name: "Glyphosate",
+          value: 280,
+          unit: "μg/L",
+          whoLimit: null,
+          localLimit: 280,
+          status: "danger",
+          whoStatus: "safe",
+          localStatus: "danger",
+        },
+      ]
+
+      const { getAllByLabelText, queryByLabelText } = render(<ContaminantTable rows={rows} />)
+
+      // Only the local column has a pill, and it's danger.
+      expect(getAllByLabelText("Status: danger").length).toBe(1)
+      expect(queryByLabelText("Status: safe")).toBeNull()
+    })
+
+    it("falls back to row.status when whoStatus / localStatus are absent (cached pre-R2 data)", () => {
+      // CityStat objects deserialized from MMKV cache written before the
+      // dual-status migration won't have whoStatus / localStatus. The
+      // table must still render a pill — just both pointing at row.status.
+      const rows: ContaminantTableRow[] = [
+        {
+          ...baseRow,
+          name: "Lead",
+          value: 5,
+          unit: "μg/L",
+          whoLimit: 10,
+          localLimit: 5,
+          status: "danger",
+          // whoStatus/localStatus intentionally absent
+        },
+      ]
+
+      const { getAllByLabelText } = render(<ContaminantTable rows={rows} />)
+
+      // Both pills fall back to row.status ("danger").
+      expect(getAllByLabelText("Status: danger").length).toBe(2)
+    })
+  })
 })

--- a/apps/mobile/app/components/ContaminantTable.tsx
+++ b/apps/mobile/app/components/ContaminantTable.tsx
@@ -23,8 +23,16 @@ export interface ContaminantTableRow {
   localLimit: number | null
   /** Local jurisdiction name (e.g., "NEW YORK", "QUEBEC") */
   localJurisdictionName: string
-  /** Status based on threshold comparison */
+  /**
+   * Worst-of-(whoStatus, localStatus). Used for the trailing summary pill
+   * and as a fallback when whoStatus / localStatus are absent (older cached
+   * data shape).
+   */
   status: StatStatus
+  /** Status vs WHO threshold (EPI-18 sub-bug B). */
+  whoStatus?: StatStatus
+  /** Status vs local-jurisdiction threshold (EPI-18 sub-bug B). */
+  localStatus?: StatStatus
   /** Whether the contaminant is unregulated locally */
   isUnregulated?: boolean
 }
@@ -106,14 +114,19 @@ export function ContaminantTable(props: ContaminantTableProps) {
 
   const $valueCell: ViewStyle = {
     ...$cell,
-    flex: 1.5,
+    flex: 1.75,
     alignItems: "flex-end",
   }
 
-  const $statusCell: ViewStyle = {
-    ...$cell,
-    flex: 0.5,
+  // Inline pill sits to the left of the threshold text (EPI-18 sub-bug B).
+  const $valueCellInner: ViewStyle = {
+    flexDirection: "row",
     alignItems: "center",
+    gap: 6,
+  }
+
+  const $pillSpacer: ViewStyle = {
+    width: 8,
   }
 
   const $cellText: TextStyle = {
@@ -184,43 +197,63 @@ export function ContaminantTable(props: ContaminantTableProps) {
         >
           <Text style={onWhoHeaderPress ? $linkHeaderText : $headerText}>WHO</Text>
         </TouchableOpacity>
-        <View style={[$headerCell, $statusCell]}>
-          <Text style={$headerText}></Text>
-        </View>
       </View>
 
       {/* Data Rows */}
-      {rows.map((row, index) => (
-        <View
-          key={row.name}
-          style={[$row, index % 2 === 1 && $alternateRow, index === rows.length - 1 && $lastRow]}
-        >
-          <View style={[$nameCell, $nameCellRow]}>
-            <Text style={$cellText}>{row.name}</Text>
-            {row.contaminantId && hasHealthEffectsData(row.contaminantId) && (
-              <ContaminantInfoButton contaminantId={row.contaminantId} />
-            )}
+      {rows.map((row, index) => {
+        // EPI-18 sub-bug B: each value cell renders a status pill so the
+        // user sees that a row can be safe vs WHO yet exceed a tighter
+        // local (e.g., QC) limit. Suppress the pill when the threshold
+        // is null/unregulated — there's nothing to compare against.
+        const showLocalPill = row.localLimit !== null && !row.isUnregulated
+        const showWhoPill = row.whoLimit !== null
+        const localPillStatus = row.localStatus ?? row.status
+        const whoPillStatus = row.whoStatus ?? row.status
+        return (
+          <View
+            key={row.name}
+            style={[$row, index % 2 === 1 && $alternateRow, index === rows.length - 1 && $lastRow]}
+          >
+            <View style={[$nameCell, $nameCellRow]}>
+              <Text style={$cellText}>{row.name}</Text>
+              {row.contaminantId && hasHealthEffectsData(row.contaminantId) && (
+                <ContaminantInfoButton contaminantId={row.contaminantId} />
+              )}
+            </View>
+            <View style={$valueCell}>
+              <View style={$valueCellInner}>
+                {showLocalPill ? (
+                  <StatusIndicator status={localPillStatus} size="small" />
+                ) : (
+                  <View style={$pillSpacer} />
+                )}
+                <Text
+                  style={
+                    row.localLimit === null || row.isUnregulated ? $unregulatedText : $valueText
+                  }
+                >
+                  {formatValue(row.localLimit, row.unit, {
+                    isUnregulated: row.isUnregulated,
+                    isLocal: true,
+                  })}
+                </Text>
+              </View>
+            </View>
+            <View style={$valueCell}>
+              <View style={$valueCellInner}>
+                {showWhoPill ? (
+                  <StatusIndicator status={whoPillStatus} size="small" />
+                ) : (
+                  <View style={$pillSpacer} />
+                )}
+                <Text style={row.whoLimit === null ? $unregulatedText : $valueText}>
+                  {formatValue(row.whoLimit, row.unit)}
+                </Text>
+              </View>
+            </View>
           </View>
-          <View style={$valueCell}>
-            <Text
-              style={row.localLimit === null || row.isUnregulated ? $unregulatedText : $valueText}
-            >
-              {formatValue(row.localLimit, row.unit, {
-                isUnregulated: row.isUnregulated,
-                isLocal: true,
-              })}
-            </Text>
-          </View>
-          <View style={$valueCell}>
-            <Text style={row.whoLimit === null ? $unregulatedText : $valueText}>
-              {formatValue(row.whoLimit, row.unit)}
-            </Text>
-          </View>
-          <View style={$statusCell}>
-            <StatusIndicator status={row.status} size="small" />
-          </View>
-        </View>
-      ))}
+        )
+      })}
     </View>
   )
 }

--- a/apps/mobile/app/data/types/safety.ts
+++ b/apps/mobile/app/data/types/safety.ts
@@ -397,7 +397,23 @@ export interface StatDefinition {
 export interface CityStat {
   statId: string
   value: number
+  /**
+   * Worst-of-(whoStatus, localStatus). Kept for callers that have not yet
+   * migrated to the dual-status fields (DashboardScreen, calculateCategoryStatus).
+   */
   status: StatStatus
+  /**
+   * Status vs the WHO threshold (EPI-18 sub-bug B).
+   * Optional so MMKV entries cached before the dual-status migration still
+   * deserialize; consumers must fall back to `status`.
+   */
+  whoStatus?: StatStatus
+  /**
+   * Status vs the local-jurisdiction threshold (e.g., CA-QC). When no local
+   * threshold exists, runtime sets this to whoStatus.
+   * Optional for the same back-compat reason as whoStatus.
+   */
+  localStatus?: StatStatus
   lastUpdated: string
   history?: StatHistoryEntry[]
 }

--- a/apps/mobile/app/hooks/useLocationData.test.ts
+++ b/apps/mobile/app/hooks/useLocationData.test.ts
@@ -22,6 +22,7 @@ jest.mock("../services/amplify/data", () => ({
 }))
 
 const mockGetThreshold = jest.fn()
+const mockGetWHOThreshold = jest.fn()
 const mockGetJurisdictionForLocation = jest.fn()
 
 jest.mock("../context/ContaminantsContext", () => ({
@@ -29,6 +30,7 @@ jest.mock("../context/ContaminantsContext", () => ({
     contaminants: mockContaminants,
     isLoading: false,
     getThreshold: mockGetThreshold,
+    getWHOThreshold: mockGetWHOThreshold,
     getJurisdictionForLocation: mockGetJurisdictionForLocation,
   }),
 }))
@@ -168,10 +170,7 @@ describe("useLocationData", () => {
     it("falls back to WHO when jurisdiction not found", async () => {
       mockGetLocationMeasurements.mockResolvedValue([newYorkMeasurement])
       mockGetJurisdictionForLocation.mockReturnValue(undefined)
-      mockGetThreshold.mockImplementation((_contId, jCode) => {
-        if (jCode === "WHO") return whoThreshold
-        return null
-      })
+      mockGetWHOThreshold.mockReturnValue(whoThreshold)
 
       const { result } = renderHook(() => useLocationData("New York"), {
         wrapper: createWrapper(),
@@ -181,8 +180,13 @@ describe("useLocationData", () => {
         expect(result.current.cityData).not.toBeNull()
       })
 
-      // getThreshold should have been called with WHO fallback
-      expect(mockGetThreshold).toHaveBeenCalledWith("chlorite", "WHO")
+      // EPI-18 sub-bug B: WHO threshold is now resolved through the
+      // dedicated getWHOThreshold() helper rather than getThreshold(_, "WHO")
+      // so we always have it available alongside the local-jurisdiction
+      // threshold for the dual-status pills.
+      expect(mockGetWHOThreshold).toHaveBeenCalledWith("chlorite")
+      // And the local lookup is skipped — there is no local jurisdiction.
+      expect(mockGetThreshold).not.toHaveBeenCalledWith("chlorite", "WHO")
     })
   })
 
@@ -252,6 +256,11 @@ describe("useLocationData", () => {
       mockGetLocationMeasurements.mockResolvedValue([montrealMeasurement])
       mockGetJurisdictionForLocation.mockReturnValue({ code: "CA-QC" })
       mockGetThreshold.mockReturnValue(null)
+      // EPI-18 sub-bug B: status now considers both WHO and local thresholds.
+      // Explicitly null both so this test exercises the "no threshold at all"
+      // path rather than inheriting a leftover whoThreshold mock from a prior
+      // test (jest.clearAllMocks() clears history but not implementations).
+      mockGetWHOThreshold.mockReturnValue(null)
 
       const { result } = renderHook(() => useLocationData("Montreal"), {
         wrapper: createWrapper(),
@@ -262,6 +271,49 @@ describe("useLocationData", () => {
       })
 
       expect(result.current.cityData!.stats[0].status).toBe("safe")
+    })
+
+    it("splits status into whoStatus + localStatus when local is tighter than WHO (EPI-18 sub-bug B)", async () => {
+      // Realistic Boucherville case: Lead 5 µg/L is at the QC limit (5)
+      // but well under the WHO limit (10). Pre-fix the row read as a
+      // single "danger" badge that hid the WHO-vs-local distinction;
+      // post-fix the table can render whoStatus=safe + localStatus=danger.
+      const leadMeasurement = {
+        ...montrealMeasurement,
+        contaminantId: "lead",
+        value: 5,
+      }
+      const leadLocal = {
+        contaminantId: "lead",
+        jurisdictionCode: "CA-QC",
+        limitValue: 5,
+        warningRatio: 0.8,
+        status: "regulated",
+      }
+      const leadWho = {
+        contaminantId: "lead",
+        jurisdictionCode: "WHO",
+        limitValue: 10,
+        warningRatio: 0.8,
+        status: "regulated",
+      }
+      mockGetLocationMeasurements.mockResolvedValue([leadMeasurement])
+      mockGetJurisdictionForLocation.mockReturnValue({ code: "CA-QC" })
+      mockGetThreshold.mockReturnValue(leadLocal)
+      mockGetWHOThreshold.mockReturnValue(leadWho)
+
+      const { result } = renderHook(() => useLocationData("Montreal"), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.cityData).not.toBeNull()
+      })
+
+      const stat = result.current.cityData!.stats[0]
+      expect(stat.whoStatus).toBe("safe") // 5 < WHO warning (10*0.8=8)
+      expect(stat.localStatus).toBe("danger") // 5 >= QC limit (5)
+      expect(stat.status).toBe("danger") // worst-of-the-two
     })
   })
 

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -125,6 +125,36 @@ export function clearCachedLocationData(city: string, state?: string, country?: 
 }
 
 /**
+ * Compute a SafetyStatus from a measured value and a single threshold.
+ * Returns "safe" when the threshold is missing or has no limit (no
+ * comparison possible).
+ */
+function computeStatusForThreshold(
+  value: number,
+  threshold: { limitValue?: number | null; warningRatio?: number | null } | undefined,
+  higherIsBad: boolean,
+): StatStatus {
+  if (!threshold || threshold.limitValue == null) return "safe"
+  const limit = threshold.limitValue
+  const warningThreshold = limit * (threshold.warningRatio ?? 0.8)
+  if (higherIsBad) {
+    if (value >= limit) return "danger"
+    if (value >= warningThreshold) return "warning"
+    return "safe"
+  }
+  if (value <= limit) return "danger"
+  if (value <= warningThreshold) return "warning"
+  return "safe"
+}
+
+const STATUS_SEVERITY: Record<StatStatus, number> = { safe: 0, warning: 1, danger: 2 }
+
+/** Returns the more-severe of two statuses (danger > warning > safe). */
+function worstStatus(a: StatStatus, b: StatStatus): StatStatus {
+  return STATUS_SEVERITY[a] >= STATUS_SEVERITY[b] ? a : b
+}
+
+/**
  * Hook to fetch city safety data with caching support.
  *
  * Cascades through the location hierarchy (#123): if no city-specific
@@ -140,6 +170,7 @@ export function useLocationData(
   const {
     contaminants,
     getThreshold,
+    getWHOThreshold,
     getJurisdictionForLocation,
     isLoading: defsLoading,
   } = useContaminants()
@@ -147,37 +178,47 @@ export function useLocationData(
   const qc = useQueryClient()
 
   /**
-   * Maps new LocationMeasurement to legacy CityStat format
+   * Maps new LocationMeasurement to legacy CityStat format.
+   *
+   * Computes status against both the WHO and local-jurisdiction thresholds
+   * (EPI-18 sub-bug B). For QC, the local limits are tighter than WHO for
+   * many contaminants — a row that is safe vs WHO can read as danger vs QC.
+   * Carrying both in `whoStatus` / `localStatus` lets the table render a
+   * pill per column instead of a single row-level badge that hid the
+   * distinction.
+   *
+   * `status` is the worst of the two so callers that have not migrated
+   * (DashboardScreen summary, calculateCategoryStatus) keep behaving the
+   * same way.
    */
   const mapMeasurementToLegacyStat = useCallback(
     (measurement: AmplifyLocationMeasurement, jurisdictionCode: string): CityStat => {
       const contaminant = contaminants.find((c) => c.id === measurement.contaminantId)
-      const threshold = getThreshold(measurement.contaminantId, jurisdictionCode)
       const higherIsBad = contaminant?.higherIsBad ?? true
 
-      let status: StatStatus = "safe"
-      if (threshold && threshold.limitValue !== null) {
-        const limit = threshold.limitValue
-        const warningRatio = threshold.warningRatio ?? 0.8
-        const warningThreshold = limit * warningRatio
-
-        if (higherIsBad) {
-          if (measurement.value >= limit) status = "danger"
-          else if (measurement.value >= warningThreshold) status = "warning"
-        } else {
-          if (measurement.value <= limit) status = "danger"
-          else if (measurement.value <= warningThreshold) status = "warning"
-        }
-      }
+      const whoStatus = computeStatusForThreshold(
+        measurement.value,
+        getWHOThreshold(measurement.contaminantId),
+        higherIsBad,
+      )
+      const localThreshold =
+        jurisdictionCode === "WHO"
+          ? undefined
+          : getThreshold(measurement.contaminantId, jurisdictionCode)
+      const localStatus = localThreshold
+        ? computeStatusForThreshold(measurement.value, localThreshold, higherIsBad)
+        : whoStatus
 
       return {
         statId: measurement.contaminantId,
         value: measurement.value,
-        status,
+        status: worstStatus(whoStatus, localStatus),
+        whoStatus,
+        localStatus,
         lastUpdated: measurement.measuredAt ?? new Date().toISOString(),
       }
     },
-    [contaminants, getThreshold],
+    [contaminants, getThreshold, getWHOThreshold],
   )
 
   /**

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -143,6 +143,8 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
         localLimit: hasLocalThreshold ? (localThreshold.limitValue ?? null) : null,
         localJurisdictionName,
         status: stat.status,
+        whoStatus: stat.whoStatus ?? stat.status,
+        localStatus: stat.localStatus ?? stat.status,
         isUnregulated: hasLocalThreshold && localThreshold.status === "not_controlled",
       }
     })


### PR DESCRIPTION
## Summary

Resolves EPI-18 sub-bug B — every row on the Boucherville Water Quality screen rendering as `🔴 danger` even when the value is well under the WHO threshold. Roo cause was that `mapMeasurementToLegacyStat` computed status against the local-jurisdiction (QC) threshold only, then collapsed the result into a single row-level badge that hid the WHO-vs-local distinction the table was already trying to surface in its WHO and LOCAL columns.

The fix splits the status into `whoStatus` and `localStatus` and renders one pill per value cell. A row that is safe vs WHO and danger vs QC now reads as `🟢 ... 🔴`.

## Reproduction (staging, 2026-05-09)

URL: `https://staging.d2z5ddqhlc1q5.amplifyapp.com/category/water/undefined?city=Boucherville&state=QC&country=CA`

Pre-fix snapshot from `chrome-devtools` shows **all 52 contaminants reading `Status: danger`**, including:

| Contaminant | Value | QC | WHO | Pre-fix | Post-fix expected |
|---|---|---|---|---|---|
| Lead | 5 µg/L | 5 | 10 | 🔴 | WHO 🟢, QC 🔴 |
| Mercury | 1 µg/L | 1 | 6 | 🔴 | WHO 🟢, QC 🔴 |
| Atrazine | 5 µg/L | 5 | 100 | 🔴 | WHO 🟢, QC 🔴 |
| 2,4,6-Trichlorophenol | 5 µg/L | 5 | 200 | 🔴 | WHO 🟢, QC 🔴 |
| Tritium | 7000 Bq/L | 7000 | 10000 | 🔴 | WHO 🟢, QC 🔴 |
| Uranium-238 | 508 Bq/L | 10 | 10 | 🔴 | WHO 🔴, QC 🔴 (genuine) |

## Files changed

- `apps/mobile/app/hooks/useLocationData.ts` — extract `computeStatusForThreshold` + `worstStatus` helpers; pull `getWHOThreshold` from `useContaminants`; compute both statuses in `mapMeasurementToLegacyStat`.
- `apps/mobile/app/components/ContaminantTable.tsx` — render a `StatusIndicator` inside each value cell driven by `whoStatus` / `localStatus`; suppress the pill when the corresponding threshold is null/unregulated; drop the trailing single-status column.
- `apps/mobile/app/screens/CategoryDetailScreen.tsx` — thread `whoStatus` / `localStatus` through `tableRows`.
- `apps/mobile/app/data/types/safety.ts` — add `whoStatus?` / `localStatus?` to `CityStat` (optional for back-compat with cached MMKV data written before this change).

## Back-compat

- `CityStat.status` is preserved as the worst-of-(whoStatus, localStatus) so callers that haven't migrated (`DashboardScreen`, `calculateCategoryStatus`, `RecommendationsSection`) keep behaving the same way.
- `whoStatus` / `localStatus` are optional on `CityStat` and on `ContaminantTableRow`. When absent (cached MMKV entries written before this change), `ContaminantTable` falls back to `row.status` for both pills — so old cache entries still render rather than error.
- The MMKV cache prefix is **not** bumped. PR #312 already moved it to `_v2_` for the cascade-bleed fix; bumping again would evict 24 hours of legitimate offline data without benefit, since the optional-field design handles the deserialization edge case.

## Tests

- 240 / 240 tests pass across 21 suites.
- `useLocationData.test.ts` — new case `splits status into whoStatus + localStatus when local is tighter than WHO` pins the headline behavior with the real Boucherville Lead numbers (value 5, QC 5, WHO 10) — pre-fix this would have produced `status: \"danger\"` only; post-fix it produces `whoStatus: \"safe\"`, `localStatus: \"danger\"`, `status: \"danger\"`.
- `ContaminantTable.test.tsx` — three new render cases:
  - dual pills with safe vs WHO + danger vs QC
  - pill suppression when no WHO threshold (e.g. Glyphosate)
  - back-compat fallback to `row.status` when both new fields are absent

## Test plan

- [x] `npx eslint app/hooks/useLocationData.ts app/components/ContaminantTable.tsx app/screens/CategoryDetailScreen.tsx app/data/types/safety.ts` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 240/240 pass
- [ ] After merge → staging: open `https://staging.d2z5ddqhlc1q5.amplifyapp.com/category/water/undefined?city=Boucherville&state=QC&country=CA` → confirm Lead row shows WHO 🟢, QC 🔴 (pre-fix this row reads as a single 🔴)
- [ ] Same URL → confirm Uranium-238 still shows WHO 🔴 + QC 🔴 (genuine danger vs both standards)
- [ ] `?subCategoryId=fertilizer` → Nitrate row shows WHO 🟢, QC 🔴 (value is at QC limit but 1/5 of WHO)

## Out of scope (already fixed / separate PRs)

- Sub-bug A (`subCategoryId` filter) and sub-bug C (per-row units) — PR #313, merged.
- Cascade bleed and sub-bug D (duplicate rows) — PR #312, merged. Verified today on staging: Sorel-Tracy shows empty state, Boucherville shows 52 unique rows.
- Seed-data category corrections — PR #318.
- Minor: \"Showing QC data\" badge appears on Sorel-Tracy even though 0 anchored records resolve. Should collapse `scope: \"state\"` to `scope: \"none\"` when the post-anchor filter is empty. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)