### PR TITLE
fix(admin): drop `ssr: true` so localhost sign-in works

### DIFF
--- a/apps/admin/src/providers/auth-provider.tsx
+++ b/apps/admin/src/providers/auth-provider.tsx
@@ -5,8 +5,19 @@ import { Amplify } from "aws-amplify";
 import { getCurrentUser, fetchAuthSession, signOut } from "aws-amplify/auth";
 import outputs from "../../amplify_outputs.json";
 
-// Configure Amplify once at module load
-Amplify.configure(outputs, { ssr: true });
+// Configure Amplify once at module load.
+//
+// Intentionally NOT passing `{ ssr: true }`: that mode tells Amplify to
+// store tokens in cookies so server components can read them, but the
+// admin app is all client components (no server-side `getCurrentUser`
+// / `fetchAuthSession` calls) and we don't ship `@aws-amplify/adapter-
+// nextjs`. With `ssr: true` on, Amplify writes its session cookies with
+// `SameSite=None` — which the browser then requires to be `Secure` —
+// which is rejected on `http://localhost`. The cookie write fails
+// silently, `fetchAuthSession` can't read tokens back, and signIn
+// throws "Unable to get user session following successful sign-in".
+// Default mode uses localStorage and works on both localhost and HTTPS.
+Amplify.configure(outputs);
 
 interface User {
   userId: string;


### PR DESCRIPTION
## Problem

Admin sign-in fails on \`http://localhost:3000\` with **"Unable to get user session following successful sign-in"** and never has worked locally per the team. Deployed admin (HTTPS) works fine.

## Root cause

\`apps/admin/src/providers/auth-provider.tsx\` does:

\`\`\`ts
Amplify.configure(outputs, { ssr: true });
\`\`\`

\`{ ssr: true }\` tells Amplify v6 to store tokens in cookies instead of localStorage so server components can read them back. But:

1. The admin app has **zero server components** reading auth (every page using \`getCurrentUser\` / \`fetchAuthSession\` is \`"use client"\`).
2. It does **not** depend on \`@aws-amplify/adapter-nextjs\`, which is the piece that actually wires cookie-based tokens to Next.js \`cookies()\` on the server.

With those preconditions, \`ssr: true\` becomes a footgun on localhost:

1. Amplify writes its session cookies with \`SameSite=None\`.
2. Browsers require \`SameSite=None\` cookies to also be \`Secure\`.
3. \`Secure\` cookies are rejected on \`http://localhost\`.
4. The cookie write silently fails.
5. The immediately-following \`fetchAuthSession\` returns "no session", and \`signIn\` throws "Unable to get user session following successful sign-in".
6. The login page has a 3-retry recovery loop, but each retry hits the same broken storage.

Deployed admin works because it's HTTPS — the \`Secure\` cookies stick.

## Fix

Drop the \`{ ssr: true }\` option so Amplify uses default storage (localStorage on the client). Inline comment documents the trade-off so this doesn't get added back unintentionally.

## Test plan

- [ ] \`cd apps/admin && npm run dev\` → open http://localhost:3000/login → sign in with a prod admin account → land on dashboard (no error toast)
- [ ] After deploy to staging: same flow on https://staging.d26q32gc98goap.amplifyapp.com/ still works
- [ ] After deploy to main: same on https://admin.mapyourhealth.info/

## If we ever need server-side auth

This change can be reversed in tandem with installing \`@aws-amplify/adapter-nextjs\` and refactoring \`auth-provider\` to wrap server-side calls in \`runWithAmplifyServerContext\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)