### PR TITLE
fix(dashboard): show skeleton on every location search + GPS/auto-redirect resets

### DIFF
--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -44,14 +44,37 @@ import { trackEvent } from "@/utils/analytics"
 /** Orange color for WHO-only exceedances */
 const WHO_EXCEEDANCE_COLOR = "#F97316"
 
-// Survives the screen remount that `CommonActions.reset` triggers on search.
-// `useLocationData` rehydrates from MMKV via `initialData`, so cached cities
-// land in `success` state with `isLoading: false` and the skeleton would
-// otherwise never show. The search handler stamps this on dispatch and the
-// next mount consumes it to seed an initial loading state.
+// Survives the screen remount that `CommonActions.reset` triggers on every
+// city change. `useLocationData` rehydrates from MMKV via `initialData`, so
+// cached cities land in `success` state with `isLoading: false` and the
+// skeleton would otherwise never show. `resetDashboardToLocation` stamps
+// this on dispatch; the next mount consumes it to seed an initial loading
+// state. All city-changing reset paths (search, GPS, primarySubscription
+// auto-redirect) must go through the helper to stay consistent — the bare
+// "clear location" path intentionally bypasses it.
 let pendingSearchAt: number | null = null
 const SEARCH_HANDOFF_WINDOW_MS = 1000
 const SEARCH_SKELETON_HOLD_MS = 400
+
+interface DashboardResetParams {
+  city: string
+  state: string
+  country: string
+  address?: string
+}
+
+function resetDashboardToLocation(
+  navigation: AppStackScreenProps<"Dashboard">["navigation"],
+  params: DashboardResetParams,
+): void {
+  pendingSearchAt = Date.now()
+  navigation.dispatch(
+    CommonActions.reset({
+      index: 0,
+      routes: [{ name: "Dashboard", params }],
+    }),
+  )
+}
 
 interface DashboardScreenProps extends AppStackScreenProps<"Dashboard"> {}
 
@@ -104,21 +127,11 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   // Sync primary subscription to route params when no location is set yet
   useEffect(() => {
     if (!route.params?.city && isAuthenticated && primarySubscription && !subsLoading) {
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [
-            {
-              name: "Dashboard",
-              params: {
-                city: primarySubscription.city,
-                state: primarySubscription.state,
-                country: primarySubscription.country,
-              },
-            },
-          ],
-        }),
-      )
+      resetDashboardToLocation(navigation, {
+        city: primarySubscription.city,
+        state: primarySubscription.state,
+        country: primarySubscription.country,
+      })
     }
   }, [primarySubscription, isAuthenticated, subsLoading, route.params?.city, navigation])
 
@@ -304,13 +317,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   // Handle location selection from PlacesSearchBar — updates URL via route params
   const handleLocationSelect = useCallback(
     (city: string, state: string, country: string, addr?: string) => {
-      pendingSearchAt = Date.now()
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [{ name: "Dashboard", params: { city, state, country, address: addr } }],
-        }),
-      )
+      resetDashboardToLocation(navigation, { city, state, country, address: addr })
     },
     [navigation],
   )
@@ -330,21 +337,11 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   const handleLocationPress = useCallback(async () => {
     const location = await getLocationFromGPS()
     if (location) {
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [
-            {
-              name: "Dashboard",
-              params: {
-                city: location.city,
-                state: location.state,
-                country: location.country,
-              },
-            },
-          ],
-        }),
-      )
+      resetDashboardToLocation(navigation, {
+        city: location.city,
+        state: location.state,
+        country: location.country,
+      })
     }
   }, [getLocationFromGPS, navigation])
 

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles, react/no-unescaped-entities */
-import { FC, useCallback, useEffect, useMemo, useState } from "react"
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { View, ViewStyle, Pressable, TextStyle, Alert, RefreshControl, Share } from "react-native"
 import { MaterialCommunityIcons } from "@expo/vector-icons"
 import { CommonActions } from "@react-navigation/native"
@@ -43,6 +43,15 @@ import { trackEvent } from "@/utils/analytics"
 
 /** Orange color for WHO-only exceedances */
 const WHO_EXCEEDANCE_COLOR = "#F97316"
