### PR TITLE
fix(admin): restore Measurements / Hazard Reports / Contaminants routes (#354)

### DIFF
--- a/apps/admin/e2e/admin/admin-route-smoke.spec.ts
+++ b/apps/admin/e2e/admin/admin-route-smoke.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * E2E Smoke: Admin routes restored in #354
+ *
+ * Asserts that the Measurements, Hazard Reports and Contaminants admin
+ * routes resolve to their pages (not Next.js 404). Regression guard for
+ * the situation Rayane reported: sidebar links exist but the route
+ * directories were never committed, so each link landed on 404.
+ */
+
+import { test, expect } from "@playwright/test";
+import { testUrls, adminCredentials } from "../fixtures/test-data";
+
+const hasRealCredentials =
+  process.env.ADMIN_TEST_EMAIL && process.env.ADMIN_TEST_PASSWORD;
+
+const routes: { path: string; heading: RegExp }[] = [
+  { path: "/measurements", heading: /location measurements/i },
+  { path: "/hazard-reports", heading: /hazard reports/i },
+  { path: "/contaminants", heading: /contaminants/i },
+];
+
+test.describe("Admin route smoke (#354)", () => {
+  test.skip(
+    !hasRealCredentials,
+    "Skipping — requires ADMIN_TEST_EMAIL and ADMIN_TEST_PASSWORD env vars",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${testUrls.admin}/login`);
+    await page.fill("input#email", adminCredentials.email);
+    await page.fill("input#password", adminCredentials.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await page.waitForURL(`${testUrls.admin}/`, { timeout: 30000 });
+  });
+
+  for (const { path, heading } of routes) {
+    test(`${path} renders its heading (not 404)`, async ({ page }) => {
+      const response = await page.goto(`${testUrls.admin}${path}`);
+      expect(response?.status(), `${path} should not be 404`).toBeLessThan(400);
+
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByRole("heading", { name: heading }),
+        `${path} should render its primary heading`,
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(/this page could not be found/i),
+      ).toHaveCount(0);
+    });
+  }
+});

--- a/apps/admin/src/app/(admin)/contaminants/page.tsx
+++ b/apps/admin/src/app/(admin)/contaminants/page.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  CONTAMINANT_CATEGORIES,
+  contaminantCategoryColors,
+  contaminantCategoryNames,
+  type ContaminantCategory,
+} from "@/lib/constants";
+
+type Contaminant = Schema["Contaminant"]["type"];
+
+export default function ContaminantsPage() {
+  const [contaminants, setContaminants] = useState<Contaminant[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingContaminant, setEditingContaminant] =
+    useState<Contaminant | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form state
+  const [formData, setFormData] = useState({
+    contaminantId: "",
+    name: "",
+    nameFr: "",
+    unit: "",
+    description: "",
+    descriptionFr: "",
+    category: "" as ContaminantCategory | "",
+    studies: "",
+    higherIsBad: true,
+  });
+
+  const fetchContaminants = async () => {
+    try {
+      setIsLoading(true);
+      const client = generateClient<Schema>();
+      const { data, errors } = await client.models.Contaminant.list({
+        limit: 1000,
+      });
+
+      if (errors) {
+        console.error("Error fetching contaminants:", errors);
+        toast.error("Failed to fetch contaminants");
+        return;
+      }
+
+      setContaminants(data || []);
+    } catch (error) {
+      console.error("Error fetching contaminants:", error);
+      toast.error("Failed to fetch contaminants");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchContaminants();
+  }, []);
+
+  const resetForm = () => {
+    setFormData({
+      contaminantId: "",
+      name: "",
+      nameFr: "",
+      unit: "",
+      description: "",
+      descriptionFr: "",
+      category: "",
+      studies: "",
+      higherIsBad: true,
+    });
+    setEditingContaminant(null);
+  };
+
+  const openCreateDialog = () => {
+    resetForm();
+    setIsDialogOpen(true);
+  };
+
+  const openEditDialog = (contaminant: Contaminant) => {
+    setEditingContaminant(contaminant);
+    setFormData({
+      contaminantId: contaminant.contaminantId,
+      name: contaminant.name,
+      nameFr: contaminant.nameFr || "",
+      unit: contaminant.unit,
+      description: contaminant.description || "",
+      descriptionFr: contaminant.descriptionFr || "",
+      category: (contaminant.category as ContaminantCategory) || "",
+      studies: contaminant.studies || "",
+      higherIsBad: contaminant.higherIsBad ?? true,
+    });
+    setIsDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (
+      !formData.contaminantId ||
+      !formData.name ||
+      !formData.unit ||
+      !formData.category
+    ) {
+      toast.error("Please fill in all required fields");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const client = generateClient<Schema>();
+
+      const contaminantData = {
+        contaminantId: formData.contaminantId,
+        name: formData.name,
+        nameFr: formData.nameFr || null,
+        unit: formData.unit,
+        description: formData.description || null,
+        descriptionFr: formData.descriptionFr || null,
+        category: formData.category as ContaminantCategory,
+        studies: formData.studies || null,
+        higherIsBad: formData.higherIsBad,
+      };
+
+      if (editingContaminant) {
+        await client.models.Contaminant.update({
+          id: editingContaminant.id,
+          ...contaminantData,
+        });
+        toast.success("Contaminant updated");
+      } else {
+        await client.models.Contaminant.create(contaminantData);
+        toast.success("Contaminant created");
+      }
+
+      setIsDialogOpen(false);
+      resetForm();
+      fetchContaminants();
+    } catch (error) {
+      console.error("Error saving contaminant:", error);
+      toast.error("Failed to save contaminant");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (contaminant: Contaminant) => {
+    if (!confirm(`Are you sure you want to delete "${contaminant.name}"?`)) {
+      return;
+    }
+
+    try {
+      const client = generateClient<Schema>();
+      await client.models.Contaminant.delete({ id: contaminant.id });
+      toast.success("Contaminant deleted");
+      fetchContaminants();
+    } catch (error) {
+      console.error("Error deleting contaminant:", error);
+      toast.error("Failed to delete contaminant");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Contaminants</h1>
+          <p className="text-muted-foreground">
+            Manage water contaminants and their properties
+          </p>
+        </div>
+        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <DialogTrigger asChild>
+            <Button onClick={openCreateDialog}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Contaminant
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-[600px]">
+            <DialogHeader>
+              <DialogTitle>
+                {editingContaminant ? "Edit Contaminant" : "Create Contaminant"}
+              </DialogTitle>
+              <DialogDescription>
+                {editingContaminant
+                  ? "Update the contaminant details below."
+                  : "Add a new water contaminant to track."}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="contaminantId">Contaminant ID *</Label>
+                  <Input
+                    id="contaminantId"
+                    placeholder="e.g., nitrate"
+                    value={formData.contaminantId}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        contaminantId: e.target.value,
+                      })
+                    }
+                    disabled={!!editingContaminant}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="category">Category *</Label>
+                  <Select
+                    value={formData.category}
+                    onValueChange={(value) =>
+                      setFormData({
+                        ...formData,
+                        category: value as ContaminantCategory,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select category" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CONTAMINANT_CATEGORIES.map((cat) => (
+                        <SelectItem key={cat} value={cat}>
+                          {contaminantCategoryNames[cat]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Name (English) *</Label>
+                  <Input
+                    id="name"
+                    placeholder="e.g., Nitrate"
+                    value={formData.name}
+                    onChange={(e) =>
+                      setFormData({ ...formData, name: e.target.value })
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="nameFr">Name (French)</Label>
+                  <Input
+                    id="nameFr"
+                    placeholder="e.g., Nitrate"
+                    value={formData.nameFr}
+                    onChange={(e) =>
+                      setFormData({ ...formData, nameFr: e.target.value })
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="unit">Unit *</Label>
+                  <Input
+                    id="unit"
+                    placeholder="e.g., μg/L"
+                    value={formData.unit}
+                    onChange={(e) =>
+                      setFormData({ ...formData, unit: e.target.value })
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Higher Values Are</Label>
+                  <Select
+                    value={formData.higherIsBad ? "bad" : "good"}
+                    onValueChange={(value) =>
+                      setFormData({ ...formData, higherIsBad: value === "bad" })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="bad">Bad (worse)</SelectItem>
+                      <SelectItem value="good">Good (better)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">Description (English)</Label>
+                <Input
+                  id="description"
+                  placeholder="Health concerns and effects"
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData({ ...formData, description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="descriptionFr">Description (French)</Label>
+                <Input
+                  id="descriptionFr"
+                  placeholder="Préoccupations et effets sur la santé"
+                  value={formData.descriptionFr}
+                  onChange={(e) =>
+                    setFormData({ ...formData, descriptionFr: e.target.value })
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="studies">Scientific References</Label>
+                <Input
+                  id="studies"
+                  placeholder="Links to scientific studies"
+                  value={formData.studies}
+                  onChange={(e) =>
+                    setFormData({ ...formData, studies: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setIsDialogOpen(false)}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={isSaving}>
+                {isSaving ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : editingContaminant ? (
+                  "Update"
+                ) : (
+                  "Create"
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Contaminants</CardTitle>
+          <CardDescription>
+            {contaminants.length} contaminant
+            {contaminants.length !== 1 ? "s" : ""} configured
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : contaminants.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No contaminants yet. Click &quot;Add Contaminant&quot; to create
+              one.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Unit</TableHead>
+                  <TableHead>Higher Is</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {contaminants.map((contaminant) => (
+                  <TableRow key={contaminant.id}>
+                    <TableCell className="font-mono text-sm">
+                      {contaminant.contaminantId}
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {contaminant.name}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={
+                          contaminant.category
+                            ? contaminantCategoryColors[
+                                contaminant.category as ContaminantCategory
+                              ]
+                            : ""
+                        }
+                      >
+                        {contaminant.category
+                          ? contaminantCategoryNames[
+                              contaminant.category as ContaminantCategory
+                            ]
+                          : "—"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{contaminant.unit}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          contaminant.higherIsBad ? "destructive" : "default"
+                        }
+                      >
+                        {contaminant.higherIsBad ? "Bad" : "Good"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openEditDialog(contaminant)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDelete(contaminant)}
+                        >
+                          <Trash2 className="h-4 w-4 text-red-500" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/hazard-reports/page.tsx
+++ b/apps/admin/src/app/(admin)/hazard-reports/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  Eye,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  CATEGORIES,
+  REPORT_STATUS_OPTIONS,
+  categoryColors,
+  reportStatusColors,
+  type Category,
+  type ReportStatus,
+} from "@/lib/constants";
+
+interface HazardReport {
+  id: string;
+  category: Category | null;
+  description: string;
+  location: string;
+  city?: string | null;
+  status: ReportStatus | null;
+  adminNotes?: string | null;
+  owner?: string | null;
+  createdAt?: string;
+}
+
+export default function ReportsPage() {
+  const [reports, setReports] = useState<HazardReport[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [selectedReport, setSelectedReport] = useState<HazardReport | null>(
+    null,
+  );
+  const [adminNotes, setAdminNotes] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchReports = async () => {
+    try {
+      setIsLoading(true);
+      const client = generateClient<Schema>();
+      const { data, errors } = await client.models.HazardReport.list();
+
+      if (errors) {
+        console.error("Error fetching reports:", errors);
+        toast.error("Failed to fetch reports");
+        return;
+      }
+
+      // Sort by creation date, newest first
+      const sortedData = (data || []).sort((a, b) => {
+        const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return dateB - dateA;
+      });
+
+      setReports(sortedData as unknown as HazardReport[]);
+    } catch (error) {
+      console.error("Error fetching reports:", error);
+      toast.error("Failed to fetch reports");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReports();
+  }, []);
+
+  const filteredReports = reports.filter((report) => {
+    if (statusFilter !== "all" && report.status !== statusFilter) return false;
+    if (categoryFilter !== "all" && report.category !== categoryFilter)
+      return false;
+    return true;
+  });
+
+  const openReportDialog = (report: HazardReport) => {
+    setSelectedReport(report);
+    setAdminNotes(report.adminNotes || "");
+  };
+
+  const updateReportStatus = async (newStatus: ReportStatus) => {
+    if (!selectedReport) return;
+
+    setIsSaving(true);
+    try {
+      const client = generateClient<Schema>();
+      await client.models.HazardReport.update({
+        id: selectedReport.id,
+        status: newStatus,
+        adminNotes: adminNotes || null,
+      });
+
+      toast.success(`Report marked as ${newStatus}`);
+      setSelectedReport(null);
+      fetchReports();
+    } catch (error) {
+      console.error("Error updating report:", error);
+      toast.error("Failed to update report");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const pendingCount = reports.filter((r) => r.status === "pending").length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Hazard Reports</h1>
+        <p className="text-muted-foreground">
+          Review and moderate user-submitted hazard reports
+        </p>
+      </div>
+
+      {pendingCount > 0 && (
+        <div className="flex items-center gap-2 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <AlertTriangle className="h-5 w-5 text-yellow-600" />
+          <span className="text-yellow-800">
+            {pendingCount} report{pendingCount !== 1 ? "s" : ""} awaiting review
+          </span>
+        </div>
+      )}
+
+      <div className="flex gap-4">
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Statuses</SelectItem>
+            {REPORT_STATUS_OPTIONS.map((status) => (
+              <SelectItem key={status} value={status}>
+                {status.charAt(0).toUpperCase() + status.slice(1)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All categories" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Categories</SelectItem>
+            {CATEGORIES.map((category) => (
+              <SelectItem key={category} value={category}>
+                {category.charAt(0).toUpperCase() + category.slice(1)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Reports</CardTitle>
+          <CardDescription>
+            {filteredReports.length} report
+            {filteredReports.length !== 1 ? "s" : ""}{" "}
+            {statusFilter !== "all" || categoryFilter !== "all"
+              ? "(filtered)"
+              : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredReports.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No reports match your filters.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Location</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredReports.map((report) => (
+                  <TableRow key={report.id}>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={
+                          report.category ? categoryColors[report.category] : ""
+                        }
+                      >
+                        {report.category}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-xs truncate">
+                      {report.description}
+                    </TableCell>
+                    <TableCell>
+                      <div>
+                        <div className="truncate max-w-32">
+                          {report.location}
+                        </div>
+                        {report.city && (
+                          <div className="text-xs text-muted-foreground">
+                            {report.city}
+                          </div>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={
+                          reportStatusColors[report.status || "pending"]
+                        }
+                      >
+                        {report.status || "pending"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {report.createdAt
+                        ? new Date(report.createdAt).toLocaleDateString()
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openReportDialog(report)}
+                      >
+                        <Eye className="mr-2 h-4 w-4" />
+                        View
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={!!selectedReport}
+        onOpenChange={() => setSelectedReport(null)}
+      >
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>Review Report</DialogTitle>
+            <DialogDescription>
+              Review this hazard report and update its status
+            </DialogDescription>
+          </DialogHeader>
+          {selectedReport && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-muted-foreground">Category</Label>
+                  <p className="mt-1">
+                    <Badge
+                      variant="secondary"
+                      className={
+                        selectedReport.category
+                          ? categoryColors[selectedReport.category]
+                          : ""
+                      }
+                    >
+                      {selectedReport.category}
+                    </Badge>
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-muted-foreground">
+                    Current Status
+                  </Label>
+                  <p className="mt-1">
+                    <Badge
+                      variant="secondary"
+                      className={
+                        reportStatusColors[selectedReport.status || "pending"]
+                      }
+                    >
+                      {selectedReport.status || "pending"}
+                    </Badge>
+                  </p>
+                </div>
+              </div>
+
+              <div>
+                <Label className="text-muted-foreground">Location</Label>
+                <p className="mt-1">{selectedReport.location}</p>
+                {selectedReport.city && (
+                  <p className="text-sm text-muted-foreground">
+                    City: {selectedReport.city}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Label className="text-muted-foreground">Description</Label>
+                <p className="mt-1 p-3 bg-muted rounded-md">
+                  {selectedReport.description}
+                </p>
+              </div>
+
+              <div>
+                <Label className="text-muted-foreground">Submitted</Label>
+                <p className="mt-1">
+                  {selectedReport.createdAt
+                    ? new Date(selectedReport.createdAt).toLocaleString()
+                    : "Unknown"}
+                </p>
+              </div>
+
+              <div>
+                <Label htmlFor="adminNotes">Admin Notes</Label>
+                <Input
+                  id="adminNotes"
+                  placeholder="Add internal notes about this report..."
+                  value={adminNotes}
+                  onChange={(e) => setAdminNotes(e.target.value)}
+                  className="mt-1"
+                />
+              </div>
+            </div>
+          )}
+          <DialogFooter className="flex-col sm:flex-row gap-2">
+            <Button
+              variant="outline"
+              onClick={() => updateReportStatus("reviewed")}
+              disabled={isSaving}
+            >
+              <Eye className="mr-2 h-4 w-4" />
+              Mark Reviewed
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => updateReportStatus("dismissed")}
+              disabled={isSaving}
+            >
+              <XCircle className="mr-2 h-4 w-4" />
+              Dismiss
+            </Button>
+            <Button
+              onClick={() => updateReportStatus("resolved")}
+              disabled={isSaving}
+            >
+              {isSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle className="mr-2 h-4 w-4" />
+              )}
+              Mark Resolved
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/measurements/[city]/page.tsx
+++ b/apps/admin/src/app/(admin)/measurements/[city]/page.tsx
@@ -1,0 +1,777 @@
+"use client";
+
+import { useEffect, useState, use, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Plus, Pencil, Trash2, Loader2, MapPin, Bell, Users } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+import { fetchAuthSession } from "aws-amplify/auth";
+import { toast } from "sonner";
+import {
+  statStatusColors,
+  type StatStatus,
+  contaminantCategoryNames,
+  contaminantCategoryColors,
+  type ContaminantCategory,
+} from "@/lib/constants";
+
+type LocationMeasurement = Schema["LocationMeasurement"]["type"];
+type Contaminant = Schema["Contaminant"]["type"];
+type ContaminantThreshold = Schema["ContaminantThreshold"]["type"];
+type UserSubscription = Schema["UserSubscription"]["type"];
+
+// Lambda function name for notifications
+const NOTIFICATIONS_LAMBDA_FUNCTION =
+  process.env.NEXT_PUBLIC_NOTIFICATIONS_LAMBDA || "process-notifications";
+
+type AlertLevel = "info" | "warning" | "danger";
+
+/**
+ * Calculate status based on measurement value and threshold
+ */
+function calculateStatus(
+  value: number,
+  threshold: ContaminantThreshold | undefined,
+  higherIsBad: boolean = true,
+): StatStatus {
+  if (!threshold || threshold.limitValue === null) {
+    return "safe";
+  }
+  if (threshold.status === "banned") {
+    return "danger";
+  }
+
+  const limit = threshold.limitValue!;
+  const warningRatio = threshold.warningRatio ?? 0.8;
+  const warningThreshold = limit * warningRatio;
+
+  if (higherIsBad) {
+    if (value >= limit) return "danger";
+    if (value >= warningThreshold) return "warning";
+    return "safe";
+  } else {
+    if (value <= limit) return "danger";
+    if (value <= warningThreshold) return "warning";
+    return "safe";
+  }
+}
+
+export default function LocationDetailPage({
+  params,
+}: {
+  params: Promise<{ city: string }>;
+}) {
+  const { city: locationId } = use(params);
+  const cityName = decodeURIComponent(locationId);
+  const router = useRouter();
+  const [measurements, setMeasurements] = useState<LocationMeasurement[]>([]);
+  const [contaminants, setContaminants] = useState<Contaminant[]>([]);
+  const [thresholds, setThresholds] = useState<ContaminantThreshold[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingMeasurement, setEditingMeasurement] =
+    useState<LocationMeasurement | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [formData, setFormData] = useState({
+    contaminantId: "",
+    value: "",
+    source: "",
+    sourceUrl: "",
+    notes: "",
+  });
+
+  // Alert dialog state
+  const [isAlertDialogOpen, setIsAlertDialogOpen] = useState(false);
+  const [alertLevel, setAlertLevel] = useState<AlertLevel>("warning");
+  const [customMessage, setCustomMessage] = useState("");
+  const [isSendingAlert, setIsSendingAlert] = useState(false);
+  const [subscribers, setSubscribers] = useState<UserSubscription[]>([]);
+  const [isLoadingSubscribers, setIsLoadingSubscribers] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const client = generateClient<Schema>();
+
+      const [measurementsResult, contaminantsResult, thresholdsResult] =
+        await Promise.all([
+          client.models.LocationMeasurement.listLocationMeasurementByCity({
+            city: cityName,
+          }),
+          client.models.Contaminant.list({ limit: 1000 }),
+          client.models.ContaminantThreshold.list({ limit: 1000 }),
+        ]);
+
+      setMeasurements(measurementsResult.data || []);
+      setContaminants(contaminantsResult.data || []);
+      setThresholds(thresholdsResult.data || []);
+    } catch (error) {
+      console.error("Error fetching data:", error);
+      toast.error("Failed to fetch data");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [cityName]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const getContaminant = (contaminantId: string) => {
+    return contaminants.find((c) => c.contaminantId === contaminantId);
+  };
+
+  const getThreshold = (contaminantId: string) => {
+    // Try WHO first, then US as fallback
+    return (
+      thresholds.find(
+        (t) =>
+          t.contaminantId === contaminantId && t.jurisdictionCode === "WHO",
+      ) ||
+      thresholds.find(
+        (t) => t.contaminantId === contaminantId && t.jurisdictionCode === "US",
+      )
+    );
+  };
+
+  const resetForm = () => {
+    setFormData({
+      contaminantId: "",
+      value: "",
+      source: "",
+      sourceUrl: "",
+      notes: "",
+    });
+    setEditingMeasurement(null);
+  };
+
+  const openCreateDialog = () => {
+    resetForm();
+    setIsDialogOpen(true);
+  };
+
+  const openEditDialog = (measurement: LocationMeasurement) => {
+    setEditingMeasurement(measurement);
+    setFormData({
+      contaminantId: measurement.contaminantId,
+      value: measurement.value.toString(),
+      source: measurement.source || "",
+      sourceUrl: measurement.sourceUrl || "",
+      notes: measurement.notes || "",
+    });
+    setIsDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!formData.contaminantId || !formData.value) {
+      toast.error("Please fill in all required fields");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const client = generateClient<Schema>();
+      const value = parseFloat(formData.value);
+      const now = new Date().toISOString();
+
+      // Inherit state/country from any existing measurement for this city,
+      // or from the row being edited. Schema (#123) requires `country`, so
+      // surface a clear error if neither is available rather than failing
+      // opaquely on create.
+      const reference = editingMeasurement ?? measurements[0];
+      if (!reference?.country) {
+        toast.error(
+          "Cannot infer country for this city — add a measurement via the import page first.",
+        );
+        setIsSaving(false);
+        return;
+      }
+      const measurementData = {
+        city: cityName,
+        state: reference.state ?? null,
+        country: reference.country,
+        contaminantId: formData.contaminantId,
+        value,
+        measuredAt: now,
+        source: formData.source || null,
+        sourceUrl: formData.sourceUrl || null,
+        notes: formData.notes || null,
+      };
+
+      if (editingMeasurement) {
+        await client.models.LocationMeasurement.update({
+          id: editingMeasurement.id,
+          ...measurementData,
+        });
+        toast.success("Measurement updated");
+      } else {
+        await client.models.LocationMeasurement.create(measurementData);
+        toast.success("Measurement created");
+      }
+
+      setIsDialogOpen(false);
+      resetForm();
+      fetchData();
+    } catch (error) {
+      console.error("Error saving measurement:", error);
+      toast.error("Failed to save measurement");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (measurement: LocationMeasurement) => {
+    const contaminant = getContaminant(measurement.contaminantId);
+    if (
+      !confirm(
+        `Are you sure you want to delete "${contaminant?.name || measurement.contaminantId}"?`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const client = generateClient<Schema>();
+      await client.models.LocationMeasurement.delete({ id: measurement.id });
+      toast.success("Measurement deleted");
+      fetchData();
+    } catch (error) {
+      console.error("Error deleting measurement:", error);
+      toast.error("Failed to delete measurement");
+    }
+  };
+
+  // Get available contaminants (not already added)
+  const availableContaminants = editingMeasurement
+    ? contaminants
+    : contaminants.filter(
+        (c) => !measurements.some((m) => m.contaminantId === c.contaminantId),
+      );
+
+  const fetchSubscribers = useCallback(async () => {
+    setIsLoadingSubscribers(true);
+    try {
+      const client = generateClient<Schema>();
+      const result = await client.models.UserSubscription.listUserSubscriptionByCity({
+        city: cityName,
+      });
+      setSubscribers(result.data || []);
+    } catch (error) {
+      console.error("Error fetching subscribers:", error);
+      toast.error("Failed to fetch subscribers");
+    } finally {
+      setIsLoadingSubscribers(false);
+    }
+  }, [cityName]);
+
+  const openAlertDialog = async () => {
+    setAlertLevel("warning");
+    setCustomMessage("");
+    setIsAlertDialogOpen(true);
+    await fetchSubscribers();
+  };
+
+  const sendManualAlert = async () => {
+    if (subscribers.length === 0) {
+      toast.error("No subscribers to notify");
+      return;
+    }
+
+    setIsSendingAlert(true);
+    try {
+      const session = await fetchAuthSession();
+      const credentials = session.credentials;
+
+      if (!credentials) {
+        toast.error("Not authenticated");
+        return;
+      }
+
+      const lambdaClient = new LambdaClient({
+        region: "ca-central-1",
+        credentials: {
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey,
+          sessionToken: credentials.sessionToken,
+        },
+      });
+
+      const command = new InvokeCommand({
+        FunctionName: NOTIFICATIONS_LAMBDA_FUNCTION,
+        InvocationType: "RequestResponse",
+        Payload: Buffer.from(
+          JSON.stringify({
+            city: cityName,
+            triggerType: "manual_alert",
+            adminTriggered: true,
+            alertLevel,
+            customMessage: customMessage || undefined,
+          }),
+        ),
+      });
+
+      const response = await lambdaClient.send(command);
+
+      if (response.Payload) {
+        const result = JSON.parse(Buffer.from(response.Payload).toString());
+        if (result.success) {
+          toast.success(
+            `Alert sent to ${result.subscribersNotified} subscriber(s)`,
+          );
+          setIsAlertDialogOpen(false);
+        } else {
+          toast.error(result.errors?.[0] || "Failed to send alert");
+        }
+      }
+    } catch (error) {
+      console.error("Error sending alert:", error);
+      toast.error("Failed to send alert");
+    } finally {
+      setIsSendingAlert(false);
+    }
+  };
+
+  // Count subscribers by notification type
+  const subscriberStats = {
+    total: subscribers.length,
+    email: subscribers.filter((s) => s.enableEmail).length,
+    push: subscribers.filter((s) => s.enablePush).length,
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => router.push("/measurements")}
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <div className="flex items-center gap-2">
+              <MapPin className="h-5 w-5 text-muted-foreground" />
+              <h1 className="text-3xl font-bold tracking-tight">{cityName}</h1>
+            </div>
+            <p className="text-muted-foreground">
+              Manage contaminant measurements for this location
+            </p>
+          </div>
+        </div>
+        <Button onClick={openAlertDialog} variant="outline">
+          <Bell className="mr-2 h-4 w-4" />
+          Send Alert
+        </Button>
+      </div>
+
+      {/* Send Alert Dialog */}
+      <Dialog open={isAlertDialogOpen} onOpenChange={setIsAlertDialogOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle>Send Manual Alert</DialogTitle>
+            <DialogDescription>
+              Send a notification to all subscribers of {cityName}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="space-y-2">
+              <Label>Alert Level</Label>
+              <Select
+                value={alertLevel}
+                onValueChange={(value: AlertLevel) => setAlertLevel(value)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="danger">
+                    <span className="flex items-center gap-2">
+                      <Badge variant="destructive">Danger</Badge>
+                      <span className="text-muted-foreground">- Critical issue requiring immediate attention</span>
+                    </span>
+                  </SelectItem>
+                  <SelectItem value="warning">
+                    <span className="flex items-center gap-2">
+                      <Badge className="bg-yellow-500">Warning</Badge>
+                      <span className="text-muted-foreground">- Caution advised</span>
+                    </span>
+                  </SelectItem>
+                  <SelectItem value="info">
+                    <span className="flex items-center gap-2">
+                      <Badge variant="secondary">Info</Badge>
+                      <span className="text-muted-foreground">- General notice</span>
+                    </span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="customMessage">Custom Message (optional)</Label>
+              <Textarea
+                id="customMessage"
+                placeholder="Enter a custom message for the alert..."
+                value={customMessage}
+                onChange={(e) => setCustomMessage(e.target.value)}
+                rows={3}
+              />
+              <p className="text-xs text-muted-foreground">
+                If left empty, a default message will be used.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Subscribers Preview</Label>
+              <Card>
+                <CardContent className="pt-4">
+                  {isLoadingSubscribers ? (
+                    <div className="flex items-center justify-center py-4">
+                      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : subscribers.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-2">
+                      No subscribers for this location
+                    </p>
+                  ) : (
+                    <div className="flex items-center gap-6">
+                      <div className="flex items-center gap-2">
+                        <Users className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{subscriberStats.total}</span>
+                        <span className="text-muted-foreground">total</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">{subscriberStats.push} push</Badge>
+                        <Badge variant="outline">{subscriberStats.email} email</Badge>
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setIsAlertDialogOpen(false)}
+              disabled={isSendingAlert}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={sendManualAlert}
+              disabled={isSendingAlert || subscribers.length === 0}
+            >
+              {isSendingAlert ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                <>
+                  <Bell className="mr-2 h-4 w-4" />
+                  Send Alert
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Measurements</CardTitle>
+            <CardDescription>
+              {measurements.length} measurement
+              {measurements.length !== 1 ? "s" : ""} for this location
+            </CardDescription>
+          </div>
+          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+            <Button
+              onClick={openCreateDialog}
+              disabled={availableContaminants.length === 0}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Add Measurement
+            </Button>
+            <DialogContent className="sm:max-w-[500px]">
+              <DialogHeader>
+                <DialogTitle>
+                  {editingMeasurement ? "Edit Measurement" : "Add Measurement"}
+                </DialogTitle>
+                <DialogDescription>
+                  {editingMeasurement
+                    ? "Update the measurement value for this location."
+                    : "Add a new contaminant measurement for this location."}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4">
+                <div className="space-y-2">
+                  <Label htmlFor="contaminantId">Contaminant *</Label>
+                  <Select
+                    value={formData.contaminantId}
+                    onValueChange={(value) =>
+                      setFormData({ ...formData, contaminantId: value })
+                    }
+                    disabled={!!editingMeasurement}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a contaminant" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableContaminants.map((c) => (
+                        <SelectItem
+                          key={c.contaminantId}
+                          value={c.contaminantId}
+                        >
+                          {c.name} ({c.unit})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="value">Value *</Label>
+                  <Input
+                    id="value"
+                    type="number"
+                    step="any"
+                    placeholder="Enter measured value"
+                    value={formData.value}
+                    onChange={(e) =>
+                      setFormData({ ...formData, value: e.target.value })
+                    }
+                  />
+                  {formData.contaminantId && formData.value && (
+                    <p className="text-sm text-muted-foreground">
+                      Status will be:{" "}
+                      <Badge
+                        variant="secondary"
+                        className={
+                          statStatusColors[
+                            calculateStatus(
+                              parseFloat(formData.value),
+                              getThreshold(formData.contaminantId),
+                              getContaminant(formData.contaminantId)
+                                ?.higherIsBad ?? true,
+                            )
+                          ]
+                        }
+                      >
+                        {calculateStatus(
+                          parseFloat(formData.value),
+                          getThreshold(formData.contaminantId),
+                          getContaminant(formData.contaminantId)?.higherIsBad ??
+                            true,
+                        )}
+                      </Badge>
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="source">Data Source</Label>
+                  <Input
+                    id="source"
+                    placeholder="e.g., EPA, CDC, Local Health Dept"
+                    value={formData.source}
+                    onChange={(e) =>
+                      setFormData({ ...formData, source: e.target.value })
+                    }
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="sourceUrl">Source URL</Label>
+                  <Input
+                    id="sourceUrl"
+                    type="url"
+                    placeholder="https://..."
+                    value={formData.sourceUrl}
+                    onChange={(e) =>
+                      setFormData({ ...formData, sourceUrl: e.target.value })
+                    }
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="notes">Notes</Label>
+                  <Input
+                    id="notes"
+                    placeholder="Additional notes..."
+                    value={formData.notes}
+                    onChange={(e) =>
+                      setFormData({ ...formData, notes: e.target.value })
+                    }
+                  />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsDialogOpen(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : editingMeasurement ? (
+                    "Update"
+                  ) : (
+                    "Add"
+                  )}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : measurements.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No measurements for this location yet. Click &quot;Add
+              Measurement&quot; to add one.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Contaminant</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead title="Where the measurement data was obtained — not the regulatory standard">
+                    Data Source
+                  </TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {measurements.map((measurement) => {
+                  const contaminant = getContaminant(measurement.contaminantId);
+                  const threshold = getThreshold(measurement.contaminantId);
+                  const status = calculateStatus(
+                    measurement.value,
+                    threshold,
+                    contaminant?.higherIsBad ?? true,
+                  );
+
+                  return (
+                    <TableRow key={measurement.id}>
+                      <TableCell className="font-medium">
+                        {contaminant?.name || measurement.contaminantId}
+                      </TableCell>
+                      <TableCell>
+                        {contaminant?.category && (
+                          <Badge
+                            variant="secondary"
+                            className={
+                              contaminantCategoryColors[
+                                contaminant.category as ContaminantCategory
+                              ]
+                            }
+                          >
+                            {
+                              contaminantCategoryNames[
+                                contaminant.category as ContaminantCategory
+                              ]
+                            }
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {measurement.value} {contaminant?.unit}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="secondary"
+                          className={statStatusColors[status]}
+                        >
+                          {status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{measurement.source || "—"}</TableCell>
+                      <TableCell>
+                        {measurement.measuredAt
+                          ? new Date(
+                              measurement.measuredAt,
+                            ).toLocaleDateString()
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => openEditDialog(measurement)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDelete(measurement)}
+                          >
+                            <Trash2 className="h-4 w-4 text-red-500" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/measurements/page.tsx
+++ b/apps/admin/src/app/(admin)/measurements/page.tsx
@@ -1,0 +1,527 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Search, MapPin, Loader2, Plus } from "lucide-react";
+import { statStatusColors, type StatStatus } from "@/lib/constants";
+
+type LocationMeasurement = Schema["LocationMeasurement"]["type"];
+type ContaminantThreshold = Schema["ContaminantThreshold"]["type"];
+type Contaminant = Schema["Contaminant"]["type"];
+
+// Aggregation results, one per scope. The cascade introduced in #278
+// allows a `LocationMeasurement` to be anchored at city, state, or
+// country level (city/state nullable, country required). The admin
+// page surfaces all three via separate sections so admins can verify
+// what data lives at each scope without a DynamoDB scan.
+interface LocationStats {
+  city: string;
+  state: string;
+  measurementCount: number;
+  worstStatus: StatStatus;
+  lastUpdated: string;
+}
+
+interface StateStats {
+  state: string;
+  country: string;
+  measurementCount: number;
+  worstStatus: StatStatus;
+  lastUpdated: string;
+}
+
+interface CountryStats {
+  country: string;
+  measurementCount: number;
+  worstStatus: StatStatus;
+  lastUpdated: string;
+}
+
+/**
+ * Calculate status based on measurement value and threshold
+ */
+function calculateStatus(
+  value: number,
+  threshold: ContaminantThreshold | undefined,
+  higherIsBad: boolean = true,
+): StatStatus {
+  if (!threshold || threshold.limitValue === null) {
+    return "safe";
+  }
+  if (threshold.status === "banned") {
+    return "danger";
+  }
+
+  const limit = threshold.limitValue!;
+  const warningRatio = threshold.warningRatio ?? 0.8;
+  const warningThreshold = limit * warningRatio;
+
+  if (higherIsBad) {
+    if (value >= limit) return "danger";
+    if (value >= warningThreshold) return "warning";
+    return "safe";
+  } else {
+    if (value <= limit) return "danger";
+    if (value <= warningThreshold) return "warning";
+    return "safe";
+  }
+}
+
+/**
+ * Shared aggregator: contributes one measurement to a running aggregate.
+ * Mutates and returns the aggregate so callers can use the
+ * `map.set(key, contribute(map.get(key) ?? init, m))` idiom in three
+ * scope-specific loops without three copies of the same code.
+ */
+function contributeMeasurement<
+  T extends {
+    measurementCount: number;
+    worstStatus: StatStatus;
+    lastUpdated: string;
+  },
+>(
+  agg: T,
+  measurement: LocationMeasurement,
+  thresholdMap: Map<string, ContaminantThreshold>,
+  contaminantMap: Map<string, Contaminant>,
+): T {
+  agg.measurementCount += 1;
+
+  const threshold =
+    thresholdMap.get(`${measurement.contaminantId}:WHO`) ||
+    thresholdMap.get(`${measurement.contaminantId}:US`);
+  const contaminant = contaminantMap.get(measurement.contaminantId);
+  const higherIsBad = contaminant?.higherIsBad ?? true;
+  const status = calculateStatus(measurement.value, threshold, higherIsBad);
+
+  if (status === "danger") {
+    agg.worstStatus = "danger";
+  } else if (status === "warning" && agg.worstStatus !== "danger") {
+    agg.worstStatus = "warning";
+  }
+
+  const measurementDate = new Date(measurement.measuredAt ?? 0);
+  const existingDate = new Date(agg.lastUpdated);
+  if (measurementDate > existingDate) {
+    agg.lastUpdated = measurement.measuredAt ?? agg.lastUpdated;
+  }
+
+  return agg;
+}
+
+export default function ZipCodesPage() {
+  const router = useRouter();
+  const [locationStats, setLocationStats] = useState<LocationStats[]>([]);
+  const [stateStats, setStateStats] = useState<StateStats[]>([]);
+  const [countryStats, setCountryStats] = useState<CountryStats[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [newCity, setNewCity] = useState("");
+
+  const fetchData = async () => {
+    try {
+      setIsLoading(true);
+      const client = generateClient<Schema>();
+
+      // Fetch measurements, thresholds, and contaminants in parallel
+      const [measurementsResult, thresholdsResult, contaminantsResult] =
+        await Promise.all([
+          client.models.LocationMeasurement.list({ limit: 1000 }),
+          client.models.ContaminantThreshold.list({ limit: 1000 }),
+          client.models.Contaminant.list({ limit: 1000 }),
+        ]);
+
+      if (measurementsResult.errors) {
+        console.error(
+          "Error fetching measurements:",
+          measurementsResult.errors,
+        );
+        return;
+      }
+
+      const measurements = measurementsResult.data || [];
+      const thresholds = thresholdsResult.data || [];
+      const contaminants = contaminantsResult.data || [];
+
+      // Create lookup maps
+      const thresholdMap = new Map<string, ContaminantThreshold>();
+      for (const t of thresholds) {
+        thresholdMap.set(`${t.contaminantId}:${t.jurisdictionCode}`, t);
+      }
+
+      const contaminantMap = new Map<string, Contaminant>();
+      for (const c of contaminants) {
+        contaminantMap.set(c.contaminantId, c);
+      }
+
+      // Aggregate measurements into three Maps keyed by anchor scope.
+      // Classification mirrors the cascade lambda's deriveScope at
+      // packages/backend/amplify/functions/on-location-measurement-update/handler.ts
+      // — city wins, then state, then country. country is required by the
+      // schema so the else-branch is always reachable when a row has no
+      // city/state. Rows missing all three are dropped defensively.
+      const cityMap = new Map<string, LocationStats>();
+      const stateMapAgg = new Map<string, StateStats>();
+      const countryMapAgg = new Map<string, CountryStats>();
+
+      for (const m of measurements) {
+        if (!m.country) continue;
+        const fallbackTimestamp = m.measuredAt ?? new Date().toISOString();
+
+        if (m.city) {
+          const key = `${m.city}|${m.state ?? ""}`;
+          const init: LocationStats = cityMap.get(key) ?? {
+            city: m.city,
+            state: m.state ?? "",
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          cityMap.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
+        } else if (m.state) {
+          const key = `${m.state}|${m.country}`;
+          const init: StateStats = stateMapAgg.get(key) ?? {
+            state: m.state,
+            country: m.country,
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          stateMapAgg.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
+        } else {
+          const key = m.country;
+          const init: CountryStats = countryMapAgg.get(key) ?? {
+            country: m.country,
+            measurementCount: 0,
+            worstStatus: "safe",
+            lastUpdated: fallbackTimestamp,
+          };
+          countryMapAgg.set(
+            key,
+            contributeMeasurement(init, m, thresholdMap, contaminantMap),
+          );
+        }
+      }
+
+      const cityResult = Array.from(cityMap.values()).sort((a, b) =>
+        `${a.city}, ${a.state}`.localeCompare(`${b.city}, ${b.state}`),
+      );
+      const stateResult = Array.from(stateMapAgg.values()).sort((a, b) =>
+        `${a.state}, ${a.country}`.localeCompare(`${b.state}, ${b.country}`),
+      );
+      const countryResult = Array.from(countryMapAgg.values()).sort((a, b) =>
+        a.country.localeCompare(b.country),
+      );
+
+      setLocationStats(cityResult);
+      setStateStats(stateResult);
+      setCountryStats(countryResult);
+    } catch (error) {
+      console.error("Error fetching data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // Each section gets its own filter so a single search box matches
+  // across all three: typing "QC" surfaces Boucherville/Montreal in the
+  // city section AND the QC row in the state section; "CA" matches
+  // Canadian cities AND the country-wide row.
+  const lowerQuery = searchQuery.toLowerCase();
+  const filteredLocations = locationStats.filter((loc) =>
+    `${loc.city}, ${loc.state}`.toLowerCase().includes(lowerQuery),
+  );
+  const filteredStateStats = stateStats.filter((s) =>
+    `${s.state}, ${s.country}`.toLowerCase().includes(lowerQuery),
+  );
+  const filteredCountryStats = countryStats.filter((c) =>
+    c.country.toLowerCase().includes(lowerQuery),
+  );
+
+  const handleAddLocation = () => {
+    if (newCity.trim()) {
+      router.push(`/measurements/${encodeURIComponent(newCity.trim())}`);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">
+          Location Measurements
+        </h1>
+        <p className="text-muted-foreground">
+          View and manage contaminant measurements by city, state/province, or
+          country
+        </p>
+      </div>
+
+      <div className="flex gap-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search city, state, or country..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+        <div className="flex gap-2">
+          <Input
+            placeholder="New city"
+            value={newCity}
+            onChange={(e) => setNewCity(e.target.value)}
+            className="w-40"
+          />
+          <Button onClick={handleAddLocation} disabled={!newCity.trim()}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By city</CardTitle>
+          <CardDescription>
+            {filteredLocations.length} cit
+            {filteredLocations.length !== 1 ? "ies" : "y"}{" "}
+            with measurements anchored at city level
+            {searchQuery && filteredLocations.length !== locationStats.length
+              ? ` (of ${locationStats.length} total)`
+              : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredLocations.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No cities match your search."
+                : "No city-anchored measurement data yet. Add a location to get started."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>City</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Measurements</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredLocations.map((location) => (
+                  <TableRow key={`${location.city}-${location.state}`}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{location.city}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{location.state}</TableCell>
+                    <TableCell>
+                      {location.measurementCount} measurement
+                      {location.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={statStatusColors[location.worstStatus]}
+                      >
+                        {location.worstStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(location.lastUpdated).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          router.push(
+                            `/measurements/${encodeURIComponent(location.city)}`,
+                          )
+                        }
+                      >
+                        Manage
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By state / province</CardTitle>
+          <CardDescription>
+            {filteredStateStats.length} state-wide record
+            {filteredStateStats.length !== 1 ? "s" : ""} — apply to every city
+            in the state without its own data (#123 cascade fallback)
+            {searchQuery && filteredStateStats.length !== stateStats.length
+              ? ` (of ${stateStats.length} total)`
+              : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredStateStats.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No state-wide records match your search."
+                : "No state-anchored measurements yet. Use the Import page and leave the city column blank to add one."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>State / Province</TableHead>
+                  <TableHead>Country</TableHead>
+                  <TableHead>Measurements</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredStateStats.map((s) => (
+                  <TableRow key={`${s.state}-${s.country}`}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{s.state}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{s.country}</TableCell>
+                    <TableCell>
+                      {s.measurementCount} measurement
+                      {s.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={statStatusColors[s.worstStatus]}
+                      >
+                        {s.worstStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(s.lastUpdated).toLocaleDateString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By country</CardTitle>
+          <CardDescription>
+            {filteredCountryStats.length} country-wide record
+            {filteredCountryStats.length !== 1 ? "s" : ""} — apply to every city
+            in the country without its own (or its state&apos;s) data
+            {searchQuery && filteredCountryStats.length !== countryStats.length
+              ? ` (of ${countryStats.length} total)`
+              : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredCountryStats.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {searchQuery
+                ? "No country-wide records match your search."
+                : "No country-anchored measurements yet. Use the Import page and leave the city + state columns blank to add one."}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Country</TableHead>
+                  <TableHead>Measurements</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredCountryStats.map((c) => (
+                  <TableRow key={c.country}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4 text-muted-foreground" />
+                        <span className="font-medium">{c.country}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {c.measurementCount} measurement
+                      {c.measurementCount !== 1 ? "s" : ""}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={statStatusColors[c.worstStatus]}
+                      >
+                        {c.worstStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Date(c.lastUpdated).toLocaleDateString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds the three admin route directories that were sitting untracked locally but referenced by the sidebar on `staging`, so each link landed on a Next.js 404.
- Includes a Playwright smoke test (`apps/admin/e2e/admin/admin-route-smoke.spec.ts`) that hits each route and asserts the primary heading renders — regression guard for the same kind of half-merged refactor recurring.
- Scoped strictly to additions: orphan deletions (`reports/`, `stats/`, `testing/`, `zip-codes/`) on the local feat branch are out of scope here and left for a follow-up.

Closes #354 — reported by Rayane in his 2026-05-15 QA review (issues #353-357).

## Verification on staging (after merge)
- [ ] https://staging.d26q32gc98goap.amplifyapp.com/measurements loads and shows "Location Measurements".
- [ ] https://staging.d26q32gc98goap.amplifyapp.com/hazard-reports loads and shows "Hazard Reports".
- [ ] https://staging.d26q32gc98goap.amplifyapp.com/contaminants loads and shows "Contaminants".
- [ ] The Playwright smoke `admin-route-smoke.spec.ts` passes against staging when `ADMIN_TEST_EMAIL` / `ADMIN_TEST_PASSWORD` env vars are configured.

## Local checks
- `npx tsc --noEmit` clean.
- `npm run lint` clean (5 pre-existing warnings on unrelated files, no new errors).
- `npx playwright test --list e2e/admin/admin-route-smoke.spec.ts` enumerates 3 tests as expected.

## Test plan
- [x] Type check + lint pass locally.
- [ ] CI runs `lint`, `type-check`, `playwright-tests` green.
- [ ] Manual verification on staging admin per the URLs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)