### PR TITLE
chore(ci): validate seed-data categories against schema enum

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,28 @@ jobs:
       - name: Lint backend
         run: yarn workspace @mapyourhealth/backend lint:check
 
+  validate-seed-data:
+    name: Validate Seed Data
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Validate seed-data.json categories against schema enum
+        run: yarn workspace @mapyourhealth/backend validate:seed
+
   lint-mobile:
     name: Lint Mobile
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,9 @@ cd apps/web && npx tsc --noEmit               # Web
 
 # Unit tests
 cd apps/mobile && npm run test                # Jest
+
+# Seed-data validation (when packages/backend/scripts/seed-data.json is touched)
+yarn workspace @mapyourhealth/backend validate:seed
 ```
 
 ### Pre-promotion checks (before merging `staging` → `main`)

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,6 +11,7 @@
     "fetch:outputs": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch main --app-id d3jl0ykn4qgj9r --profile rayane && cp amplify_outputs.json ../../apps/mobile/ && cp amplify_outputs.json ../../apps/admin/ && cp amplify_outputs.json ../../",
     "fetch:outputs:staging": "AWS_REGION=ca-central-1 npx @aws-amplify/backend-cli@latest generate outputs --branch staging --app-id d3jl0ykn4qgj9r --profile rayane --out-dir ./.tmp-staging && mv ./.tmp-staging/amplify_outputs.json ./amplify_outputs.staging.json && rm -rf ./.tmp-staging && cp amplify_outputs.staging.json ../../apps/mobile/",
     "lint:check": "echo 'No lint configured'",
+    "validate:seed": "tsx scripts/validate-seed-data.ts",
     "compile": "tsc --noEmit",
     "clean": "rm -rf dist .amplify",
     "esbuild": "esbuild",

--- a/packages/backend/scripts/validate-seed-data.ts
+++ b/packages/backend/scripts/validate-seed-data.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env tsx
+/**
+ * Validates packages/backend/scripts/seed-data.json against the
+ * Contaminant.category enum declared in amplify/data/resource.ts.
+ *
+ * Fails (exit 1) if any contaminant has a category that is not a member of
+ * the schema enum. Run via `yarn workspace @mapyourhealth/backend validate:seed`.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_BACKEND = resolve(__dirname, "..")
+const SCHEMA_PATH = resolve(REPO_BACKEND, "amplify/data/resource.ts")
+const SEED_PATH = resolve(REPO_BACKEND, "scripts/seed-data.json")
+
+function extractCategoryEnum(schemaSource: string): string[] {
+  const block = schemaSource.match(/category:\s*a\.enum\(\[([\s\S]*?)\]\)/)
+  if (!block) {
+    throw new Error(
+      `Could not locate Contaminant.category enum in ${SCHEMA_PATH}. ` +
+        `If the schema was refactored, update validate-seed-data.ts.`,
+    )
+  }
+  const values = Array.from(block[1].matchAll(/"([^"]+)"/g)).map((m) => m[1])
+  if (values.length === 0) {
+    throw new Error(`Parsed an empty category enum from ${SCHEMA_PATH}.`)
+  }
+  return values
+}
+
+interface ContaminantRecord {
+  contaminantId: string
+  name: string
+  category?: string
+}
+
+interface SeedData {
+  contaminants?: ContaminantRecord[]
+}
+
+function main(): void {
+  const schemaSource = readFileSync(SCHEMA_PATH, "utf8")
+  const allowedCategories = new Set(extractCategoryEnum(schemaSource))
+
+  const seedRaw = readFileSync(SEED_PATH, "utf8")
+  let seed: SeedData
+  try {
+    seed = JSON.parse(seedRaw)
+  } catch (err) {
+    console.error(`seed-data.json is not valid JSON: ${(err as Error).message}`)
+    process.exit(1)
+  }
+
+  const contaminants = seed.contaminants ?? []
+  if (contaminants.length === 0) {
+    console.error("seed-data.json contains no contaminants.")
+    process.exit(1)
+  }
+
+  const violations: { contaminantId: string; name: string; category: unknown }[] = []
+  const tally = new Map<string, number>()
+
+  for (const c of contaminants) {
+    const cat = c.category
+    if (typeof cat !== "string" || !allowedCategories.has(cat)) {
+      violations.push({ contaminantId: c.contaminantId, name: c.name, category: cat })
+      continue
+    }
+    tally.set(cat, (tally.get(cat) ?? 0) + 1)
+  }
+
+  console.log(`Schema enum (${SCHEMA_PATH}):`)
+  console.log(`  ${[...allowedCategories].join(", ")}\n`)
+  console.log(`Seed data: ${contaminants.length} contaminants`)
+  for (const cat of [...allowedCategories].sort()) {
+    console.log(`  ${cat}: ${tally.get(cat) ?? 0}`)
+  }
+
+  if (violations.length > 0) {
+    console.error(`\n${violations.length} invalid category value(s):`)
+    for (const v of violations) {
+      console.error(
+        `  - ${v.contaminantId} (${v.name}): ${JSON.stringify(v.category)}`,
+      )
+    }
+    console.error(
+      `\nExpected one of: ${[...allowedCategories].join(", ")}`,
+    )
+    process.exit(1)
+  }
+
+  console.log("\nAll category values valid.")
+}
+
+main()


### PR DESCRIPTION
## Summary

Adds a CI gate that catches drift between `packages/backend/scripts/seed-data.json` and the `Contaminant.category` enum declared in `packages/backend/amplify/data/resource.ts`.

Motivated by the review of #318 (EPI-18): a typo like `"organic "` (trailing space) or a value outside the 7-member enum would have passed `JSON.parse` and only failed at AppSync write time during a `yarn seed` run, with no PR-time signal.

## What changed

- **New script** `packages/backend/scripts/validate-seed-data.ts` — parses the enum directly from `resource.ts` (so it stays in sync if the schema gets extended, e.g. the proposed `physical` value for microplastics) and validates every contaminant in `seed-data.json`. Prints the tally per category, exits 1 on violations.
- **`packages/backend/package.json`** — adds `yarn workspace @mapyourhealth/backend validate:seed`.
- **`.github/workflows/lint.yml`** — new `validate-seed-data` job, runs whenever backend files change. Unlike the existing lint jobs (which use `continue-on-error: true`), this one is a hard gate.
- **`CLAUDE.md`** — adds the validate command to the Pre-merge checks block.

## Test plan

- [x] Positive: `yarn workspace @mapyourhealth/backend validate:seed` against current `staging` (post-#318) — passes, prints tally `inorganic: 14, organic: 44, microbiological: 1, disinfectant: 28, fertilizer: 2, pesticide: 68, radioactive: 17` (matches #318's "After" column).
- [x] Negative: injected `"organic "` typo locally → exits 1 with `nitrate (Nitrate): "organic "` and lists allowed values. Restored cleanly (`git diff` empty).
- [ ] After merge: confirm the `Validate Seed Data` job appears as a required check on subsequent backend PRs.

## Notes

This does **not** validate that all contaminants have been seeded into DynamoDB — it only validates the source-of-truth JSON. A live "DB matches JSON" check would need an authenticated AppSync query and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)