### PR TITLE
docs(admin): "In plain English" TL;DR card at top of Data & Reseed tab

### DIFF
--- a/apps/admin/src/app/(admin)/guide/page.tsx
+++ b/apps/admin/src/app/(admin)/guide/page.tsx
@@ -1345,6 +1345,34 @@ function TestingTab() {
 function DataTab() {
   return (
     <>
+      <Card className="border-primary/40 bg-primary/5">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Lightbulb className="h-5 w-5" />
+            In plain English
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm leading-relaxed">
+          <ul className="ml-5 list-disc space-y-2">
+            <li>
+              We track ~174 substances (Lead, Fluoride, etc.) and their legal
+              limits in each country and state. All of that comes from{" "}
+              <strong>Risks.xlsx</strong>.
+            </li>
+            <li>
+              Actual readings (&quot;Montreal had 12 μg/L of lead on
+              2026-05-01&quot;) are stored separately and grow over time as
+              admins import data.
+            </li>
+            <li>
+              <strong>Reseed All</strong> wipes the reference data and
+              re-imports it from Risks.xlsx. Takes 1–3 minutes. Your users&apos;
+              alerts, subscriptions, and reports are never touched.
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Adds a short, primary-tinted callout card above the detailed entity tables on \`/guide?tab=data\`. Three plain-English bullets — no jargon (no slugs, no UUIDs, no GSIs):

1. **What's in Risks.xlsx:** ~174 substances and their legal limits per country/state.
2. **What's stored separately:** the actual readings (&quot;Montreal had 12 μg/L of lead on 2026-05-01&quot;) — grows over time.
3. **What Reseed All does:** wipes the reference data and re-imports from Risks.xlsx. 1–3 min. User alerts / subscriptions / reports are never touched.

Sits above the existing three cards from #347 + #349 (entity tables → Contaminant vs Measurement → Reseed step-by-step). Anyone who already knows the model scrolls past. Anyone who doesn't gets the bottom line in 30 seconds.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] /guide?tab=data renders the TL;DR card at the top, primary-tinted background, three bullets readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)