### PR TITLE
docs(admin): add "Data & Reseed" tab to the Guide page

### DIFF
--- a/apps/admin/src/app/(admin)/guide/page.tsx
+++ b/apps/admin/src/app/(admin)/guide/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Card,
   CardContent,
@@ -7,6 +9,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Compass,
   Database,
@@ -16,11 +27,15 @@ import {
   Lightbulb,
   Smartphone,
   VolumeX,
+  ExternalLink,
+  MapPin,
+  TestTube,
+  Droplets,
+  Wind,
+  Heart,
+  AlertTriangle,
 } from "lucide-react";
-import {
-  navigationSections,
-  observationsSections,
-} from "./data/admin-sections";
+import { adminSectionGroups } from "./data/admin-sections";
 import { AdminSectionCard } from "./components/AdminSectionCard";
 
 const crossCuttingTopics = [
@@ -60,7 +75,7 @@ const capabilityRows: CapabilityRow[] = [
   },
   {
     section: "Contaminants",
-    route: "/stats",
+    route: "/contaminants",
     whatYouCanDo:
       "Define what gets measured (174 contaminants — name EN/FR, category, unit, higherIsBad).",
     bulk: "Export only",
@@ -99,8 +114,8 @@ const capabilityRows: CapabilityRow[] = [
     mobile: "Sub-category rows under each category card",
   },
   {
-    section: "Location Stats",
-    route: "/zip-codes",
+    section: "Measurements",
+    route: "/measurements",
     whatYouCanDo:
       "List of cities that have measurements; click Manage to edit measurements one by one.",
     bulk: "No",
@@ -132,7 +147,7 @@ const capabilityRows: CapabilityRow[] = [
   },
   {
     section: "Hazard Reports",
-    route: "/reports",
+    route: "/hazard-reports",
     whatYouCanDo: "Review and moderate user-submitted hazard reports.",
     bulk: "No",
     mobile: '"Report Hazard" button writes here',
@@ -154,18 +169,10 @@ const capabilityRows: CapabilityRow[] = [
       "Orphan — consumer card removed in #309. Decision pending on EPI-25.",
   },
   {
-    section: "Testing Guide",
-    route: "/testing",
-    whatYouCanDo:
-      "Internal QA reference: staging URLs, test accounts, smoke checklist.",
-    bulk: "No",
-    mobile: "—",
-  },
-  {
     section: "Guide",
     route: "/guide",
     whatYouCanDo:
-      "This page — what each admin section does and how it reaches mobile.",
+      "This page — what each admin section does, how it reaches mobile, and the testing reference.",
     bulk: "No",
     mobile: "—",
   },
@@ -214,7 +221,7 @@ const dataPatterns = [
   {
     pattern: "Per-city water/air measurements",
     examples: "Lead, nitrate, atrazine, radon-in-air for a specific city.",
-    where: "/import (bulk) or /zip-codes (per-record)",
+    where: "/import (bulk) or /measurements (per-record)",
     bulk: "Yes — Water Quality + Air Pollution tabs accept CSV / JSON / Excel.",
   },
   {
@@ -226,7 +233,30 @@ const dataPatterns = [
   },
 ];
 
-export default function GuidePage() {
+const VALID_TABS = ["sections", "cross-cutting", "testing", "data"] as const;
+type GuideTab = (typeof VALID_TABS)[number];
+
+function isValidTab(value: string | null): value is GuideTab {
+  return value !== null && (VALID_TABS as readonly string[]).includes(value);
+}
+
+function GuidePageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const activeTab: GuideTab = isValidTab(tabParam) ? tabParam : "sections";
+
+  const handleTabChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "sections") {
+      params.delete("tab");
+    } else {
+      params.set("tab", value);
+    }
+    const query = params.toString();
+    router.replace(query ? `/guide?${query}` : "/guide", { scroll: false });
+  };
+
   return (
     <div className="space-y-8">
       <div>
@@ -237,6 +267,53 @@ export default function GuidePage() {
         </p>
       </div>
 
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList>
+          <TabsTrigger value="sections">Sections</TabsTrigger>
+          <TabsTrigger value="cross-cutting">Cross-cutting</TabsTrigger>
+          <TabsTrigger value="testing">Testing</TabsTrigger>
+          <TabsTrigger value="data">Data &amp; Reseed</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="sections" className="space-y-8">
+          <SectionsTab />
+        </TabsContent>
+
+        <TabsContent value="cross-cutting" className="space-y-8">
+          <CrossCuttingTab />
+        </TabsContent>
+
+        <TabsContent value="testing" className="space-y-8">
+          <TestingTab />
+        </TabsContent>
+
+        <TabsContent value="data" className="space-y-8">
+          <DataTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export default function GuidePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="space-y-8">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Admin Guide</h1>
+          </div>
+        </div>
+      }
+    >
+      <GuidePageContent />
+    </Suspense>
+  );
+}
+
+function SectionsTab() {
+  return (
+    <>
       {/* Capabilities at a glance — every admin route in one scan-friendly table. */}
       <Card id="capabilities-overview" className="scroll-mt-6">
         <CardHeader>
@@ -346,7 +423,7 @@ export default function GuidePage() {
         </CardContent>
       </Card>
 
-      {/* Table of contents */}
+      {/* Table of contents — grouped by mobile impact */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -354,80 +431,86 @@ export default function GuidePage() {
             On this page
           </CardTitle>
           <CardDescription>
-            Jump to any section. Each menu item is documented with its forms,
-            actions, and downstream mobile-app effect.
+            Sections are grouped by how they affect the mobile location detail
+            screen.
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-6 md:grid-cols-3">
-          <div>
-            <h3 className="font-semibold text-sm uppercase tracking-wide text-muted-foreground mb-2">
-              Navigation
-            </h3>
-            <ul className="space-y-1 text-sm">
-              {navigationSections.map((s) => (
-                <li key={s.id}>
-                  <a
-                    href={`#${s.id}`}
-                    className="text-foreground hover:underline"
-                  >
-                    {s.title}
-                  </a>{" "}
-                  <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                    {s.route}
-                  </code>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-semibold text-sm uppercase tracking-wide text-muted-foreground mb-2">
-              Observations &amp; Measurements
-            </h3>
-            <ul className="space-y-1 text-sm">
-              {observationsSections.map((s) => (
-                <li key={s.id}>
-                  <a
-                    href={`#${s.id}`}
-                    className="text-foreground hover:underline"
-                  >
-                    {s.title}
-                  </a>{" "}
-                  <code className="px-1 py-0.5 bg-muted rounded text-xs">
-                    {s.route}
-                  </code>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h3 className="font-semibold text-sm uppercase tracking-wide text-muted-foreground mb-2">
-              Cross-cutting
-            </h3>
-            <ul className="space-y-1 text-sm">
-              {crossCuttingTopics.map((t) => (
-                <li key={t.id}>
-                  <a
-                    href={`#${t.id}`}
-                    className="text-foreground hover:underline"
-                  >
-                    {t.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
+        <CardContent className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {adminSectionGroups.map((group) =>
+            group.sections.length === 0 ? null : (
+              <div key={group.id}>
+                <h3 className="font-semibold text-sm uppercase tracking-wide text-muted-foreground mb-2">
+                  {group.label}
+                </h3>
+                <p className="text-xs text-muted-foreground mb-2">
+                  {group.description}
+                </p>
+                <ul className="space-y-1 text-sm">
+                  {group.sections.map((s) => (
+                    <li key={s.id}>
+                      <a
+                        href={`#${s.id}`}
+                        className="text-foreground hover:underline"
+                      >
+                        {s.title}
+                      </a>{" "}
+                      <code className="px-1 py-0.5 bg-muted rounded text-xs">
+                        {s.route}
+                      </code>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ),
+          )}
         </CardContent>
       </Card>
 
-      {/* Per-page sections — Navigation group */}
-      {navigationSections.map((section) => (
-        <AdminSectionCard key={section.id} section={section} />
-      ))}
+      {/* Per-section cards, grouped */}
+      {adminSectionGroups.map((group) =>
+        group.sections.length === 0 ? null : (
+          <div key={group.id} className="space-y-4">
+            <div className="border-b pb-2">
+              <h2 className="text-xl font-semibold">{group.label}</h2>
+              <p className="text-sm text-muted-foreground">
+                {group.description}
+              </p>
+            </div>
+            {group.sections.map((section) => (
+              <AdminSectionCard key={section.id} section={section} />
+            ))}
+          </div>
+        ),
+      )}
+    </>
+  );
+}
 
-      {/* Per-page sections — Observations & Measurements group */}
-      {observationsSections.map((section) => (
-        <AdminSectionCard key={section.id} section={section} />
-      ))}
+function CrossCuttingTab() {
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Compass className="h-5 w-5" />
+            On this tab
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-1 text-sm">
+            {crossCuttingTopics.map((t) => (
+              <li key={t.id}>
+                <a
+                  href={`#${t.id}`}
+                  className="text-foreground hover:underline"
+                >
+                  {t.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
 
       {/* Data Import */}
       <Card id="data-import" className="scroll-mt-6">
@@ -547,7 +630,8 @@ export default function GuidePage() {
               tracked by the system. There are 172+ contaminant types, each with
               a unique ID, name, unit of measurement, and category (e.g., Water,
               Air, Health, Disaster). Managed from the{" "}
-              <code className="px-1 py-0.5 bg-muted rounded">/stats</code> page.
+              <code className="px-1 py-0.5 bg-muted rounded">/contaminants</code>{" "}
+              page.
             </p>
           </div>
 
@@ -584,7 +668,7 @@ export default function GuidePage() {
               jurisdictions. Locations are what users subscribe to for
               notifications. Each location is linked to the jurisdictions whose
               thresholds apply to it. Managed from the{" "}
-              <code className="px-1 py-0.5 bg-muted rounded">/zip-codes</code>{" "}
+              <code className="px-1 py-0.5 bg-muted rounded">/measurements</code>{" "}
               page.
             </p>
           </div>
@@ -833,6 +917,742 @@ export default function GuidePage() {
           </div>
         </CardContent>
       </Card>
-    </div>
+    </>
   );
 }
+
+function TestingTab() {
+  return (
+    <>
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Testing Locations
+        </h2>
+        <p className="text-muted-foreground">
+          Reference for testing with seeded data.
+        </p>
+      </div>
+
+      {/* Production URLs */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ExternalLink className="h-5 w-5" />
+            Production URLs
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Mobile App:</span>
+            <a
+              href="https://app.mapyourhealth.info/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://app.mapyourhealth.info/
+            </a>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Admin Dashboard:</span>
+            <a
+              href="https://admin.mapyourhealth.info/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://admin.mapyourhealth.info/
+            </a>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Web Landing:</span>
+            <a
+              href="https://www.mapyourhealth.info/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://www.mapyourhealth.info/
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Staging URLs */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ExternalLink className="h-5 w-5" />
+            Staging URLs
+          </CardTitle>
+          <CardDescription>
+            Validate changes here before promoting to production.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Mobile App:</span>
+            <a
+              href="https://staging.d2z5ddqhlc1q5.amplifyapp.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://staging.d2z5ddqhlc1q5.amplifyapp.com/
+            </a>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Admin Dashboard:</span>
+            <a
+              href="https://staging.d26q32gc98goap.amplifyapp.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://staging.d26q32gc98goap.amplifyapp.com/
+            </a>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-medium">Web Landing:</span>
+            <a
+              href="https://staging.dv0j563gt073v.amplifyapp.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              https://staging.dv0j563gt073v.amplifyapp.com/
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Seeded Locations */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MapPin className="h-5 w-5" />
+            Seeded Locations (34 total)
+          </CardTitle>
+          <CardDescription>
+            Pre-populated with test data.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <h3 className="font-semibold mb-3">Major US Cities (10)</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>City</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Notable Conditions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {majorCities.map((city) => (
+                  <TableRow key={city.city}>
+                    <TableCell className="font-medium">{city.city}</TableCell>
+                    <TableCell>{city.state}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {city.conditions}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div>
+            <h3 className="font-semibold mb-3">Queens, NY (12)</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Neighborhood</TableHead>
+                  <TableHead>Notable Conditions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {queensNeighborhoods.map((loc) => (
+                  <TableRow key={loc.neighborhood}>
+                    <TableCell className="font-medium">
+                      {loc.neighborhood}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {loc.conditions}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div>
+            <h3 className="font-semibold mb-3">Manhattan, NY (12)</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Neighborhood</TableHead>
+                  <TableHead>Notable Conditions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {manhattanNeighborhoods.map((loc) => (
+                  <TableRow key={loc.neighborhood}>
+                    <TableCell className="font-medium">
+                      {loc.neighborhood}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {loc.conditions}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Testing Scenarios */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TestTube className="h-5 w-5" />
+            Testing Scenarios
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <h3 className="font-semibold mb-3">Mobile App</h3>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <span className="font-medium">Safe area:</span> Search{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">Seattle</code> -
+                should show mostly green/safe
+              </li>
+              <li>
+                <span className="font-medium">Mixed warnings:</span> Search{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">New York</code> -
+                should show multiple yellow warnings
+              </li>
+              <li>
+                <span className="font-medium">Danger alerts:</span> Search{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">Chicago</code> -
+                should show red danger for lead
+              </li>
+              <li>
+                <span className="font-medium">Flood risk:</span> Search{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">
+                  Miami Beach
+                </code>{" "}
+                - should show flood danger
+              </li>
+              <li>
+                <span className="font-medium">Wildfire risk:</span> Search{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">Phoenix</code> -
+                should show wildfire danger
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="font-semibold mb-3">GPS Location Feature</h3>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <span className="font-medium">Use My Location button:</span> Tap
+                the GPS icon (crosshairs) next to the search bar
+              </li>
+              <li>
+                <span className="font-medium">Permission prompt:</span> Grant
+                location permission when prompted
+              </li>
+              <li>
+                <span className="font-medium">Auto-populate:</span> Verify city
+                is auto-populated from device location
+              </li>
+              <li>
+                <span className="font-medium">Loading state:</span> GPS button
+                shows spinner while fetching location
+              </li>
+              <li>
+                <span className="font-medium">Permission denied:</span> Decline
+                permission - should show alert explaining how to enable
+              </li>
+              <li>
+                <span className="font-medium">Location unavailable:</span> Test
+                with location services disabled - should show error message
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="font-semibold mb-3">Admin Dashboard</h3>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <span className="font-medium">Measurements page:</span>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">
+                  /measurements
+                </code>{" "}
+                - should list all 34 locations
+              </li>
+              <li>
+                <span className="font-medium">Contaminants page:</span>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">
+                  /contaminants
+                </code>{" "}
+                - should show 11 stat definitions
+              </li>
+              <li>
+                <span className="font-medium">Location detail:</span>{" "}
+                <code className="px-1 py-0.5 bg-muted rounded">
+                  /measurements/New%20York
+                </code>{" "}
+                - should show all stats for NYC
+              </li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Stat Definitions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Stat Definitions (11 total)</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Droplets className="h-4 w-4 text-blue-500" />
+              <span className="font-semibold">Water (3)</span>
+            </div>
+            <ul className="text-sm space-y-1 ml-6">
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  water-lead
+                </code>{" "}
+                - Lead Levels (ppb)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  water-nitrate
+                </code>{" "}
+                - Nitrate Levels (mg/L)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  water-bacteria
+                </code>{" "}
+                - Bacteria Count (CFU/100mL)
+              </li>
+            </ul>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Wind className="h-4 w-4 text-gray-500" />
+              <span className="font-semibold">Air (3)</span>
+            </div>
+            <ul className="text-sm space-y-1 ml-6">
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">air-aqi</code> -
+                Air Quality Index
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">air-pm25</code>{" "}
+                - PM2.5 Levels (µg/m³)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">air-ozone</code>{" "}
+                - Ozone Levels (ppb)
+              </li>
+            </ul>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Heart className="h-4 w-4 text-red-500" />
+              <span className="font-semibold">Health (3)</span>
+            </div>
+            <ul className="text-sm space-y-1 ml-6">
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  health-covid
+                </code>{" "}
+                - COVID-19 Cases (per 100k)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  health-flu
+                </code>{" "}
+                - Flu Cases (per 100k)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  health-access
+                </code>{" "}
+                - Healthcare Access (%)
+              </li>
+            </ul>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-orange-500" />
+              <span className="font-semibold">Disaster (2)</span>
+            </div>
+            <ul className="text-sm space-y-1 ml-6">
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  disaster-wildfire
+                </code>{" "}
+                - Wildfire Risk (level 1-10)
+              </li>
+              <li>
+                <code className="text-xs bg-muted px-1 rounded">
+                  disaster-flood
+                </code>{" "}
+                - Flood Risk (level 1-10)
+              </li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Seed Script */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Running the Seed Script</CardTitle>
+          <CardDescription>
+            From the repository root, run the following command.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm">
+            <code>
+              ADMIN_EMAIL=your-admin@email.com ADMIN_PASSWORD=your-password yarn
+              seed:data
+            </code>
+          </pre>
+          <p className="text-sm text-muted-foreground mt-3">
+            The seed script is idempotent — it skips existing records and only
+            creates missing ones.
+          </p>
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+function DataTab() {
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MapPin className="h-5 w-5" />
+            How data fits together (in plain English)
+          </CardTitle>
+          <CardDescription>
+            How a city, a contaminant, and its measurement actually connect.
+            No foreign keys between them — the cascade is what stitches it all
+            together at read time.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm leading-relaxed">
+          <p>
+            <strong>Key insight:</strong> there&apos;s no foreign key from a
+            measurement to a Location row. Every data row carries its own{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              city / state / country
+            </code>{" "}
+            fields directly. The <code>Location</code> table is just a lookup
+            cache that maps &quot;Montreal, QC, CA&quot; to its regulatory
+            jurisdiction.
+          </p>
+
+          <div>
+            <p className="font-medium">
+              Step 1 — A Location row exists for a city
+            </p>
+            <p className="mt-1">Two ways a Location appears:</p>
+            <ul className="ml-6 mt-1 list-disc space-y-1">
+              <li>
+                <strong>Seeded at reseed time</strong> — 18 well-known cities
+                (Montreal, Toronto, NYC, etc.) ship in{" "}
+                <code>seed-locations.json</code>. Each row stores city, state,
+                country, and a <code>jurisdictionCode</code> like{" "}
+                <code>CA-QC</code> that tells the app which regulator&apos;s
+                limits apply.
+              </li>
+              <li>
+                <strong>Resolved on demand</strong> — when a mobile user
+                searches a new city, the <code>resolve-location</code> Lambda
+                hits Google Places, derives the jurisdiction code (try{" "}
+                <code>{"{country}-{state}"}</code>, then{" "}
+                <code>{"{country}"}</code>, then <code>WHO</code>), and caches
+                the row.
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <p className="font-medium">
+              Step 2 — Data is stored with city/state/country on the row itself
+            </p>
+            <p className="mt-1">
+              When an admin enters a measurement, the{" "}
+              <code>LocationMeasurement</code> row looks like:
+            </p>
+            <pre className="mt-2 overflow-x-auto rounded-md bg-muted px-3 py-2 text-xs">
+              {`{
+  city: "Montreal",
+  state: "QC",
+  country: "CA",
+  contaminantId: "lead",    // slug, not UUID
+  value: 12,
+  unit: "μg/L",
+  measuredAt: "2026-05-01"
+}`}
+            </pre>
+            <p className="mt-2">
+              Two things to notice: <strong>no FK to Location</strong> (same
+              fields duplicated) and{" "}
+              <strong>
+                <code>contaminantId</code> is a slug
+              </strong>{" "}
+              (lookups go through the <code>byContaminantId</code> GSI on the
+              Contaminant table). The duplication enables{" "}
+              <strong>cascade</strong>: a row with{" "}
+              <code>city: null, state: &quot;QC&quot;, country: &quot;CA&quot;</code>{" "}
+              applies to any QC city; one with all-null city + state applies
+              country-wide.
+            </p>
+          </div>
+
+          <div>
+            <p className="font-medium">Step 3 — Mobile joins at read time</p>
+            <p className="mt-1">When a user opens Sorel-Tracy, QC:</p>
+            <ol className="ml-6 mt-1 list-decimal space-y-1">
+              <li>
+                <strong>Cascade-fetch</strong>: try{" "}
+                <code>city = &quot;Sorel-Tracy&quot;</code> → empty. Fall back
+                to <code>state = &quot;QC&quot;, city = null</code> → returns
+                the QC-anchored rows. Returns rows plus a scope label
+                (&quot;Showing QC data&quot;) for the badge.
+              </li>
+              <li>
+                <strong>Lookup the Contaminant</strong> by slug → name,
+                category, unit.
+              </li>
+              <li>
+                <strong>Lookup the ContaminantThreshold</strong> for{" "}
+                <code>(contaminantId, jurisdictionCode)</code>. Try{" "}
+                <code>CA-QC</code>, fall back to <code>CA</code>, then{" "}
+                <code>WHO</code>.
+              </li>
+              <li>
+                <strong>Compute status</strong>:{" "}
+                <code>value ≥ limit</code> → DANGER.{" "}
+                <code>value ≥ limit × 0.8</code> → WARNING. Else SAFE.
+              </li>
+            </ol>
+          </div>
+
+          <div className="rounded-md border border-muted bg-muted/40 p-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Why no foreign key?
+            </p>
+            <ul className="mt-2 ml-5 list-disc space-y-1">
+              <li>
+                Duplication enables cascade with zero JOIN logic — the GSI on
+                city/state/country gives O(1) lookup at any scope.
+              </li>
+              <li>
+                Measurements survive Location wipes — Reseed All wipes the
+                Location table, but measurements anchor themselves correctly
+                via their own fields.
+              </li>
+              <li>
+                Jurisdiction is derived from state + country alone — no
+                consultation with Location is needed for the threshold-lookup
+                chain.
+              </li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Database className="h-5 w-5" />
+            How the Reseed All action works
+          </CardTitle>
+          <CardDescription>
+            Step-by-step what the Settings → Reseed All Data button does when
+            you click it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm leading-relaxed">
+          <p>
+            The reference data on this platform comes from a master spreadsheet
+            called <strong>Risks.xlsx</strong> — it defines every contaminant
+            we track, the legal limits for each one in each country/state, and
+            the regulatory bodies whose rules apply. <strong>Reseed</strong> is
+            how we push updated values from that spreadsheet into the live
+            database.
+          </p>
+
+          <div>
+            <p className="font-medium">Step 1 — Wipe the reference tables</p>
+            <p className="mt-1">
+              All rows are deleted from 10 reference tables:
+            </p>
+            <ul className="ml-6 mt-1 list-disc space-y-0.5 text-muted-foreground">
+              <li>Jurisdiction · Contaminant · ContaminantThreshold</li>
+              <li>Location · LocationMeasurement · LocationObservation</li>
+              <li>Category · SubCategory</li>
+              <li>ObservedProperty · PropertyThreshold</li>
+            </ul>
+          </div>
+
+          <div>
+            <p className="font-medium">Step 2 — Reload in dependency order</p>
+            <p className="mt-1">
+              Data is added back in this sequence because each table depends on
+              the ones before it:
+            </p>
+            <ol className="ml-6 mt-2 list-decimal space-y-2">
+              <li>
+                <strong>Jurisdictions</strong> (~18) — the regulatory bodies:
+                WHO, US states, Canadian provinces, EU, etc.
+              </li>
+              <li>
+                <strong>Contaminants</strong> (~174) — the substances we track
+                (Lead, Fluoride, PFAS, Silver, etc.), loaded from Risks.xlsx.
+              </li>
+              <li>
+                <strong>Thresholds</strong> (~414) — the actual limit values,
+                one per <em>contaminant × jurisdiction</em> (e.g., WHO Lead =
+                10 μg/L; Quebec Lead = 5 μg/L).
+              </li>
+              <li>
+                <strong>Locations</strong> (~18) — city/state/country lookup
+                cache for known cities.
+              </li>
+              <li>
+                <strong>Observed Properties &amp; Property Thresholds</strong>{" "}
+                (2 + 3) — environmental measurements (radon, Lyme disease) and
+                their limits per jurisdiction.
+              </li>
+              <li>
+                <strong>Measurements</strong> (~1,771) — actual contaminant
+                readings per city (e.g., Montreal nitrate = 8,500 μg/L).
+              </li>
+              <li>
+                <strong>Categories &amp; Sub-Categories</strong> (4 + 9) —
+                top-level groupings (Water, Air) and sub-categories (Organic,
+                Inorganic, Disinfectant, etc.).
+              </li>
+              <li>
+                <strong>Observations</strong> (~6,660) — actual radon / Lyme
+                data points per city.
+              </li>
+            </ol>
+          </div>
+
+          <div className="rounded-md border border-muted bg-muted/40 p-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              What&apos;s preserved
+            </p>
+            <p className="mt-2">
+              User-submitted data (subscriptions, notification logs, hazard
+              reports, health records) and admin-curated content (warning
+              banners, pollution sources) are <strong>never touched</strong> by
+              the wipe. They survive every reseed.
+            </p>
+          </div>
+
+          <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/30">
+            <p className="text-xs font-medium uppercase tracking-wide text-amber-900 dark:text-amber-200">
+              Source-of-truth caveat
+            </p>
+            <p className="mt-2 text-amber-900 dark:text-amber-200">
+              The seed values come from JSON files generated at the{" "}
+              <strong>last backend deploy</strong>. If you&apos;ve edited
+              Risks.xlsx since then, your changes won&apos;t appear in this
+              reseed until a new backend build runs and bundles the updated
+              JSON. Trigger a backend deploy first if you&apos;ve made
+              source-data changes you want reflected.
+            </p>
+          </div>
+
+          <p className="text-muted-foreground">
+            Roughly <strong>1–3 minutes</strong> end-to-end. Don&apos;t close
+            the page until the operation completes.
+          </p>
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+const majorCities = [
+  { city: "Beverly Hills", state: "CA", conditions: "Wildfire warning" },
+  { city: "New York", state: "NY", conditions: "Air quality & lead warnings" },
+  { city: "Miami Beach", state: "FL", conditions: "Flood danger" },
+  { city: "Chicago", state: "IL", conditions: "Lead danger, bacteria warning" },
+  { city: "Seattle", state: "WA", conditions: "Very safe overall" },
+  { city: "Atlanta", state: "GA", conditions: "Air quality warnings" },
+  { city: "Dallas", state: "TX", conditions: "Ozone & flood warnings" },
+  { city: "Phoenix", state: "AZ", conditions: "Ozone danger, wildfire danger" },
+  { city: "Denver", state: "CO", conditions: "Wildfire danger" },
+  { city: "Boston", state: "MA", conditions: "Lead & flu warnings" },
+];
+
+const queensNeighborhoods = [
+  { neighborhood: "Corona", conditions: "Dense urban, multiple warnings" },
+  { neighborhood: "College Point", conditions: "Flood danger (coastal)" },
+  {
+    neighborhood: "Long Island City",
+    conditions: "Industrial area, flood warning",
+  },
+  { neighborhood: "Astoria", conditions: "Good transit, moderate air" },
+  { neighborhood: "Flushing", conditions: "Busy commercial, air warnings" },
+  { neighborhood: "Jackson Heights", conditions: "Dense, health warnings" },
+  { neighborhood: "Elmhurst", conditions: "Dense residential" },
+  { neighborhood: "Forest Hills", conditions: "Suburban feel, mostly safe" },
+  { neighborhood: "Bayside", conditions: "Quiet residential" },
+  { neighborhood: "Jamaica", conditions: "Transit hub, multiple warnings" },
+  { neighborhood: "Ridgewood", conditions: "Border with Brooklyn" },
+  { neighborhood: "Rockaway Beach", conditions: "Flood danger (coastal)" },
+];
+
+const manhattanNeighborhoods = [
+  {
+    neighborhood: "Lower East Side",
+    conditions: "Older buildings, lead warning",
+  },
+  { neighborhood: "Greenwich Village", conditions: "Generally good" },
+  { neighborhood: "SoHo", conditions: "Moderate air quality" },
+  {
+    neighborhood: "Tribeca",
+    conditions: "Excellent healthcare, flood warning",
+  },
+  { neighborhood: "Murray Hill", conditions: "Dense residential" },
+  { neighborhood: "Midtown East", conditions: "High traffic, air warnings" },
+  { neighborhood: "Upper West Side", conditions: "Family-friendly, safe" },
+  {
+    neighborhood: "Upper East Side",
+    conditions: "Affluent, excellent services",
+  },
+  {
+    neighborhood: "East Harlem",
+    conditions: "Lead danger, health disparities",
+  },
+  { neighborhood: "Harlem", conditions: "Aging infrastructure" },
+  { neighborhood: "Washington Heights", conditions: "Diverse community" },
+  {
+    neighborhood: "Financial District",
+    conditions: "Modern infrastructure, flood warning",
+  },
+];


### PR DESCRIPTION
## Summary

Adds long-form documentation as a new tab in the admin Guide so admins (and future-you) can understand what's actually happening underneath the buttons. Two cards:

### Card 1: How data fits together (plain English)

Walks through the architectural surprise that there's **no foreign key** from \`LocationMeasurement\` to \`Location\`. Every measurement row carries its own city/state/country fields. \`Location\` is just a lookup cache from city → jurisdiction.

- How a Location row appears (seeded vs. resolved-on-demand via the \`resolve-location\` Lambda + Google Places)
- The structure of a measurement row (slug-based \`contaminantId\`, GSI lookups)
- How mobile cascade-fetches at read time (city → state → country), joins contaminant + threshold + jurisdiction, and computes safe/warning/danger status
- Why the design avoids a FK (cascade with zero JOINs, measurements survive Location wipes, jurisdiction is derived from state+country)

### Card 2: How the Reseed All action works

Step-by-step walkthrough of the Settings → **Reseed All Data** button:

1. **Wipe** the 10 reference tables (named explicitly)
2. **Reload in dependency order** with row counts: Jurisdictions → Contaminants → Thresholds → Locations → Observed Properties & Property Thresholds → Measurements → Categories & Sub-Categories → Observations
3. **What's preserved** across the wipe (user-submitted + admin-curated content)
4. **Source-of-truth caveat** — the seed JSON is bundled into the \`manage-data\` Lambda at backend build time; edits to \`Risks.xlsx\` only land after a redeploy

## Heads-up on scope

The diff is larger than just the new tab because longstanding WIP edits to \`apps/admin/src/app/(admin)/guide/page.tsx\` were sitting uncommitted in the working tree and got bundled in (same pattern as PR #342). If the diff includes unrelated changes you'd rather split out, say so and I'll rebase.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Open \`/guide?tab=data\` on localhost or staging deploy — both cards render, no console errors
- [ ] URL tab state works (refresh on \`?tab=data\` preserves the active tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)