### PR TITLE
fix(mobile): bump MMKV cache prefix v2→v3 for #319 dual pills

### DIFF
--- a/apps/mobile/app/hooks/useLocationData.test.ts
+++ b/apps/mobile/app/hooks/useLocationData.test.ts
@@ -361,7 +361,7 @@ describe("useLocationData", () => {
       // cities in different states don't alias each other in the cache.
       // Legacy single-arg form (city only) appears as `_Montreal||`.
       expect(mockSave).toHaveBeenCalledWith(
-        "location_stats_v2_Montreal||",
+        "location_stats_v3_Montreal||",
         expect.objectContaining({
           data: expect.objectContaining({ cityName: "Montreal" }),
           cachedAt: expect.any(Number),

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -24,14 +24,26 @@ import { load, save, remove } from "@/utils/storage"
 /**
  * Cache key prefix for location stats.
  *
- * Bumped to `_v2_` alongside the EPI-17 / EPI-18 cascade-bleed fix so any
- * MMKV entries written under the old `location_stats_` prefix — which may
- * contain leaked sibling-city data from the pre-fix cascade — are
- * orphaned rather than served to offline users for up to 24 hours after
- * the fix deploys. Old entries remain in storage until MMKV evicts them
- * naturally; the cost is negligible (each entry is a few KB).
+ * History:
+ * - `_v2_`: bumped alongside the EPI-17 / EPI-18 cascade-bleed fix so any
+ *   MMKV entries written under the original `location_stats_` prefix —
+ *   which may contain leaked sibling-city data from the pre-fix cascade —
+ *   are orphaned rather than served to offline users for up to 24 hours
+ *   after the fix deploys.
+ * - `_v3_`: bumped alongside #319 (EPI-18 sub-bug B / dual status pills).
+ *   `_v2_` entries lack the new `whoStatus` / `localStatus` fields on
+ *   `CityStat`. Without a bump, those entries deserialize cleanly (the
+ *   new fields are optional) but the table renders both pills via the
+ *   `stat.status` fallback — which is the worst-of-(WHO, local) and
+ *   therefore "danger" for almost every Boucherville row. Verified on
+ *   staging post-deploy: every WHO pill read "danger" until the cache
+ *   was cleared. Bumping the prefix orphans `_v2_` entries so users see
+ *   the correct WHO=safe / QC=danger split immediately on next fetch.
+ *
+ * Old entries remain in storage until MMKV evicts them naturally; the
+ * cost is negligible (each entry is a few KB).
  */
-const CACHE_KEY_PREFIX = "location_stats_v2_"
+const CACHE_KEY_PREFIX = "location_stats_v3_"
 
 /** Cache duration in milliseconds (24 hours) */
 const CACHE_DURATION_MS = 24 * 60 * 60 * 1000


### PR DESCRIPTION
## Summary

Cache-invalidation follow-up to #319. After #319 deployed to staging, every WHO pill on the Boucherville Water Quality screen rendered "danger" — Lead at 5 µg/L (WHO 10), Mercury at 1 µg/L (WHO 6), Atrazine at 5 µg/L (WHO 100), and ~30 other rows that should read "safe vs WHO".

Fix: bump the MMKV cache prefix from \`_v2_\` to \`_v3_\` so pre-#319 cached entries are orphaned and a fresh fetch happens immediately.

## Root cause

#319 added \`whoStatus\` and \`localStatus\` to \`CityStat\` as **optional** fields so MMKV entries written before #319 would still deserialize cleanly. The trade-off was that \`ContaminantTable\` falls back \`whoStatus ?? row.status\` for stale entries, and \`row.status\` is the worst-of-(WHO, local) — for QC, "danger" for almost every row. So every WHO pill silently inherits the local verdict for any user whose MMKV cache was warm before deploy.

Verified on staging immediately after the deploy:

```
Pre cache-clear:  danger=94  warning=0  safe=0   ← all wrong
Post cache-clear: danger=75  warning=0  safe=19  ← correct (19 WHO pills now green)
```

## Why a prefix bump (vs. deserialize-and-recompute)

The other option was: when reading an entry, detect missing \`whoStatus\` / \`localStatus\`, look up thresholds, recompute, write back. That'd preserve cached data across the migration. Not worth the complexity for a 24-hour transient eviction window — the prefix-bump matches the precedent set by [#312](https://github.com/epiphanyapps/mapyourhealth/pull/312) for the EPI-17 cascade-bleed fix, which had the same shape (cached entries had stale data after a behavior change).

Old \`_v2_\` keys remain in MMKV until natural eviction. Each entry is a few KB; negligible cost.

## Tests

- Updated \`useLocationData.test.ts\` cache-key assertion from \`_v2_Montreal||\` to \`_v3_Montreal||\`.
- 22 / 22 useLocationData tests pass.

## Test plan

- [x] Local jest passes (\`useLocationData.test.ts\` 22/22)
- [x] Reproduced the bug on staging post-#319-deploy
- [x] Confirmed cache-clear restores correct dual pills
- [ ] After merge → staging deploy → re-open Boucherville Water Quality on a fresh device/browser → confirm WHO column shows ~19 green pills (Lead 🟢, Mercury 🟢, Atrazine 🟢, Tritium 🟢, etc.) without manual cache clearing

## Related

- #319 — the dual-pills fix this unblocks
- #312 — the precedent (same prefix-bump pattern for EPI-17 cascade fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)