+
+// Survives the screen remount that `CommonActions.reset` triggers on search.
+// `useLocationData` rehydrates from MMKV via `initialData`, so cached cities
+// land in `success` state with `isLoading: false` and the skeleton would
+// otherwise never show. The search handler stamps this on dispatch and the
+// next mount consumes it to seed an initial loading state.
+let pendingSearchAt: number | null = null
+const SEARCH_HANDOFF_WINDOW_MS = 1000
+const SEARCH_SKELETON_HOLD_MS = 400
 
 interface DashboardScreenProps extends AppStackScreenProps<"Dashboard"> {}
 
@@ -146,9 +155,37 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     refresh,
   } = locationData
 
+  // Force-show the skeleton on every search. MMKV-cached cities rehydrate
+  // through `initialData` with `isLoading: false`, which otherwise leaves
+  // search with no visual feedback. Two paths cover both navigation modes:
+  //   1. Module-level handoff for `CommonActions.reset` (remounts the screen).
+  //   2. City-change ref for the same-instance case (e.g., setParams).
+  const [isSearching, setIsSearching] = useState<boolean>(() => {
+    if (pendingSearchAt !== null && Date.now() - pendingSearchAt < SEARCH_HANDOFF_WINDOW_MS) {
+      pendingSearchAt = null
+      return true
+    }
+    return false
+  })
+  const prevCityRef = useRef<string | undefined>(currentLocation?.city)
+
+  useEffect(() => {
+    const newCity = currentLocation?.city
+    if (newCity && newCity !== prevCityRef.current) {
+      setIsSearching(true)
+    }
+    prevCityRef.current = newCity
+  }, [currentLocation?.city])
+
+  useEffect(() => {
+    if (!isSearching) return
+    const timer = setTimeout(() => setIsSearching(false), SEARCH_SKELETON_HOLD_MS)
+    return () => clearTimeout(timer)
+  }, [isSearching])
+
   // Hold the loading state for at least 250ms so the skeleton does not flash
   // on warm-cache rehydration (where isLoading flips false in <50ms).
-  const isLoading = useMinimumDuration(isLoadingRaw, 250)
+  const isLoading = useMinimumDuration(isLoadingRaw || isSearching, 250)
 
   // Track city view for analytics
   useEffect(() => {
@@ -267,6 +304,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   // Handle location selection from PlacesSearchBar — updates URL via route params
   const handleLocationSelect = useCallback(
     (city: string, state: string, country: string, addr?: string) => {
+      pendingSearchAt = Date.now()
       navigation.dispatch(
         CommonActions.reset({
           index: 0,


### PR DESCRIPTION
## Summary

Two follow-ups to the dashboard skeleton work (#306/#310). Both fix cases where the loading skeleton failed to appear during city changes that go through `CommonActions.reset`.

- **`0239431` — show skeleton on every location search.** `useLocationData` seeds React Query with MMKV `initialData`, so re-searching a recently visited city resolves to `success` instantly and `useMinimumDuration` (only holds true values, never produces them) leaves the skeleton hidden. The search dispatches `CommonActions.reset`, remounting the screen, so in-component refs alone can't bridge it. Adds a module-level `pendingSearchAt` stamp set before the reset and read on the next mount; combined with `isLoadingRaw` inside the existing minimum-duration hold. A city-change `useRef` fallback covers same-instance navigation.
- **`102530b` — apply skeleton signal to GPS + primarySubscription resets.** The previous commit only stamped `pendingSearchAt` from the search handler. The GPS button and the primary-subscription auto-redirect on mount also dispatch `CommonActions.reset` and hit the same MMKV-rehydrated `isLoading: false` path with no skeleton. Extracts `resetDashboardToLocation` so all three city-changing reset sites flow through one seam that owns the stamp. The bare clear-location path stays as a direct dispatch — clearing intentionally lands on empty state and should not flash a skeleton.

## Test plan
- [ ] Search for a recently visited city (in MMKV cache) → skeleton appears for the minimum duration before data renders
- [ ] Tap GPS location button → skeleton appears during the location switch
- [ ] Land on dashboard with a `primarySubscription` set → skeleton appears during the auto-redirect
- [ ] Clear location (no city selected) → empty state shows immediately, no skeleton flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)