### PR TITLE
fix(admin): export adminSectionGroups from admin-sections.ts (unblocks CI)

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -54,12 +54,19 @@ export type MobileImpact = {
   edgeCases?: string[];
 };
 
+export type AdminSectionGroupId =
+  | "daily-ops"
+  | "reference-data"
+  | "web-marketing"
+  | "system"
+  | "orphan";
+
 export type AdminSection = {
   id: string;
   title: string;
   route: string;
   icon: ComponentType<{ className?: string }>;
-  group: "navigation" | "observations";
+  group: AdminSectionGroupId;
   purpose: string;
   lists?: AdminList[];
   fields?: AdminField[];
@@ -68,13 +75,13 @@ export type AdminSection = {
   notes?: string[];
 };
 
-export const navigationSections: AdminSection[] = [
+const allSections: AdminSection[] = [
   {
     id: "dashboard",
     title: "Dashboard",
     route: "/",
     icon: LayoutDashboard,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "Read-only landing page that summarizes platform state. The first screen an admin sees after login. No data is created or modified here.",
     lists: [
@@ -105,7 +112,7 @@ export const navigationSections: AdminSection[] = [
     title: "Analytics",
     route: "/analytics",
     icon: BarChart3,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "Real-time inventory of platform usage. Use this to verify that recent imports landed and that visit traffic looks reasonable.",
     lists: [
@@ -136,9 +143,9 @@ export const navigationSections: AdminSection[] = [
   {
     id: "contaminants",
     title: "Contaminants",
-    route: "/stats",
+    route: "/contaminants",
     icon: Droplets,
-    group: "navigation",
+    group: "reference-data",
     purpose:
       "Defines every contaminant the platform tracks (lead, nitrate, radon, PM2.5, etc.). A contaminant is the row that appears in a category's standards table on mobile, with its name, unit, and description. Edits here change what mobile users read.",
     lists: [
@@ -243,7 +250,7 @@ export const navigationSections: AdminSection[] = [
     title: "Thresholds",
     route: "/thresholds",
     icon: Scale,
-    group: "navigation",
+    group: "reference-data",
     purpose:
       "Pairs a contaminant with a jurisdiction and a numeric limit. The mobile safety badge (green/orange/red) is computed entirely from these records. Missing thresholds silently fall back to the parent jurisdiction, then to WHO.",
     lists: [
@@ -339,7 +346,7 @@ export const navigationSections: AdminSection[] = [
     title: "Jurisdictions",
     route: "/jurisdictions",
     icon: Globe,
-    group: "navigation",
+    group: "reference-data",
     purpose:
       "Defines the regulatory bodies whose thresholds the app compares against (WHO, US, US-NY, CA-QC, EU, etc.). Each location resolves to one jurisdiction; the parent chain provides the cascade fallback when a state-level threshold is missing.",
     lists: [
@@ -428,7 +435,7 @@ export const navigationSections: AdminSection[] = [
     title: "Categories",
     route: "/categories",
     icon: FolderTree,
-    group: "navigation",
+    group: "reference-data",
     purpose:
       "Defines the top-level groupings on the mobile dashboard (Water, Air, Health, Disaster). Each category card on mobile takes its icon, color, name, sort order, and optional external links from this page.",
     lists: [
@@ -545,7 +552,7 @@ export const navigationSections: AdminSection[] = [
     title: "Sub-Categories",
     route: "/subcategories",
     icon: Layers,
-    group: "navigation",
+    group: "reference-data",
     purpose:
       "Optional second level of grouping under a category (e.g. Pesticides, Fertilizers under Water). Sub-categories can inherit the parent's icon and color.",
     lists: [
@@ -628,9 +635,9 @@ export const navigationSections: AdminSection[] = [
   {
     id: "location-stats",
     title: "Location Stats",
-    route: "/zip-codes",
+    route: "/measurements",
     icon: MapPin,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "View measurements aggregated by city, state, and country. Use this page to verify recent imports and to add a new city as a target for future imports. Three tables surface the cascade levels users actually see.",
     lists: [
@@ -662,7 +669,7 @@ export const navigationSections: AdminSection[] = [
       {
         label: "Manage",
         description:
-          "Drills into /zip-codes/[zipCode] for per-contaminant editing of that city's measurements.",
+          "Drills into /measurements/[city] for per-contaminant editing of that city's measurements.",
       },
     ],
     mobileImpact: {
@@ -691,7 +698,7 @@ export const navigationSections: AdminSection[] = [
     title: "Import Data",
     route: "/import",
     icon: Upload,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "Bulk-import LocationMeasurement records from CSV, JSON, or Excel. The Silent Import checkbox is the single most consequential control on this page — without it, every imported row triggers push and email alerts.",
     lists: [
@@ -764,7 +771,7 @@ export const navigationSections: AdminSection[] = [
     title: "Warning Banners",
     route: "/banners",
     icon: Megaphone,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "Show alert banners at the top of the mobile dashboard. Use for boil-water advisories, infrastructure outages, regulatory updates, or any time-bounded user-facing message. Scope is determined by the city/state/country fields — leave them all blank for a global banner.",
     lists: [
@@ -854,7 +861,7 @@ export const navigationSections: AdminSection[] = [
     title: "Landing Page",
     route: "/landing-page",
     icon: FileText,
-    group: "navigation",
+    group: "web-marketing",
     purpose:
       "Edit text and theme colors on the marketing landing site (apps/web). EN and FR copy are managed independently via the override system; the Theme tab tunes the site's color tokens. This section does not affect the mobile app.",
     lists: [
@@ -893,9 +900,9 @@ export const navigationSections: AdminSection[] = [
   {
     id: "reports",
     title: "Hazard Reports",
-    route: "/reports",
+    route: "/hazard-reports",
     icon: AlertTriangle,
-    group: "navigation",
+    group: "daily-ops",
     purpose:
       "Moderate user-submitted hazard reports. Reports arrive with status=pending; admins review the description, decide whether the report is actionable, and update the status. Notes are private to admins.",
     lists: [
@@ -948,7 +955,7 @@ export const navigationSections: AdminSection[] = [
     title: "Subscribers",
     route: "/subscribers",
     icon: Mail,
-    group: "navigation",
+    group: "web-marketing",
     purpose:
       "Manage newsletter signups captured from the landing site. Distinct from mobile UserSubscription records (which gate location alerts) — this page only handles email-list subscribers.",
     lists: [
@@ -988,7 +995,7 @@ export const navigationSections: AdminSection[] = [
     title: "Pollution Sources",
     route: "/pollution-sources",
     icon: Factory,
-    group: "navigation",
+    group: "orphan",
     purpose:
       "Pin known pollution sources (industrial sites, landfills, etc.) to the map. Each source has a location, an impact radius, a severity, and a status. Mobile renders these on the dedicated PollutionSourcesScreen.",
     lists: [
@@ -1038,28 +1045,18 @@ export const navigationSections: AdminSection[] = [
     ],
     mobileImpact: {
       summary:
-        "Pollution sources appear on the dedicated PollutionSourcesScreen as cards plus an optional map view. Visibility is gated on the user having a real (non-demo) location.",
-      surfaces: [
-        {
-          screen: "PollutionSourcesScreen",
-          behavior:
-            "One card per source: name, type label, status label, severity icon (critical=alert-octagon red, high=alert red, moderate=alert-circle orange, low=shield-check green), impact radius (e.g. \"2.5 km\").",
-        },
-      ],
+        "ORPHAN (EPI-25): no current mobile consumer. Service helpers exist in apps/mobile/app/services/amplify/data.ts but no screen, hook, or component renders pollution sources. Edits here are not visible to users today.",
       edgeCases: [
-        "No sources at the user's location → cascade to state, then country, then empty state.",
-        "Missing sourceType → labeled \"Other\".",
-        "Missing severity → defaults to \"moderate\".",
-        "Missing status → defaults to \"active\".",
+        "If EPI-25 reinstates a PollutionSourcesScreen, the cascade rules (city → state → country) will mirror banners and measurements.",
       ],
     },
   },
   {
     id: "testing",
     title: "Testing Guide",
-    route: "/testing",
+    route: "/guide?tab=testing",
     icon: TestTube,
-    group: "navigation",
+    group: "system",
     purpose:
       "Static reference page. Lists the production and staging URLs, the 34 seeded test locations (major cities + NYC neighborhoods), the testing scenarios, and the seed-script command. No data is written from this page.",
     mobileImpact: {
@@ -1072,7 +1069,7 @@ export const navigationSections: AdminSection[] = [
     title: "Guide",
     route: "/guide",
     icon: BookOpen,
-    group: "navigation",
+    group: "system",
     purpose:
       "This page. The long-form admin reference. Each section above documents one menu item; each cross-cutting card below covers a behavior that spans pages.",
     mobileImpact: {
@@ -1085,7 +1082,7 @@ export const navigationSections: AdminSection[] = [
     title: "Settings",
     route: "/settings",
     icon: Settings,
-    group: "navigation",
+    group: "system",
     purpose:
       "Application-wide feature toggles and destructive database operations. Wipes and reseeds in this page affect every mobile user immediately. Confirmation phrases are case-sensitive and must be typed exactly.",
     fields: [
@@ -1146,15 +1143,12 @@ export const navigationSections: AdminSection[] = [
       ],
     },
   },
-];
-
-export const observationsSections: AdminSection[] = [
   {
     id: "properties",
     title: "Properties",
     route: "/properties",
     icon: Activity,
-    group: "observations",
+    group: "orphan",
     purpose:
       "Defines observable phenomena beyond classical numeric contaminants — radon zones, endemic disease flags, incidence rates, binary presence indicators. Each property declares its observationType, which dictates how thresholds and observations are entered and rendered.",
     lists: [
@@ -1224,7 +1218,7 @@ export const observationsSections: AdminSection[] = [
     title: "Property Thresholds",
     route: "/property-thresholds",
     icon: Gauge,
-    group: "observations",
+    group: "orphan",
     purpose:
       "Per-jurisdiction thresholds for non-numeric properties. The form fields you see depend on the parent property's observationType.",
     lists: [
@@ -1310,7 +1304,7 @@ export const observationsSections: AdminSection[] = [
     title: "Observations",
     route: "/observations",
     icon: Eye,
-    group: "observations",
+    group: "orphan",
     purpose:
       "Records of measured property values. The value field on the form changes based on the property's observationType. Location uses the same city/state/country cascade as banners and pollution sources — blank fields scope wider.",
     lists: [
@@ -1379,3 +1373,46 @@ export const observationsSections: AdminSection[] = [
     },
   },
 ];
+
+export const adminSections = allSections;
+
+export type AdminSectionGroup = {
+  id: AdminSectionGroupId;
+  label: string;
+  description: string;
+  sections: AdminSection[];
+};
+
+const groupOrder: { id: AdminSectionGroupId; label: string; description: string }[] = [
+  {
+    id: "daily-ops",
+    label: "Mobile App — Daily Ops",
+    description: "Drives the location detail screen. Edits here are visible to mobile users immediately.",
+  },
+  {
+    id: "reference-data",
+    label: "Reference Data",
+    description: "Catalogs that classify the daily-ops data. Rarely edited but high blast-radius.",
+  },
+  {
+    id: "web-marketing",
+    label: "Web & Marketing",
+    description: "Landing site and newsletter. No effect on the mobile app.",
+  },
+  {
+    id: "system",
+    label: "System",
+    description: "Feature flags and documentation.",
+  },
+  {
+    id: "orphan",
+    label: "Orphaned (EPI-25)",
+    description: "Routes whose mobile consumer was removed. Pending the EPI-25 decision.",
+  },
+];
+
+export const adminSectionGroups: AdminSectionGroup[] = groupOrder.map((g) => ({
+  ...g,
+  sections: allSections.filter((s) => s.group === g.id),
+}));
+


### PR DESCRIPTION
## Problem

CI **Type Check Admin** is failing on every recent guide-page-touching PR (#347, #349, #350):

\`\`\`
./apps/admin/src/app/(admin)/guide/page.tsx:38:1
Export adminSectionGroups doesn't exist in target module
Did you mean to import navigationSections?
\`\`\`

## Root cause

\`guide/page.tsx\` was updated in an earlier WIP bundle to import \`adminSectionGroups\`, but the corresponding rename inside \`data/admin-sections.ts\` — restructuring from a flat \`navigationSections / omSections\` split into the 5-group sidebar structure (\`daily-ops\` / \`reference-data\` / \`web-marketing\` / \`system\` / \`orphan\`) — was sitting in the local working tree, never committed.

Locally everything built because the working tree had the rename; CI ran against \`origin/staging\` which had the page.tsx import but not the export.

## Fix

Commits the longstanding WIP to \`data/admin-sections.ts\`:

- New \`AdminSectionGroupId\` union type with the 5 group ids
- \`AdminSection.group\` typed as \`AdminSectionGroupId\` instead of the old \`"navigation" | "observations"\`
- Sections re-grouped under the new ids
- New \`adminSectionGroups\` export at the bottom of the file (built from \`groupOrder.map(...)\`)

## Test plan

- [x] \`npx tsc --noEmit\` from \`apps/admin/\` clean locally
- [ ] After merge, CI **Type Check Admin** passes on PRs #347/#349/#350

🤖 Generated with [Claude Code](https://claude.com/claude-code)