### PR TITLE
feat(backend): cascade GSIs for WarningBanner + HazardReport (EPI-22, EPI-24)

### DIFF
--- a/apps/mobile/app/services/amplify/data.ts
+++ b/apps/mobile/app/services/amplify/data.ts
@@ -837,6 +837,48 @@ export async function getWarningBanners(): Promise<AmplifyWarningBanner[]> {
   return data
 }
 
+/**
+ * Fetch warning banners for a specific city via the byCity GSI (EPI-22).
+ */
+export async function getWarningBannersByCity(city: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by city", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByCity({
+      city,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
+/**
+ * Fetch warning banners for a specific state/province via the byState GSI (EPI-22).
+ */
+export async function getWarningBannersByState(state: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by state", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByState({
+      state,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
+/**
+ * Fetch warning banners for a specific country via the byCountry GSI (EPI-22).
+ */
+export async function getWarningBannersByCountry(country: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by country", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByCountry({
+      country,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
 // =============================================================================
 // Pollution Sources (Public Read)
 // =============================================================================

--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -440,7 +440,8 @@ const schema = a.schema({
     .authorization((allow) => [
       allow.owner().to(["create", "read"]),
       allow.group("admin").to(["create", "update", "delete", "read"]),
-    ]),
+    ])
+    .secondaryIndexes((index) => [index("city"), index("state"), index("country")]),
 
   // =========================================================================
   // Analytics
@@ -491,7 +492,8 @@ const schema = a.schema({
       allow.guest().to(["read"]),
       allow.authenticated().to(["read"]),
       allow.group("admin").to(["create", "update", "delete", "read"]),
-    ]),
+    ])
+    .secondaryIndexes((index) => [index("city"), index("state"), index("country")]),
 
   /**
    * AppConfig - Admin-manageable application configuration


### PR DESCRIPTION
## Summary

Phase 2.1 of the cascade-functionality migration. Bundles **EPI-22** (WarningBanner cascade GSIs) + **EPI-24** (HazardReport cascade GSIs) so both schema migrations land in one Amplify deploy.

- Backend: append `.secondaryIndexes((idx) => [idx("city"), idx("state"), idx("country")])` to `WarningBanner` and `HazardReport`. Pattern copied verbatim from `PollutionSource` and `LocationObservation`.
- Mobile: add dormant `getWarningBannersByCity/State/Country` fetchers in `apps/mobile/app/services/amplify/data.ts`, mirroring `getPollutionSourcesBy*` (uses `paginateList` + `CASCADE_PAGE_LIMIT`). No consumer wired yet.

### Decisions (from planning)

- **`country` stays optional.** Mobile hazard form (`HazardReportForm.tsx`) never captures country and admin banner form writes `country: null` when blank, so forcing required would break creation. Items with null country simply don't appear in the byCountry GSI — correct behavior for "global" banners.
- **Banner UX stays UNION** in the eventual hook rewrite (Step 2 follow-up). This PR only lands the schema + fetchers; `useWarningBanners` still uses the existing list+filter path and its 25-test Jest suite passes unchanged.
- **No HazardReport fetchers** — no consumer exists yet, per cascade-work handoff guidance against speculative fetchers.

### Refs

- Plan: `docs/cascade-work-handoff-2026-05-10.md` → Phase 2.1
- Linear: [EPI-22](https://linear.app/epiphany-apps/issue/EPI-22), [EPI-24](https://linear.app/epiphany-apps/issue/EPI-24)

## Test plan

- [x] `tsc --noEmit` clean on `apps/mobile` and `packages/backend`
- [x] `eslint apps/mobile/app/services/amplify/data.ts` clean
- [x] `useWarningBanners.test.ts` still 25/25 (existing JS-filter path untouched)
- [ ] After merge, confirm new GSIs land on the staging tables:
  ```bash
  aws dynamodb describe-table --table-name "WarningBanner-dwz5zs2ghrc5xplczomoh4fzke-NONE" \
    --profile rayane --region ca-central-1 \
    --query 'Table.GlobalSecondaryIndexes[*].IndexName'
  aws dynamodb describe-table --table-name "HazardReport-dwz5zs2ghrc5xplczomoh4fzke-NONE" \
    --profile rayane --region ca-central-1 \
    --query 'Table.GlobalSecondaryIndexes[*].IndexName'
  ```
- [ ] Mobile staging URL — DashboardScreen still renders any active warning banners (existing list+filter path untouched)
- [ ] Smoke-test one new fetcher from a sandbox script:
  ```ts
  await client.models.WarningBanner.listWarningBannerByCity({ city: "Boucherville" })
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)