### PR TITLE
ci(e2e): switch mobile E2E gate from iOS to Android

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -1,0 +1,186 @@
+name: Android E2E Tests
+
+# Tiered triggers (mirrors the prior iOS workflow, see #364 + #365):
+#   - pull_request touching apps/mobile/** → smoke suite (E2E-100/101/102), ~12-15 min wall
+#   - push to main                          → full suite (every flow under .maestro/flows/), ~25 min wall, informational
+#   - workflow_dispatch                     → caller picks the suite via the `suite` input
+#
+# Switched from iOS to Android in <follow-up PR> for cost: macOS runners
+# are 10× billable on private repos, ubuntu-latest is 1×. The Maestro
+# flows are platform-agnostic (same appId, percentage-based taps) so
+# Android coverage exercises the same code paths at ~1/10 the runner
+# cost. iOS still has a workflow_dispatch-only entry point in
+# .github/workflows/e2e-ios.yml for occasional manual verification.
+on:
+  pull_request:
+    branches: [staging, main]
+    paths:
+      - 'apps/mobile/**'
+      - '.github/workflows/e2e-android.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - '.github/workflows/e2e-android.yml'
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Test suite to run (smoke | core | full)
+        required: false
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - core
+          - full
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  MAESTRO_DRIVER_STARTUP_TIMEOUT: 240000
+
+jobs:
+  android-e2e:
+    name: Android E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Java (for Maestro + Gradle)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            node_modules
+            apps/mobile/node_modules
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-android-deps-${{ hashFiles('**/yarn.lock', '**/build.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      # apps/mobile/app/app.tsx imports `amplify_outputs.json` and defaults
+      # to it (the "prod" path). On real prod, the AppConfig "comingSoon"
+      # gate is ENABLED, which renders <ComingSoonScreen /> instead of
+      # the Dashboard — smoke flows assert dashboard strings and fail.
+      # Fetch outputs from the STAGING backend instead.
+      - name: Generate Amplify outputs (staging backend, written as the default amplify_outputs.json)
+        run: |
+          npx ampx generate outputs \
+            --branch staging \
+            --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
+            --out-dir apps/mobile
+
+      # `eas build --local` honors .gitignore when packaging the project
+      # archive, so the just-generated amplify_outputs.json would be
+      # excluded (it's gitignored everywhere). Drop the rule for this
+      # CI checkout so EAS includes the file.
+      - name: Unignore amplify_outputs.json for EAS pack
+        run: sed -i.bak '/^amplify_outputs\.json$/d' .gitignore && rm .gitignore.bak
+
+      - name: Setup EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Build Android APK
+        working-directory: apps/mobile
+        run: |
+          mkdir -p ./build
+          eas build --profile e2e --platform android --local --non-interactive --output ./build/MapYourHealth.apk
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      # Pick the suite glob from the trigger (same as the iOS workflow):
+      #   pull_request    → smoke (E2E-100/101/102)
+      #   push to main    → full (.maestro/flows/)
+      #   workflow_dispatch → suite input (smoke | core | full)
+      - name: Determine suite
+        id: suite
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request)   SUITE="smoke" ;;
+            push)           SUITE="full" ;;
+            workflow_dispatch) SUITE="${{ inputs.suite }}" ;;
+            *)              SUITE="smoke" ;;
+          esac
+          case "$SUITE" in
+            smoke) GLOB=".maestro/flows/E2E-10*.yaml" ;;
+            core)  GLOB=".maestro/flows/E2E-0*.yaml .maestro/flows/E2E-10*.yaml" ;;
+            full|*) GLOB=".maestro/flows" ;;
+          esac
+          echo "suite=$SUITE" >> "$GITHUB_OUTPUT"
+          echo "glob=$GLOB" >> "$GITHUB_OUTPUT"
+          echo "Running suite: $SUITE → $GLOB"
+
+      # KVM enablement so the AVD runs with hardware acceleration (10×+
+      # faster boot/test). ubuntu-latest has nested virt enabled by
+      # default but we still need to set up the device permission.
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-pixel6-api33-${{ runner.os }}
+
+      - name: Create AVD + run Maestro suite
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            adb wait-for-device
+            adb install -r ./apps/mobile/build/MapYourHealth.apk
+            $HOME/.maestro/bin/maestro test ${{ steps.suite.outputs.glob }} \
+              --env MAESTRO_APP_ID=com.epiphanyapps.mapyourhealth
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-results-${{ steps.suite.outputs.suite }}
+          path: ~/.maestro/tests
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -1,24 +1,14 @@
-name: iOS E2E Tests
+name: iOS E2E Tests (manual)
 
