### PR TITLE
docs(admin): clarify jurisdictions are rulebooks, not places

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -348,7 +348,7 @@ const allSections: AdminSection[] = [
     icon: Globe,
     group: "reference-data",
     purpose:
-      "Defines the regulatory bodies whose thresholds the app compares against (WHO, US, US-NY, CA-QC, EU, etc.). Each location resolves to one jurisdiction; the parent chain provides the cascade fallback when a state-level threshold is missing.",
+      "Catalog of regulatory standards — the laws and guidelines used to judge whether a measurement is safe (WHO, US federal EPA, US-NY, CA-QC, EU, etc.). This is NOT a list of places; cities and measurements live in the Locations and Measurements sections. A jurisdiction is the rulebook (\"what New York State's regulations say about lead\"), not the geography. Each location resolves to one jurisdiction, and the parentCode chain provides cascade fallback (US-NY → US → WHO) when a state-specific threshold isn't seeded.",
     lists: [
       {
         title: "Table",
@@ -368,7 +368,8 @@ const allSections: AdminSection[] = [
         name: "country",
         type: "text",
         required: true,
-        description: 'ISO country code (e.g. "US", "CA", "MX") used for the cascade.',
+        description:
+          'ISO country code (e.g. "US", "CA", "MX") this regulator belongs to. Used to match a measurement\'s country to the right rulebook — it does NOT mean this jurisdiction is "located in" that country in any geographic sense.',
       },
       {
         name: "name / nameFr",
@@ -379,7 +380,8 @@ const allSections: AdminSection[] = [
       {
         name: "region",
         type: "text",
-        description: 'Optional state/province code (e.g. "NY", "QC") used to match measurements to this jurisdiction.',
+        description:
+          'Optional state/province code this regulator governs (e.g. "NY" for the State of New York\'s rules, "QC" for Quebec\'s). Used to match a measurement\'s state to the right rulebook. Leave blank for country-level (e.g. US federal EPA) or global (WHO) standards.',
       },
       {
         name: "parentCode",

--- a/apps/admin/src/app/(admin)/jurisdictions/page.tsx
+++ b/apps/admin/src/app/(admin)/jurisdictions/page.tsx
@@ -208,7 +208,13 @@ export default function JurisdictionsPage() {
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Jurisdictions</h1>
           <p className="text-muted-foreground">
-            Manage regulatory jurisdictions for threshold comparisons
+            Regulatory standards (WHO, US EPA, US-NY, CA-QC, EU…) the mobile app
+            compares measurements against. This is the rulebook catalog — not a
+            list of places. Cities and measurements live in{" "}
+            <span className="font-medium">Measurements</span>; this page only
+            defines which laws/guidelines exist and how they cascade
+            (US-NY&nbsp;→&nbsp;US&nbsp;→&nbsp;WHO) when a state-specific
+            threshold is missing.
           </p>
         </div>
         <div className="flex gap-2">
@@ -236,8 +242,8 @@ export default function JurisdictionsPage() {
               </DialogTitle>
               <DialogDescription>
                 {editingJurisdiction
-                  ? "Update the jurisdiction details below."
-                  : "Add a new regulatory jurisdiction."}
+                  ? "Update this regulatory standard. A jurisdiction is a rulebook (e.g. WHO, US EPA, New York State law) — not a place."
+                  : "Add a new regulatory standard (e.g. WHO, US EPA, New York State law). Jurisdictions are rulebooks the app compares measurements against — not geographic locations."}
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">


### PR DESCRIPTION
## Summary
- Rewrote the Jurisdictions page subtitle and create/edit dialog description to make it unambiguous that a jurisdiction is a regulatory standard (WHO, US EPA, NY State law) — not a geographic location.
- Updated the in-app Guide entry (purpose + `country` + `region` field descriptions) with the same framing, and added an explicit pointer that cities/measurements live in Locations/Measurements.
- No behavior changes; copy only. Two files touched, ~14 lines added / 6 removed.

## Why
While reviewing the admin portal we noticed the page reads like a list of *places* ("country", "region" columns) when it's actually a catalog of *rulebooks* that drive the WHO vs LOCAL threshold cascade (US-NY → US → WHO). The current wording invited confusion about what to put in it and why the columns looked sparse.

## Test plan
- [ ] Open `/jurisdictions` in admin staging — header copy reads as the regulatory-standards framing
- [ ] Click **Add Jurisdiction** — dialog description matches
- [ ] Open `/guide`, scroll to Jurisdictions card — purpose + field descriptions reflect new framing
- [ ] No console errors / lint regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)