### PR TITLE
chore(backend): drop banner seeding from reseed-all.sh

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -106,7 +106,7 @@ aws dynamodb scan --table-name "Jurisdiction-uusoeozunzdy5biliji7vxbjcy-NONE" \
 
 ## Full Wipe and Reseed (`reseed-all.sh`)
 
-Use when you want to reset a test environment to a known-good state with cascade-test fixtures populated. The script runs nine steps end-to-end (~30 min):
+Use when you want to reset a test environment to a known-good state with cascade-test fixtures populated. The script runs eight steps end-to-end (~30 min):
 
 ```
 1. wipe-all-data.ts                  → wipes 10 reference + measurement tables
@@ -116,9 +116,10 @@ Use when you want to reset a test environment to a known-good state with cascade
 5. seed-cascade-test-observations.ts → radon observations at QC / CA / US anchors
 6. seed-categories.ts                → Category + SubCategory (AppSync)
 7. seed-om-data.ts --observations-only → 6,660 location observations (AppSync)
-8. seed-warning-banners.ts           → 4 test banners (global / country / state / city)
-9. seed-pollution-sources.ts         → 5 test sources at varied anchors
+8. seed-pollution-sources.ts         → 5 test sources at varied anchors
 ```
+
+**Warning banners are intentionally NOT included.** Banners surface prominently on the mobile Dashboard, so auto-seeding them risks fake `[SEED]` advisories reaching real users if the admin Reseed action ever runs on prod. Real banner content should always be created by an admin in response to a real situation. Run `yarn seed:banners` standalone if a fresh staging env genuinely needs sample banners to demo the UI.
 
 ### Prerequisites
 

--- a/packages/backend/scripts/reseed-all.sh
+++ b/packages/backend/scripts/reseed-all.sh
@@ -74,15 +74,19 @@ echo "=== Step 7: Seed O&M observations (AppSync — requires Cognito) ==="
 npx tsx scripts/seed-om-data.ts --json scripts/seed-om-data.json --observations-only
 
 echo ""
-echo "=== Step 8: Seed warning banners (AppSync — requires Cognito) ==="
-# 4 banners (global, country, state, city) for verifying the warning-banner
-# cascade end-to-end. Idempotent upsert by title.
-npx tsx scripts/seed-warning-banners.ts
-
-echo ""
-echo "=== Step 9: Seed pollution sources (AppSync — requires Cognito) ==="
-# 5 sources at varied anchors and types for verifying the pollution-source
-# cascade. Idempotent upsert by sourceId.
+echo "=== Step 8: Seed pollution sources (AppSync — requires Cognito) ==="
+# 5 sources at varied anchors (Montreal city, Toronto city, QC state,
+# ON state, CA country) and varied source types. Idempotent upsert by
+# sourceId. Doubles as cascade-demonstration data for the orphan
+# PollutionSource feature.
+#
+# Note: warning banners are intentionally NOT seeded by reseed-all.sh.
+# Banners surface prominently on the mobile Dashboard, so auto-seeding
+# them risks fake `[SEED]` advisories reaching real users if the admin
+# Reseed action ever runs on prod. Real banner content should always be
+# created by an admin in response to a real situation. The standalone
+# `yarn seed:banners` script still exists for one-off use when a fresh
+# staging env genuinely needs sample banners to demo the UI.
 npx tsx scripts/seed-pollution-sources.ts
 
 echo ""


### PR DESCRIPTION
## Why

Banners surface prominently on the mobile Dashboard, so auto-seeding them via the reseed pipeline carries a real risk: if the admin **Reseed All Data** button (Settings page → \`manage-data\` Lambda) ever runs against prod, four \`[SEED]\`-prefixed advisories appear on every prod mobile dashboard until an admin notices and removes them. That's an active misinformation vector — *"Quebec province-wide alert"* showing up on every QC user's phone is bad even if the title says \`[SEED]\`.

Real banner content should always be created by an admin in response to a real situation (boil-water advisory, tick season, etc.), never pre-populated by automation.

## Changes

- \`scripts/reseed-all.sh\`: drops step 8 (seed-warning-banners.ts). Pipeline is now 8 steps, not 9. Step 9 (seed-pollution-sources.ts) renumbered to step 8.
- \`README.md\`: pipeline diagram updated; adds a "Warning banners are intentionally NOT included" callout explaining the rationale + pointing to the manual \`yarn seed:banners\` for one-off use.

## What stays the same

- \`scripts/seed-warning-banners.ts\` still exists.
- \`yarn seed:banners\` still works standalone — fresh staging envs that genuinely need sample banners to demo the UI can invoke it manually.
- Existing \`[SEED]\` banners on staging + prod (from prior reseed runs) **persist** because \`wipe-all-data.ts\` preserves the WarningBanner table. Clean them up manually via the admin \`/banners\` page if desired.

## Why pollution sources stay in the reseed

Same question got asked, different answer:

- Pollution sources don't surface on the mobile Dashboard.
- EPI-44 (mobile re-add) is still gated — no mobile reader today.
- The 5 seed sources span city / state / country anchors, so they double as cascade-demonstration data for QA.

The leak-to-prod-users risk that bans banners doesn't apply.

## Test plan

- [x] \`bash -n reseed-all.sh\` clean
- [ ] After merge: run reseed against staging end-to-end → no errors, banners on staging unchanged (still the 4 existing \`[SEED]\` rows, no new ones, no deletes)
- [ ] Pollution sources on staging still upsert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)