### PR TITLE
release: cascade GSIs (EPI-22 + EPI-24) and admin coverage count (EPI-31)

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -84,7 +84,7 @@ export const navigationSections: AdminSection[] = [
           "Contaminants",
           "Jurisdictions",
           "Thresholds",
-          "Locations with Data",
+          "Locations covered",
           "Pending Reports",
         ],
       },

--- a/apps/admin/src/app/(admin)/page.tsx
+++ b/apps/admin/src/app/(admin)/page.tsx
@@ -24,10 +24,13 @@ import {
 type LocationMeasurement = Schema["LocationMeasurement"]["type"];
 type HazardReport = Schema["HazardReport"]["type"];
 
-// Extended type for LocationMeasurement with city/state fields from schema
+// Extended type for LocationMeasurement with city/state/country fields from schema.
+// All three are optional at runtime — cascade scope (#123) means a row can be
+// state-anchored (city null) or country-anchored (city + state null).
 type LocationMeasurementWithLocation = LocationMeasurement & {
-  city: string;
-  state: string;
+  city: string | null | undefined;
+  state: string | null | undefined;
+  country: string | null | undefined;
 };
 
 export default function AdminDashboard() {
@@ -63,17 +66,27 @@ export default function AdminDashboard() {
         // Count contaminants
         const contaminants = contaminantsResult.data?.length || 0;
 
-        // Count unique cities with data. Cascade scope (#123) means
-        // city/state may be null on state-/country-anchored records — skip
-        // those so the count reflects actual distinct city locations
-        // rather than collapsing every null row into one bogus bucket.
-        const uniqueCities = new Set(
-          measurementsResult.data
-            ?.map((m) => m as LocationMeasurementWithLocation)
-            .filter((m) => m.city && m.state)
-            .map((m) => `${m.city}|${m.state}`) || [],
+        // Count unique cascade scopes covered. After PR #312 (EPI-17 / EPI-18
+        // anchored cascade), state-anchored rows (city null, state set) and
+        // country-anchored rows (city + state null, country set) are valid
+        // coverage levels — they back the state/country fallback that mobile
+        // hits when the user's exact city has no city-keyed records. Counting
+        // only distinct cities (the pre-EPI-31 behavior) under-reported as
+        // state-/country-anchored seeding ramps. Each row is bucketed by its
+        // narrowest non-null anchor; rows with all three null are dropped (no
+        // cascade level can address them).
+        const uniqueScopes = new Set(
+          (measurementsResult.data || [])
+            .map((m) => m as LocationMeasurementWithLocation)
+            .map((m) => {
+              if (m.city && m.state) return `city|${m.country ?? ""}|${m.state}|${m.city}`;
+              if (m.state) return `state|${m.country ?? ""}|${m.state}`;
+              if (m.country) return `country|${m.country}`;
+              return null;
+            })
+            .filter((k): k is string => k !== null),
         );
-        const locationsWithData = uniqueCities.size;
+        const locationsWithData = uniqueScopes.size;
 
         // Count pending reports
         const pendingReports =
@@ -196,7 +209,7 @@ export default function AdminDashboard() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Locations with Data
+              Locations covered
             </CardTitle>
             <MapPin className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -204,7 +217,12 @@ export default function AdminDashboard() {
             <div className="text-2xl font-bold">
               {isLoading ? "..." : stats.locationsWithData}
             </div>
-            <p className="text-xs text-muted-foreground">Cities tracked</p>
+            <p
+              className="text-xs text-muted-foreground"
+              title="Counts unique cascade scopes: city-anchored rows by city, state-anchored rows by state, country-anchored rows by country. Rows missing all three anchors are excluded."
+            >
+              City + state + country scopes
+            </p>
           </CardContent>
         </Card>
 

--- a/apps/mobile/app/services/amplify/data.ts
+++ b/apps/mobile/app/services/amplify/data.ts
@@ -837,6 +837,48 @@ export async function getWarningBanners(): Promise<AmplifyWarningBanner[]> {
   return data
 }
 
+/**
+ * Fetch warning banners for a specific city via the byCity GSI (EPI-22).
+ */
+export async function getWarningBannersByCity(city: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by city", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByCity({
+      city,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
+/**
+ * Fetch warning banners for a specific state/province via the byState GSI (EPI-22).
+ */
+export async function getWarningBannersByState(state: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by state", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByState({
+      state,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
+/**
+ * Fetch warning banners for a specific country via the byCountry GSI (EPI-22).
+ */
+export async function getWarningBannersByCountry(country: string): Promise<AmplifyWarningBanner[]> {
+  const client = await getPublicClient()
+  return paginateList("warning banners by country", (nextToken) =>
+    client.models.WarningBanner.listWarningBannerByCountry({
+      country,
+      limit: CASCADE_PAGE_LIMIT,
+      nextToken,
+    }),
+  )
+}
+
 // =============================================================================
 // Pollution Sources (Public Read)
 // =============================================================================

--- a/packages/backend/amplify/data/resource.ts
+++ b/packages/backend/amplify/data/resource.ts
@@ -440,7 +440,8 @@ const schema = a.schema({
     .authorization((allow) => [
       allow.owner().to(["create", "read"]),
       allow.group("admin").to(["create", "update", "delete", "read"]),
-    ]),
+    ])
+    .secondaryIndexes((index) => [index("city"), index("state"), index("country")]),
 
   // =========================================================================
   // Analytics
@@ -491,7 +492,8 @@ const schema = a.schema({
       allow.guest().to(["read"]),
       allow.authenticated().to(["read"]),
       allow.group("admin").to(["create", "update", "delete", "read"]),
-    ]),
+    ])
+    .secondaryIndexes((index) => [index("city"), index("state"), index("country")]),
 
   /**
    * AppConfig - Admin-manageable application configuration


### PR DESCRIPTION
## Summary

Promote `staging` → `main`. Bundles two validated changes:

- **#329** `4e1b285` — `feat(backend)`: cascade GSIs for `WarningBanner` and `HazardReport` (EPI-22 + EPI-24). Adds byCity/byState/byCountry secondary indexes to both DDB models, plus dormant `getWarningBannersBy*` mobile fetchers (no consumer wired yet).
- **#328** `b1e3db6` — `fix(admin)`: cascade-aware coverage count on dashboard (EPI-31).

## Staging verification

- Backend Amplify job 16 ✅ SUCCEED (a fresh redeploy after job 15 hit the 30-min build timeout despite CFN succeeding server-side).
- Mobile Web ✅ Admin Portal ✅ Web Landing Page ✅
- DDB GSIs ACTIVE on both staging tables:
  - `warningBannersByCity` / `…ByState` / `…ByCountry`
  - `hazardReportsByCity` / `…ByState` / `…ByCountry`

## Heads-up for prod deploy

The first staging deploy timed out at 30 min because the CFN multi-stack update (creating 6 GSIs + 12 AppSync resolvers) exceeds the Amplify Hosting build window. The schema work itself succeeded — just the build orchestrator timed out. **Same pattern is likely on prod.** If the main Amplify deploy reports FAILED, check the actual CFN nested stack state and DDB GSI status before assuming a rollback is needed; a follow-up no-op `aws amplify start-job` should clean the status to SUCCEED.

## Test plan

- [x] Lint, type-check, unit tests green on staging
- [x] CFN nested stacks reached UPDATE_COMPLETE on staging
- [x] DDB GSIs ACTIVE on both staging tables
- [x] Mobile/Admin/Web staging URLs deployed cleanly
- [ ] After merge: confirm prod CFN reaches UPDATE_COMPLETE for both nested stacks
- [ ] After merge: confirm prod DDB GSIs reach ACTIVE
- [ ] After merge: run outstanding `update-contaminant-categories.ts` against prod (separate manual step, idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)