### PR TITLE
feat(dashboard): expand sub-categories inline to show contaminants

### DIFF
--- a/apps/mobile/app/components/ExpandableCategoryCard.tsx
+++ b/apps/mobile/app/components/ExpandableCategoryCard.tsx
@@ -145,6 +145,12 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
   const [measured, setMeasured] = useState(false)
   const contentHeight = useSharedValue(0)
   const progress = useSharedValue(0)
+  // Tracks the steady "fully open" state. The measured contentHeight is
+  // captured once with all sub-category accordions collapsed, so once the
+  // open animation completes we switch to height:"auto" so a child accordion
+  // expanding (and growing the natural height) is not clipped by the parent's
+  // overflow:hidden.
+  const fullyOpenShared = useSharedValue(0)
 
   const handleMeasured = useCallback(() => {
     setMeasured(true)
@@ -164,14 +170,24 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
   const toggleExpand = useCallback(() => {
     const newExpanded = !expanded
 
-    // Animate
-    progress.value = withTiming(newExpanded ? 1 : 0, {
-      duration: ANIMATION_DURATION,
-      easing: EASING,
-    })
+    if (!newExpanded) {
+      // Closing: drop the steady-open flag immediately so the height
+      // interpolation animates from the measured value rather than "auto".
+      fullyOpenShared.value = 0
+    }
+
+    progress.value = withTiming(
+      newExpanded ? 1 : 0,
+      { duration: ANIMATION_DURATION, easing: EASING },
+      (finished) => {
+        if (finished && newExpanded) {
+          fullyOpenShared.value = 1
+        }
+      },
+    )
 
     setExpanded(newExpanded)
-  }, [expanded, progress])
+  }, [expanded, progress, fullyOpenShared])
 
   const handlePress = () => {
     if (hasSubCategories) {
@@ -185,6 +201,15 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
   const animatedContentStyle = useAnimatedStyle(() => {
     // Before measurement, use auto height for initial render
     if (contentHeight.value === 0) {
+      return {
+        height: "auto" as unknown as number,
+        opacity: 1,
+      }
+    }
+
+    // Once the open animation has settled, let height grow naturally so a
+    // nested sub-category accordion expanding doesn't get clipped.
+    if (fullyOpenShared.value === 1) {
       return {
         height: "auto" as unknown as number,
         opacity: 1,

--- a/apps/mobile/app/components/ExpandableCategoryCard.tsx
+++ b/apps/mobile/app/components/ExpandableCategoryCard.tsx
@@ -14,9 +14,11 @@ import { useCategories } from "@/context/CategoriesContext"
 import { CATEGORY_CONFIG, SubCategory as LegacySubCategory } from "@/data/categoryConfig"
 import type { StatCategory, StatStatus, SubCategory } from "@/data/types/safety"
 import { useAppTheme } from "@/theme/context"
+import { trackEvent } from "@/utils/analytics"
 
 import { CategoryIcon } from "./CategoryIcon"
 import { CategoryInfoButton } from "./CategoryInfoButton"
+import { StatItem } from "./StatItem"
 import { StatusIndicator } from "./StatusIndicator"
 import { Text } from "./Text"
 
@@ -31,6 +33,17 @@ export interface SubCategoryStatusResult {
   status: StatStatus
   /** Optional color override (e.g., orange for WHO-only exceedances) */
   color?: string
+}
+
+/**
+ * A single contaminant row rendered inside an expanded sub-category panel.
+ */
+export interface SubCategoryStatRow {
+  statId: string
+  name: string
+  value: number
+  unit: string
+  status: StatStatus
 }
 
 export interface ExpandableCategoryCardProps {
@@ -48,7 +61,8 @@ export interface ExpandableCategoryCardProps {
    */
   status: StatStatus
   /**
-   * Callback when the card (or a sub-category) should navigate to details
+   * Callback when the card (or a sub-category's "View details" link) should
+   * navigate to a full detail screen.
    */
   onPress: (subCategoryId?: string) => void
   /**
@@ -62,6 +76,13 @@ export interface ExpandableCategoryCardProps {
    */
   riskCount?: number
   /**
+   * Optional callback to provide the contaminant rows shown when a
+   * sub-category is expanded inline. If omitted (or returns an empty array)
+   * the sub-category panel renders a placeholder line plus a "View details"
+   * link.
+   */
+  getSubCategoryContent?: (subCategoryId: string) => SubCategoryStatRow[]
+  /**
    * Optional style override for the container
    */
   style?: StyleProp<ViewStyle>
@@ -73,7 +94,9 @@ export interface ExpandableCategoryCardProps {
  *
  * For categories with sub-categories:
  * - Tapping the card expands/collapses to show sub-categories with animation
- * - Tapping a sub-category navigates to the category detail with that sub-category focused
+ * - Each sub-category row is itself an accordion: tapping it expands inline
+ *   to show the contaminant rows that belong to that sub-category, plus a
+ *   "View details" link that calls `onPress(subCategoryId)`.
  *
  * @example
  * <ExpandableCategoryCard
@@ -84,7 +107,16 @@ export interface ExpandableCategoryCardProps {
  * />
  */
 export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
-  const { category, categoryName, status, onPress, getSubCategoryStatus, riskCount, style } = props
+  const {
+    category,
+    categoryName,
+    status,
+    onPress,
+    getSubCategoryStatus,
+    riskCount,
+    getSubCategoryContent,
+    style,
+  } = props
   const { theme } = useAppTheme()
   const { getCategoryById, getSubCategoriesByCategoryId, getCategoryDescription } = useCategories()
 
@@ -147,13 +179,6 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
     } else {
       onPress()
     }
-  }
-
-  const handleSubCategoryPress = (subCategory: SubCategory | LegacySubCategory) => {
-    // Handle both dynamic SubCategory (subCategoryId) and legacy SubCategory (id)
-    const subCategoryId =
-      "subCategoryId" in subCategory ? subCategory.subCategoryId : subCategory.id
-    onPress(subCategoryId)
   }
 
   // Animated style for content container
@@ -231,28 +256,6 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
     paddingBottom: 8,
   }
 
-  const $subCategoryRow: ViewStyle = {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 10,
-    paddingLeft: 56, // Indent: icon (28) + iconMarginRight (12) + extra indent (16)
-    paddingRight: 16,
-  }
-
-  const $subCategoryText: TextStyle = {
-    flex: 1,
-    fontSize: 15,
-    color: theme.colors.text,
-  }
-
-  const $subCategoryStatusContainer: ViewStyle = {
-    marginLeft: 8,
-  }
-
-  const $subCategoryChevron: ViewStyle = {
-    marginLeft: 8,
-  }
-
   const $divider: ViewStyle = {
     height: 1,
     backgroundColor: theme.colors.separator,
@@ -272,35 +275,16 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
       {subCategories.map((subCategory) => {
         // Handle both dynamic SubCategory (subCategoryId) and legacy SubCategory (id)
         const key = "subCategoryId" in subCategory ? subCategory.subCategoryId : subCategory.id
-        const subCategoryStatusResult = getSubCategoryStatus?.(key)
         return (
-          <Pressable
+          <SubCategoryAccordion
             key={key}
-            onPress={() => handleSubCategoryPress(subCategory)}
-            style={({ pressed }) => [
-              $subCategoryRow,
-              pressed && { backgroundColor: theme.colors.palette.neutral100 },
-            ]}
-            accessibilityRole="button"
-            accessibilityLabel={`${subCategory.name} sub-category${subCategoryStatusResult ? `, status: ${subCategoryStatusResult.status}` : ""}`}
-          >
-            <Text style={$subCategoryText}>{subCategory.name}</Text>
-            {"description" in subCategory && subCategory.description && (
-              <CategoryInfoButton name={subCategory.name} description={subCategory.description} />
-            )}
-            {subCategoryStatusResult && (
-              <View style={$subCategoryStatusContainer}>
-                <StatusIndicator
-                  status={subCategoryStatusResult.status}
-                  size="small"
-                  color={subCategoryStatusResult.color}
-                />
-              </View>
-            )}
-            <View style={$subCategoryChevron}>
-              <MaterialCommunityIcons name="chevron-right" size={20} color={theme.colors.textDim} />
-            </View>
-          </Pressable>
+            subCategoryId={key}
+            name={subCategory.name}
+            description={"description" in subCategory ? subCategory.description : undefined}
+            statusResult={getSubCategoryStatus?.(key)}
+            content={getSubCategoryContent?.(key)}
+            onViewDetails={() => onPress(key)}
+          />
         )
       })}
     </View>
@@ -350,6 +334,223 @@ export function ExpandableCategoryCard(props: ExpandableCategoryCardProps) {
           </Animated.View>
         </>
       )}
+    </View>
+  )
+}
+
+interface SubCategoryAccordionProps {
+  subCategoryId: string
+  name: string
+  description?: string
+  statusResult?: SubCategoryStatusResult
+  /** Contaminant rows to show when expanded. Empty array = placeholder. */
+  content?: SubCategoryStatRow[]
+  /** Called when the user taps "View details" inside the expanded panel. */
+  onViewDetails: () => void
+}
+
+/**
+ * One sub-category row inside `ExpandableCategoryCard`. Tapping the row
+ * toggles an inner accordion that reveals the contaminants belonging to
+ * the sub-category plus a "View details" link to the full detail screen.
+ *
+ * Re-implements the same Reanimated height-measurement pattern used by
+ * `ExpandableCard` instead of composing it directly, because the header
+ * needs to embed `StatusIndicator` and `CategoryInfoButton` next to the
+ * chevron — which the generic `ExpandableCard` doesn't expose.
+ */
+function SubCategoryAccordion(props: SubCategoryAccordionProps) {
+  const { subCategoryId, name, description, statusResult, content, onViewDetails } = props
+  const { theme } = useAppTheme()
+
+  const [expanded, setExpanded] = useState(false)
+  const [measured, setMeasured] = useState(false)
+  const contentHeight = useSharedValue(0)
+  const progress = useSharedValue(0)
+
+  const handleMeasured = useCallback(() => {
+    setMeasured(true)
+  }, [])
+
+  const onContentLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const height = event.nativeEvent.layout.height
+      if (height > 0 && contentHeight.value === 0) {
+        contentHeight.value = height
+        runOnJS(handleMeasured)()
+      }
+    },
+    [contentHeight, handleMeasured],
+  )
+
+  const toggleExpand = useCallback(() => {
+    const newExpanded = !expanded
+
+    progress.value = withTiming(newExpanded ? 1 : 0, {
+      duration: ANIMATION_DURATION,
+      easing: EASING,
+    })
+
+    setExpanded(newExpanded)
+
+    if (newExpanded) {
+      trackEvent("SubCategoryExpanded", { subCategoryId })
+    }
+  }, [expanded, progress, subCategoryId])
+
+  const animatedContentStyle = useAnimatedStyle(() => {
+    if (contentHeight.value === 0) {
+      return {
+        height: "auto" as unknown as number,
+        opacity: 1,
+      }
+    }
+
+    const height = interpolate(progress.value, [0, 1], [0, contentHeight.value])
+
+    return {
+      height,
+      opacity: interpolate(progress.value, [0, 0.3, 1], [0, 0.8, 1]),
+    }
+  })
+
+  const animatedChevronStyle = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          rotate: `${interpolate(progress.value, [0, 1], [0, 90])}deg`,
+        },
+      ],
+    }
+  })
+
+  const $row: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingLeft: 56, // Indent: icon (28) + iconMarginRight (12) + extra indent (16)
+    paddingRight: 16,
+  }
+
+  const $rowText: TextStyle = {
+    flex: 1,
+    fontSize: 15,
+    color: theme.colors.text,
+  }
+
+  const $rowStatusContainer: ViewStyle = {
+    marginLeft: 8,
+  }
+
+  const $rowChevron: ViewStyle = {
+    marginLeft: 8,
+  }
+
+  const $contentOuter: ViewStyle = {
+    overflow: "hidden",
+  }
+
+  const $innerContent: ViewStyle = {
+    paddingLeft: 56,
+    paddingRight: 16,
+    paddingBottom: 12,
+  }
+
+  const $emptyText: TextStyle = {
+    fontSize: 13,
+    color: theme.colors.textDim,
+    fontStyle: "italic",
+    paddingVertical: 8,
+  }
+
+  const $viewDetailsRow: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    marginTop: 4,
+  }
+
+  const $viewDetailsText: TextStyle = {
+    fontSize: 14,
+    color: theme.colors.tint,
+    fontWeight: "500",
+  }
+
+  const $viewDetailsChevron: ViewStyle = {
+    marginLeft: 4,
+  }
+
+  const $measureContainer: ViewStyle = {
+    position: "absolute",
+    opacity: 0,
+    pointerEvents: "none",
+  }
+
+  const renderInnerContent = () => (
+    <View style={$innerContent}>
+      {content && content.length > 0 ? (
+        content.map((row) => (
+          <StatItem
+            key={row.statId}
+            name={row.name}
+            value={row.value}
+            unit={row.unit}
+            status={row.status}
+          />
+        ))
+      ) : (
+        <Text style={$emptyText}>No measurements for this sub-category at this location.</Text>
+      )}
+      <Pressable
+        onPress={onViewDetails}
+        style={({ pressed }) => [$viewDetailsRow, pressed && { opacity: 0.6 }]}
+        accessibilityRole="link"
+        accessibilityLabel={`View details for ${name}`}
+      >
+        <Text style={$viewDetailsText}>View details</Text>
+        <View style={$viewDetailsChevron}>
+          <MaterialCommunityIcons name="chevron-right" size={18} color={theme.colors.tint} />
+        </View>
+      </Pressable>
+    </View>
+  )
+
+  return (
+    <View>
+      <Pressable
+        onPress={toggleExpand}
+        style={({ pressed }) => [
+          $row,
+          pressed && { backgroundColor: theme.colors.palette.neutral100 },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`${name} sub-category${statusResult ? `, status: ${statusResult.status}` : ""}`}
+        accessibilityState={{ expanded }}
+      >
+        <Text style={$rowText}>{name}</Text>
+        {description && <CategoryInfoButton name={name} description={description} />}
+        {statusResult && (
+          <View style={$rowStatusContainer}>
+            <StatusIndicator status={statusResult.status} size="small" color={statusResult.color} />
+          </View>
+        )}
+        <Animated.View style={[$rowChevron, animatedChevronStyle]}>
+          <MaterialCommunityIcons name="chevron-right" size={20} color={theme.colors.textDim} />
+        </Animated.View>
+      </Pressable>
+
+      {/* Hidden measurement view - renders once to get height */}
+      {!measured && (
+        <View style={$measureContainer}>
+          <View onLayout={onContentLayout}>{renderInnerContent()}</View>
+        </View>
+      )}
+
+      <Animated.View style={[$contentOuter, animatedContentStyle]}>
+        {renderInnerContent()}
+      </Animated.View>
     </View>
   )
 }