-# Tiered triggers (see docs/e2e-ci-review-2026-05-16.md + the CI plan):
-#   - pull_request touching apps/mobile/** → smoke suite (E2E-100/101/102), ~10 min wall
-#   - push to main                          → full suite (every flow under .maestro/flows/), ~30 min wall, informational
-#   - workflow_dispatch                     → caller picks the suite via the `suite` input
+# Manual-only after the Android switch. macos-15 runners are 10× billable
+# on private repos vs. 1× for ubuntu-latest; Maestro flows are platform-
+# agnostic so Android coverage in e2e-android.yml exercises the same
+# code paths at ~1/10 the cost. iOS regression is caught by manual
+# testing on the maintainer's iPhone.
 #
-# Path filter keeps non-mobile PRs from spinning up the (~10 min) macOS
-# runner. Workflow self-changes (this file) trigger the run too so flips
-# to the config don't go untested.
+# Run this manually via `gh workflow run e2e-ios.yml -f suite=smoke` (or
+# core/full) when you need to verify something on iOS specifically.
 on:
-  pull_request:
-    branches: [staging, main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-ios.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mobile/**'
-      - '.github/workflows/e2e-ios.yml'
   workflow_dispatch:
     inputs:
       suite:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,22 +408,24 @@ GitHub Actions workflows in `.github/workflows/`:
 | `admin-deploy.yml` | Push to `main` or `staging` | Deploy admin dashboard |
 | `mobile-deploy.yml` | Push to `main` or `staging` | Deploy mobile web |
 | `web-deploy.yml` | Push to `main` or `staging` | Deploy web landing page |
-| `e2e-ios.yml` | PR (smoke), push to main (full), manual | iOS Maestro E2E tests — tiered suite |
+| `e2e-android.yml` | PR (smoke), push to main (full), manual | Android Maestro E2E tests — tiered suite (primary mobile gate) |
+| `e2e-ios.yml` | Manual only | iOS Maestro E2E tests — `workflow_dispatch` only, not gating |
 | `playwright-tests.yml` | PR + push to main on admin/backend paths, manual | Admin Playwright tests |
 
 ### E2E strategy (tiered)
 
-Two surviving E2E workflows after the 2026-05-16 audit (`docs/e2e-ci-review-2026-05-16.md`). The previously dormant `e2e-tests.yml`, `e2e-orchestrated.yml`, `e2e-orchestration.yml` were deleted as 940+ lines of duplicate plumbing nobody ran.
+Three surviving E2E workflows after the audits in `docs/e2e-ci-review-2026-05-16.md` (previously dormant `e2e-tests.yml` / `e2e-orchestrated.yml` / `e2e-orchestration.yml` were deleted as 940+ lines of duplicate plumbing nobody ran). Android replaced iOS as the primary mobile gate for cost: `ubuntu-latest` (1×) vs `macos-15` (10×) on private repos, and the Maestro flows are platform-agnostic (same `appId`, percentage-based taps).
 
 | Trigger | Suite | Runner | Time budget | Gating? |
 |---|---|---|---|---|
-| PR touching `apps/mobile/**` | Maestro **smoke** (E2E-100/101/102) | `macos-14` | ~10 min wall | Required check |
+| PR touching `apps/mobile/**` | Maestro **smoke** (E2E-100/101/102) on Android | `ubuntu-latest` (AVD api-33 google_apis x86_64) | ~12-15 min wall | Required check |
 | PR touching `apps/admin/**` or `packages/backend/**` | Playwright admin | `ubuntu-latest` | ~3 min wall | Required check |
-| Push to `main` touching `apps/mobile/**` | Maestro **full** (every flow in `.maestro/flows/`) | `macos-14` | ~30 min wall | Informational |
+| Push to `main` touching `apps/mobile/**` | Maestro **full** (every flow in `.maestro/flows/`) on Android | `ubuntu-latest` | ~25 min wall | Informational |
 | Push to `main` touching `apps/admin/**` | Playwright admin | `ubuntu-latest` | ~3 min wall | Informational |
-| `workflow_dispatch` (e2e-ios.yml) | configurable via `suite` input — `smoke` / `core` / `full` | `macos-14` | varies | — |
+| `workflow_dispatch` (e2e-android.yml) | configurable via `suite` input — `smoke` / `core` / `full` | `ubuntu-latest` | varies | — |
+| `workflow_dispatch` (e2e-ios.yml) | configurable via `suite` input — `smoke` / `core` / `full` | `macos-15` | varies (~15-30 min) | — (manual-only) |
 
-PR feedback target is **≤15 min** (Maestro smoke + Playwright run in parallel on different runners). Deploy gating on these workflows is deferred to a Phase 2 PR once we have a few weeks of green-signal data on real PR traffic.
+PR feedback target is **≤15 min** (Android Maestro smoke + Playwright run in parallel on different `ubuntu-latest` runners). iOS regression is caught by manual testing on the maintainer's iPhone + occasional `gh workflow run e2e-ios.yml`. Deploy gating on these workflows is deferred to a Phase 2 PR once we have a few weeks of green-signal data on real PR traffic.
 
 ## GitHub Issue Labels (MUST FOLLOW)
 


### PR DESCRIPTION
## Summary

Switch the mobile E2E gate from iOS (\`macos-15\`, 10× billable) to Android (\`ubuntu-latest\`, 1×) for cost. The Maestro flows are platform-agnostic, so Android coverage exercises the same React Native code paths at ~1/10 the runner cost. iOS regression is caught by manual maintainer testing on a real iPhone.

## Cost estimate (current PR velocity)

| Workflow | Runner | Smoke billable min | At 30 PR/mo |
|---|---|---|---|
| iOS smoke (before) | macos-15 | ~170 (17 min × 10) | ~5100 min |
| Android smoke (now) | ubuntu-latest | ~15 | ~450 min |

iOS smoke alone was ~$400+/mo beyond the free tier; Android smoke fits comfortably under it.

## Changes

### NEW \`.github/workflows/e2e-android.yml\` — primary mobile gate

Same tiered triggers as the prior iOS workflow:
- PR on \`apps/mobile/**\` → smoke suite (\`E2E-10*.yaml\`)
- Push to \`main\` → full suite (every flow in \`.maestro/flows/\`)
- \`workflow_dispatch\` → caller picks smoke / core / full

Uses \`reactivecircus/android-emulator-runner@v2\` for the AVD: api-33 google_apis x86_64 pixel_6, KVM-accelerated, headless, animations disabled. Builds the .apk via \`eas build --profile e2e --platform android --local\`, installs via \`adb install -r\`, runs Maestro inside the emulator-runner script block.

Carries over from the iOS workflow:
- Fetches Amplify outputs from \`--branch staging\` (production has the \`comingSoon\` AppConfig gate enabled)
- Seds \`amplify_outputs.json\` out of \`.gitignore\` so EAS includes the fetched file in the project archive
- Maestro install + suite-glob selector logic

### \`.github/workflows/e2e-ios.yml\` — demoted to manual-only

\`pull_request\` + \`push\` triggers removed. Still runnable via \`gh workflow run e2e-ios.yml -f suite=smoke\` (or \`core\` / \`full\`) when iOS-specific verification is needed.

### \`CLAUDE.md\` — CI/CD doc refresh

Updated the workflows table and E2E strategy table to reflect Android-primary, iOS-manual.

## Test plan

This PR is self-verifying — the Android workflow's path filter matches the workflow file itself, so it runs on this PR's own checks:

- [ ] \`Android E2E Tests\` runs on \`ubuntu-latest\`, build succeeds, AVD boots, .apk installs
- [ ] Smoke suite (E2E-100, E2E-101, E2E-102) passes on Android
- [ ] Wall time stays under ~15 min so the PR feedback target is met
- [ ] iOS workflow does NOT trigger on this PR (it's now manual-only)
- [ ] Playwright admin gate unaffected (no admin paths changed)

## Risk notes

- If a smoke flow has an iOS-specific assertion I missed, this PR will fail Android. Mitigation: I scanned the smoke flows for \`simctl\` / \`iPhone\` / iOS-specific strings — found one percentage-based tap in E2E-101 (\`93%,6%\` for the profile icon) which Maestro handles cross-platform.
- KVM nested virt needs \`/dev/kvm\` permissions on \`ubuntu-latest\` — handled by the standard udev rule in the workflow.
- AVD boot time on cold runs can be 3-5 min; cached on subsequent runs via \`actions/cache@v4\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)