### PR TITLE
fix(backend): send Cognito verification emails via SES (#353)

### DIFF
--- a/packages/backend/amplify/backend.ts
+++ b/packages/backend/amplify/backend.ts
@@ -128,6 +128,19 @@ locationMeasurementStreamMapping.node.addDependency(onLocationMeasurementStreamP
 const userPoolId = backend.auth.resources.userPool.userPoolId;
 const authStack = Stack.of(backend.auth.resources.userPool);
 
+// Switch the Cognito user pool to send verification / recovery emails via SES
+// instead of the default Cognito sender. The default sender is capped at 50
+// emails/day pool-wide, which silently drops recovery codes (#353). The
+// matching SES identity policy authorising this user pool to send via
+// mapyourhealth.info is applied to the SES identity out-of-band (one-time).
+const { cfnUserPool } = backend.auth.resources.cfnResources;
+cfnUserPool.emailConfiguration = {
+  emailSendingAccount: 'DEVELOPER',
+  sourceArn: `arn:aws:ses:${authStack.region}:${authStack.account}:identity/mapyourhealth.info`,
+  from: 'MapYourHealth <noreply@mapyourhealth.info>',
+  replyToEmailAddress: 'contact@mapyourhealth.info',
+};
+
 // Create DynamoDB table for rate limiting magic link requests
 const rateLimitTable = new Table(authStack, 'MagicLinkRateLimitTable', {
   tableName: `MagicLinkRateLimit-${authStack.stackName}`,


### PR DESCRIPTION
## Summary
- Switches the staging Cognito user pool from `COGNITO_DEFAULT` (50 emails/day hard cap, poor deliverability) to `DEVELOPER` mode using the already-verified `mapyourhealth.info` SES domain identity.
- Companion to issue #353 — the Cognito half of the fix. Rayane's recovery code email never arrived because the default sender silently dropped above its quota.

## Why this is safe
- The `mapyourhealth.info` SES identity already has DKIM enabled and verification `Success`.
- SES in `ca-central-1` is still in sandbox, but a verified **domain** identity covers any address `@mapyourhealth.info` as a recipient — so Rayane (and the seed admin) keep receiving mail without waiting on production-access approval.
- A strictly-scoped SESv2 identity policy (`CognitoStagingSESSender`) has been put on the SES identity out-of-band, allowing only the staging user pool ARN (`arn:aws:cognito-idp:ca-central-1:741448949873:userpool/ca-central-1_tPykL7wal`) to send via this identity, conditioned on `aws:SourceAccount` + `aws:SourceArn`. That policy survives across backend redeploys.
- Backend `npx tsc --noEmit` passes locally.

## What this does NOT do
- Does **not** fix the magic-link `NetworkError` half of #353 — that's a separate mobile-side hardcoded URL issue, planned as a follow-up PR.
- Does **not** touch the production Cognito pool (`ca-central-1_YJw20H7Xt`). When this is promoted `staging → main`, the same CDK config will apply to prod automatically, and we'll need to put an analogous SES identity policy for that pool ARN before the prod backend deploys.

## Verification on staging (after Amplify backend redeploys)
- [ ] In the Cognito console, the staging pool's *Messaging* tab shows email sending via `noreply@mapyourhealth.info` (SES).
- [ ] Trigger a password reset on `rayane@mapyourhealth.info` from the staging admin / mobile web. The verification-code email arrives in his inbox (check SES `Sent` metric).
- [ ] No regression on signup-confirmation emails for new test users.

## Before promoting to `main`
- [ ] Apply an analogous SESv2 identity policy authorising the prod user pool ARN (`ca-central-1_YJw20H7Xt`) — repeat the `put-email-identity-policy` step with that ARN.

Refs #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)