### PR TITLE
fix(backend): wipe-all-data --force flag for non-TTY runs

### DIFF
--- a/packages/backend/scripts/reseed-all.sh
+++ b/packages/backend/scripts/reseed-all.sh
@@ -39,7 +39,11 @@ if [ -z "$COGNITO_EMAIL" ] || [ -z "$COGNITO_PASSWORD" ]; then
 fi
 
 echo "=== Step 1: Wipe all data tables ==="
-AWS_PROFILE=rayane npx tsx scripts/wipe-all-data.ts
+# `--force` skips the interactive prompt. Without it, a non-TTY shell
+# (e.g. CI or a backgrounded run) reads EOF, treats it as "no", and the
+# wipe is silently aborted — leaving downstream seed steps to double up
+# the data. The reseed-all.sh entrypoint is itself the confirmation gate.
+AWS_PROFILE=rayane npx tsx scripts/wipe-all-data.ts --force
 
 echo ""
 echo "=== Step 2: Parse Risks.xlsx ==="

--- a/packages/backend/scripts/wipe-all-data.ts
+++ b/packages/backend/scripts/wipe-all-data.ts
@@ -128,7 +128,14 @@ async function main() {
   console.log(`Table suffix: ${TABLE_SUFFIX}`);
   console.log(`Tables to wipe: ${TABLES_TO_WIPE.join(", ")}\n`);
 
-  const confirmed = await confirm("Are you sure you want to delete all data in the above tables?");
+  // --force / --yes lets reseed-all.sh (and CI) skip the prompt. Without
+  // it, a non-TTY shell reads EOF, treats it as "no", prints "Aborted.",
+  // and exits cleanly — which silently no-ops the wipe in pipelines and
+  // produces doubled-up data when the downstream seed steps still run.
+  const skipPrompt = process.argv.includes("--force") || process.argv.includes("--yes");
+  const confirmed =
+    skipPrompt ||
+    (await confirm("Are you sure you want to delete all data in the above tables?"));
   if (!confirmed) {
     console.log("Aborted.");
     process.exit(0);


### PR DESCRIPTION
## Why

\`wipe-all-data.ts\` has an interactive \`Are you sure? (y/N)\` prompt. When \`reseed-all.sh\` runs from a non-TTY shell (CI job, backgrounded process, anything without an attached terminal), readline reads EOF, treats it as "no", prints \`Aborted.\` and exits 0. \`set -e\` in the parent script doesn't catch the clean exit, so all the downstream seed steps run and **double up** the data on top of what wasn't wiped.

Bit us today during a prod reseed:
- Contaminant: 174 → 348
- Jurisdiction: 18 → 36
- ContaminantThreshold: 414 → 828
- LocationMeasurement: 1,771 → 3,544

## What changed

- \`wipe-all-data.ts\`: accept \`--force\` (or \`--yes\`) to skip the prompt. Running standalone still prompts as before.
- \`reseed-all.sh\`: pass \`--force\` to the wipe step. \`reseed-all.sh\` is already the confirmation gate — it enforces \`TABLE_SUFFIX\` with explicit prod-vs-staging guidance and refuses to run without Cognito creds.

## Test plan

- [x] \`bash -n scripts/reseed-all.sh\` clean
- [x] Running \`reseed-all.sh\` against staging proceeded through wipe correctly (verified live during today's prod cleanup)
- [ ] Running \`wipe-all-data.ts\` standalone still prompts: \`TABLE_SUFFIX=... npx tsx scripts/wipe-all-data.ts\` → "Are you sure? (y/N)"
- [ ] Running standalone with \`--force\`: \`TABLE_SUFFIX=... npx tsx scripts/wipe-all-data.ts --force\` → skips prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)