### PR TITLE
feat(mobile): fan-out warning banner fetch via cascade GSIs (EPI-22 step 2)

### DIFF
--- a/apps/mobile/app/hooks/useWarningBanners.test.ts
+++ b/apps/mobile/app/hooks/useWarningBanners.test.ts
@@ -8,10 +8,16 @@
 import { act, renderHook, waitFor } from "@testing-library/react-native"
 
 const mockGetWarningBanners = jest.fn()
+const mockGetWarningBannersByCity = jest.fn()
+const mockGetWarningBannersByState = jest.fn()
+const mockGetWarningBannersByCountry = jest.fn()
 
 // Mock the data service
 jest.mock("../services/amplify/data", () => ({
   getWarningBanners: (...args) => mockGetWarningBanners(...args),
+  getWarningBannersByCity: (...args) => mockGetWarningBannersByCity(...args),
+  getWarningBannersByState: (...args) => mockGetWarningBannersByState(...args),
+  getWarningBannersByCountry: (...args) => mockGetWarningBannersByCountry(...args),
 }))
 
 // eslint-disable-next-line import/first
@@ -41,6 +47,9 @@ describe("useWarningBanners", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetWarningBanners.mockResolvedValue([])
+    mockGetWarningBannersByCity.mockResolvedValue([])
+    mockGetWarningBannersByState.mockResolvedValue([])
+    mockGetWarningBannersByCountry.mockResolvedValue([])
   })
 
   describe("initial state", () => {
@@ -552,6 +561,92 @@ describe("useWarningBanners", () => {
       expect(ids).not.toContain("country-no-match")
 
       expect(result.current.banners).toHaveLength(4)
+    })
+  })
+
+  describe("fan-out fetch (EPI-22)", () => {
+    it("includes a banner returned only by the byCity GSI", async () => {
+      const cityBanner = createBanner({
+        id: "by-city-only",
+        title: "Toronto Alert via GSI",
+        city: "Toronto",
+        state: "ON",
+        country: "CA",
+      })
+      // Global list returns nothing — banner is only in the GSI result.
+      mockGetWarningBanners.mockResolvedValue([])
+      mockGetWarningBannersByCity.mockResolvedValue([cityBanner])
+
+      const { result } = renderHook(() =>
+        useWarningBanners({ city: "Toronto", state: "ON", country: "CA" }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.banners).toHaveLength(1)
+      expect(result.current.banners[0].id).toBe("by-city-only")
+    })
+
+    it("includes a banner returned only by the byState GSI", async () => {
+      const stateBanner = createBanner({
+        id: "by-state-only",
+        city: null,
+        state: "ON",
+        country: "CA",
+      })
+      mockGetWarningBanners.mockResolvedValue([])
+      mockGetWarningBannersByState.mockResolvedValue([stateBanner])
+
+      const { result } = renderHook(() =>
+        useWarningBanners({ city: "Ottawa", state: "ON", country: "CA" }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.banners).toHaveLength(1)
+      expect(result.current.banners[0].id).toBe("by-state-only")
+    })
+
+    it("dedupes a banner that appears in multiple fanout results", async () => {
+      const banner = createBanner({
+        id: "dup",
+        city: "Toronto",
+        state: "ON",
+        country: "CA",
+      })
+      mockGetWarningBanners.mockResolvedValue([banner])
+      mockGetWarningBannersByCity.mockResolvedValue([banner])
+      mockGetWarningBannersByState.mockResolvedValue([banner])
+      mockGetWarningBannersByCountry.mockResolvedValue([banner])
+
+      const { result } = renderHook(() =>
+        useWarningBanners({ city: "Toronto", state: "ON", country: "CA" }),
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.banners).toHaveLength(1)
+      expect(result.current.banners[0].id).toBe("dup")
+    })
+
+    it("skips GSI fetchers when corresponding option is missing", async () => {
+      mockGetWarningBanners.mockResolvedValue([])
+
+      renderHook(() => useWarningBanners({}))
+
+      await waitFor(() => {
+        expect(mockGetWarningBanners).toHaveBeenCalled()
+      })
+
+      expect(mockGetWarningBannersByCity).not.toHaveBeenCalled()
+      expect(mockGetWarningBannersByState).not.toHaveBeenCalled()
+      expect(mockGetWarningBannersByCountry).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/mobile/app/hooks/useWarningBanners.ts
+++ b/apps/mobile/app/hooks/useWarningBanners.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import type { AmplifyWarningBanner } from "@/services/amplify/data"
-import { getWarningBanners } from "@/services/amplify/data"
+import {
+  getWarningBanners,
+  getWarningBannersByCity,
+  getWarningBannersByCountry,
+  getWarningBannersByState,
+} from "@/services/amplify/data"
 
 interface UseWarningBannersOptions {
   /** City to filter banners for */
@@ -26,11 +31,18 @@ interface UseWarningBannersResult {
 /**
  * Hook to fetch and filter active warning banners for a user's location.
  *
- * Filters by:
- * - isActive === true
- * - startsAt <= now
- * - expiresAt is null OR expiresAt > now
- * - Location match: banners with null location fields (global) + banners matching user's city/state/country
+ * Fan-out fetch (EPI-22): runs up to four parallel queries — by city, by
+ * state, by country (each via the byCity/byState/byCountry GSI), plus a
+ * list scan that picks up globally-scoped banners (no GSI yet exists for
+ * the all-null scope). Results are unioned by `id`, then a JS filter
+ * enforces isActive, time-window, and case-insensitive cross-field
+ * consistency: a banner with non-null city must match the user's city,
+ * non-null state must match the user's state, etc.
+ *
+ * The GSI lookups are case-sensitive against DDB. If admin-entered data
+ * has inconsistent casing, banners can be missed by the GSI and only
+ * recovered via the bounded list scan — normalize at the admin layer
+ * when this matters at scale.
  */
 export function useWarningBanners(options: UseWarningBannersOptions): UseWarningBannersResult {
   const { city, state, country } = options
@@ -42,15 +54,25 @@ export function useWarningBanners(options: UseWarningBannersOptions): UseWarning
     try {
       setIsLoading(true)
       setError(null)
-      const data = await getWarningBanners()
-      setAllBanners(data)
+      const empty: AmplifyWarningBanner[] = []
+      const [cityRows, stateRows, countryRows, scanRows] = await Promise.all([
+        city ? getWarningBannersByCity(city) : Promise.resolve(empty),
+        state ? getWarningBannersByState(state) : Promise.resolve(empty),
+        country ? getWarningBannersByCountry(country) : Promise.resolve(empty),
+        getWarningBanners(),
+      ])
+      const byId = new Map<string, AmplifyWarningBanner>()
+      for (const banner of [...cityRows, ...stateRows, ...countryRows, ...scanRows]) {
+        byId.set(banner.id, banner)
+      }
+      setAllBanners(Array.from(byId.values()))
     } catch (err) {
       console.error("Error fetching warning banners:", err)
       setError(err instanceof Error ? err.message : "Failed to fetch warning banners")
     } finally {
       setIsLoading(false)
     }
-  }, [])
+  }, [city, state, country])
 
   useEffect(() => {
     fetchBanners()


### PR DESCRIPTION
## Summary

- Rewrites \`useWarningBanners\` to fan out parallel queries against the new \`byCity\` / \`byState\` / \`byCountry\` GSIs deployed in PR #329, plus a bounded list scan for global (all-null) banners.
- Unions results by \`id\` and reapplies the existing \`isActive\` + time-window + case-insensitive cross-field consistency filter — UX is unchanged.
- Refetch behavior: when \`{city, state, country}\` changes the hook now requeries the GSIs (deps added to \`fetchBanners\`). Previously the hook fetched once and only re-filtered locally.
- Adds 4 fan-out specific tests (byCity-only, byState-only, dedupe across fetchers, GSI fetcher skipped when option missing); existing 25 tests pass unchanged.

## Why this matters

PR #329 landed the schema and fetchers but no consumer — this is the first hook that actually uses the cascade GSIs. Sets the pattern for future banner / hazard-report consumers.

## Known limitation

GSI lookups are case-sensitive against DDB. If admin-entered city/state/country has inconsistent casing (e.g. \"toronto\" vs \"Toronto\"), banners can be missed by the GSI and only recovered via the bounded list scan. Documented inline; a follow-up should normalize at the admin layer.

## Test plan

- [x] \`npx jest hooks/useWarningBanners\` → 29/29 passing
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint app/hooks/useWarningBanners.ts*\` clean
- [x] \`npx prettier --check\` clean
- [ ] Smoke-test mobile staging URL after deploy: dashboard renders banners for a known location
- [ ] Verify in admin: create a city-anchored, state-anchored, and country-anchored banner; each shows on the correct mobile location

🤖 Generated with [Claude Code](https://claude.com/claude-code)