--- a/apps/mobile/app/components/__tests__/ExpandableCategoryCard.test.tsx
+++ b/apps/mobile/app/components/__tests__/ExpandableCategoryCard.test.tsx
@@ -199,4 +199,16 @@ describe("ExpandableCategoryCard - inline sub-category expansion", () => {
       getAllByText("No measurements for this sub-category at this location.").length,
     ).toBeGreaterThan(0)
   })
+
+  it("renders contaminant StatItems inside the expanded sub-category panel", () => {
+    const { getAllByLabelText, getAllByTestId, getSubCategoryContent } = setup()
+
+    fireEvent.press(lastByLabel(getAllByLabelText, "Water, status: safe, expandable"))
+    fireEvent.press(lastByLabel(getAllByLabelText, "Fertilizer sub-category"))
+
+    // The mock returns one row (Nitrate) for fertilizer; assert the StatItem
+    // mock surfaces it inside the expanded panel.
+    expect(getSubCategoryContent).toHaveBeenCalledWith("fertilizer")
+    expect(getAllByTestId("stat-item-Nitrate").length).toBeGreaterThan(0)
+  })
 })

--- a/apps/mobile/app/components/__tests__/ExpandableCategoryCard.test.tsx
+++ b/apps/mobile/app/components/__tests__/ExpandableCategoryCard.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for ExpandableCategoryCard
+ *
+ * Covers the inline sub-category expansion behavior:
+ *   1. Tapping a sub-category row toggles its inner accordion *without*
+ *      firing the navigation `onPress` callback.
+ *   2. The "View details" link inside the expanded panel calls
+ *      `onPress(subCategoryId)` exactly once with the right id.
+ *   3. When `getSubCategoryContent` returns an empty array, the panel
+ *      renders a placeholder line.
+ *
+ * The component pulls in `@/theme/context`, which transitively imports
+ * `@expo-google-fonts/space-grotesk` (broken in jest in this monorepo),
+ * and `@/context/CategoriesContext`, which requires a provider. We mock
+ * both directly so the test exercises only the card logic.
+ */
+
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { StatCategory } from "@/data/types/safety"
+
+jest.mock("@/theme/context", () => ({
+  useAppTheme: () => ({
+    theme: {
+      colors: {
+        background: "#FFFFFF",
+        cardSurface: "#FFFFFF",
+        text: "#000000",
+        textDim: "#666666",
+        tint: "#0284C7",
+        separator: "#E5E5E5",
+        accentBlueBg: "#E0F2FE",
+        palette: {
+          neutral100: "#F5F5F5",
+          neutral200: "#EEEEEE",
+          neutral800: "#1F2937",
+        },
+      },
+    },
+    themed: (style: unknown) => style,
+  }),
+}))
+
+jest.mock("@/context/CategoriesContext", () => ({
+  useCategories: () => ({
+    getCategoryById: () => undefined,
+    getSubCategoriesByCategoryId: () => [
+      {
+        subCategoryId: "fertilizer",
+        categoryId: "water",
+        name: "Fertilizer",
+        sortOrder: 1,
+        isActive: true,
+      },
+      {
+        subCategoryId: "pesticide",
+        categoryId: "water",
+        name: "Pesticide",
+        sortOrder: 2,
+        isActive: true,
+      },
+    ],
+  }),
+}))
+
+// `categoryConfig` is imported at module scope and pulls in icon assets;
+// stub it so the legacy fallback path is a no-op.
+jest.mock("@/data/categoryConfig", () => ({
+  CATEGORY_CONFIG: {},
+}))
+
+// Avoid pulling Pinpoint into the test runtime.
+jest.mock("@/utils/analytics", () => ({
+  trackEvent: jest.fn(),
+}))
+
+// Stub the visual children — they pull theme + icons we don't need to
+// exercise here. Each renders a recognisable label so queries can find them.
+jest.mock("../CategoryIcon", () => {
+  const { View } = require("react-native")
+  return { CategoryIcon: () => <View testID="category-icon" /> }
+})
+
+jest.mock("../CategoryInfoButton", () => {
+  const { View } = require("react-native")
+  return { CategoryInfoButton: () => <View testID="category-info-button" /> }
+})
+
+jest.mock("../StatusIndicator", () => {
+  const { View } = require("react-native")
+  return { StatusIndicator: () => <View testID="status-indicator" /> }
+})
+
+jest.mock("../StatItem", () => {
+  const { View, Text } = require("react-native")
+  return {
+    StatItem: ({ name, value, unit }: { name: string; value: number; unit: string }) => (
+      <View testID={`stat-item-${name}`}>
+        <Text>{`${name} ${value} ${unit}`}</Text>
+      </View>
+    ),
+  }
+})
+
+// Custom Text wrapper just delegates to the RN Text in tests.
+jest.mock("../Text", () => {
+  const RN = require("react-native")
+  return { Text: RN.Text }
+})
+
+// eslint-disable-next-line import/first
+import { ExpandableCategoryCard } from "../ExpandableCategoryCard"
+
+function setup(overrides: Partial<React.ComponentProps<typeof ExpandableCategoryCard>> = {}) {
+  const onPress = jest.fn()
+  const getSubCategoryContent = jest.fn((subCategoryId: string) => {
+    if (subCategoryId === "fertilizer") {
+      return [
+        {
+          statId: "nitrate",
+          name: "Nitrate",
+          value: 1.2,
+          unit: "mg/L",
+          status: "safe" as const,
+        },
+      ]
+    }
+    return []
+  })
+
+  const utils = render(
+    <ExpandableCategoryCard
+      category={StatCategory.water}
+      categoryName="Water"
+      status="safe"
+      onPress={onPress}
+      getSubCategoryContent={getSubCategoryContent}
+      {...overrides}
+    />,
+  )
+
+  return { ...utils, onPress, getSubCategoryContent }
+}
+
+// The parent card renders its content tree twice (a hidden measurement
+// copy + the visible animated copy), and each sub-category accordion
+// also renders an inner measurement copy. As a result, every pressable
+// shows up multiple times in the test tree. The last match in render
+// order is the user-facing instance — pick it consistently so taps land
+// on the on-screen tree.
+function lastByLabel(getAll: (text: string) => any[], label: string) {
+  const all = getAll(label)
+  return all[all.length - 1]
+}
+
+describe("ExpandableCategoryCard - inline sub-category expansion", () => {
+  it("tapping a sub-category row toggles inner expansion without calling onPress", () => {
+    const { getAllByLabelText, onPress } = setup()
+
+    // Expand the parent card so the sub-category rows are interactive.
+    fireEvent.press(lastByLabel(getAllByLabelText, "Water, status: safe, expandable"))
+
+    const fertilizerRow = lastByLabel(getAllByLabelText, "Fertilizer sub-category")
+    fireEvent.press(fertilizerRow)
+
+    // The inner accordion toggled — onPress (which would navigate to the
+    // detail screen) must NOT have fired.
+    expect(onPress).not.toHaveBeenCalled()
+    expect(fertilizerRow.props.accessibilityState).toEqual({ expanded: true })
+
+    // Tapping again collapses without navigation.
+    fireEvent.press(fertilizerRow)
+    expect(onPress).not.toHaveBeenCalled()
+    expect(fertilizerRow.props.accessibilityState).toEqual({ expanded: false })
+  })
+
+  it("'View details' press fires onPress with the sub-category id exactly once", () => {
+    const { getAllByLabelText, onPress } = setup()
+
+    fireEvent.press(lastByLabel(getAllByLabelText, "Water, status: safe, expandable"))
+    fireEvent.press(lastByLabel(getAllByLabelText, "Fertilizer sub-category"))
+
+    // The expanded panel renders a "View details" link tied to fertilizer.
+    fireEvent.press(lastByLabel(getAllByLabelText, "View details for Fertilizer"))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+    expect(onPress).toHaveBeenCalledWith("fertilizer")
+  })
+
+  it("renders a placeholder when getSubCategoryContent returns an empty array", () => {
+    const { getAllByLabelText, getAllByText } = setup()
+
+    fireEvent.press(lastByLabel(getAllByLabelText, "Water, status: safe, expandable"))
+    // Pesticide returns [] from the mocked content callback.
+    fireEvent.press(lastByLabel(getAllByLabelText, "Pesticide sub-category"))
+
+    // Placeholder appears at least once in the rendered tree.
+    expect(
+      getAllByText("No measurements for this sub-category at this location.").length,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -311,6 +311,34 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     [cityData, contaminants, getThreshold, getWHOThreshold, currentJurisdictionCode],
   )
 
+  // Build the contaminant rows shown when a sub-category is expanded inline
+  // on the dashboard. Joins `cityData.stats` to the contaminant catalog by
+  // statId and filters by `contaminant.category === subCategoryId`.
+  const getSubCategoryContent = useCallback(
+    (subCategoryId: string) => {
+      if (!cityData) return []
+
+      const subCategoryContaminantIds = new Set(
+        contaminants.filter((c) => c.category === subCategoryId).map((c) => c.id),
+      )
+      if (subCategoryContaminantIds.size === 0) return []
+
+      return cityData.stats
+        .filter((stat) => subCategoryContaminantIds.has(stat.statId))
+        .map((stat) => {
+          const definition = statDefinitions.find((d) => d.id === stat.statId)
+          return {
+            statId: stat.statId,
+            name: definition?.name ?? stat.statId,
+            value: stat.value,
+            unit: definition?.unit ?? "",
+            status: stat.status,
+          }
+        })
+    },
+    [cityData, contaminants, statDefinitions],
+  )
+
   // Categories to display (water and air only - health and disaster removed per issue #126)
   const categories = useMemo(() => [StatCategory.water, StatCategory.air], [])
 
@@ -959,6 +987,7 @@ View details: ${shareUrl}`
               riskCount={
                 cityData ? getRiskStatsForCategory(cityData, category, statDefinitions).length : 0
               }
+              getSubCategoryContent={getSubCategoryContent}
               onPress={(subCategoryId) => {
                 navigation.navigate("CategoryDetail", {
                   category,


### PR DESCRIPTION
## Summary

On the dashboard, tapping a sub-category like **Fertilizer** under **Water** now expands it inline to reveal the contaminants belonging to that sub-category, instead of navigating away to `CategoryDetailScreen`. The detail route stays reachable via a "View details" link inside the expanded panel.

- 3-level inline accordion: **Category → Sub-category → Contaminants** (e.g. `Water → Fertilizer → [Nitrate, …]`).
- Sub-category content sourced from already-loaded `cityData.stats`, joined to the contaminant catalog by `contaminant.category === subCategoryId`. No extra fetch.
- Each contaminant row reuses the existing `StatItem` component (name, value, unit, status indicator).
- Empty sub-categories render a placeholder ("No measurements for this sub-category at this location.") plus the "View details" link.
- Telemetry: `trackEvent("SubCategoryExpanded", { subCategoryId })` on inner expand.

## Files

- `apps/mobile/app/components/ExpandableCategoryCard.tsx` — added `getSubCategoryContent` prop; new `SubCategoryAccordion` (own Reanimated state + chevron); embeds `StatItem` rows + "View details" link.
- `apps/mobile/app/screens/DashboardScreen.tsx` — memoized `getSubCategoryContent` callback joining stats ↔ contaminants. Existing `onPress` navigation untouched (now serves as "View details").
- `apps/mobile/app/components/__tests__/ExpandableCategoryCard.test.tsx` — new tests.

## Stacking note

This PR targets `fix/dashboard-skeleton-on-search` (PR #323) because it builds on top of those skeleton fixes. Once #323 lands on staging, GitHub will auto-retarget this PR to staging.

## Test plan

- [ ] Open dashboard at `?city=Sorel-Tracy&state=QC&country=CA`
- [ ] Tap **Water** → existing sub-categories appear inline (no regression)
- [ ] Tap **Fertilizer** → URL does not change, row expands inline, contaminant rows render with name/value/unit/status
- [ ] Tap **View details** inside expansion → navigates to `CategoryDetail` with `subCategoryId="fertilizer"`
- [ ] Tap **Fertilizer** again → smooth collapse
- [ ] Tap an empty sub-category → placeholder text + "View details" still visible
- [ ] Repeat the above on the web build (Safari iOS + Chrome Android)
- [ ] Verify nested Reanimated animations don't flicker on web (second nesting level is new)
- [ ] Lint, typecheck, Jest all green (already verified locally: ESLint clean, `tsc --noEmit` clean, 234/234 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)