### PR TITLE
docs(admin): clarify Thresholds are (contaminant, jurisdiction) pairs and cascade

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -252,7 +252,7 @@ const allSections: AdminSection[] = [
     icon: Scale,
     group: "reference-data",
     purpose:
-      "Pairs a contaminant with a jurisdiction and a numeric limit. The mobile safety badge (green/orange/red) is computed entirely from these records. Missing thresholds silently fall back to the parent jurisdiction, then to WHO.",
+      "One row per (contaminant, jurisdiction) pair — the numeric limit the mobile safety badge (green/orange/red) is computed from. The jurisdiction is the rulebook the limit comes from (WHO, US EPA, US-NY, CA-QC…), NOT the city — cities are resolved to a jurisdiction at read time. When a row is missing for the resolved jurisdiction, the mobile app silently cascades to that jurisdiction's parentCode and finally to WHO (US-NY → US → WHO). That cascade is also why deleting a threshold may not visibly change anything: a parent row may already be answering for it.",
     lists: [
       {
         title: "Table",

--- a/apps/admin/src/app/(admin)/thresholds/page.tsx
+++ b/apps/admin/src/app/(admin)/thresholds/page.tsx
@@ -253,7 +253,14 @@ export default function ThresholdsPage() {
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Thresholds</h1>
           <p className="text-muted-foreground">
-            Manage jurisdiction-specific contaminant limits
+            One row per <span className="font-medium">(contaminant, jurisdiction)</span>{" "}
+            pair — the numeric limit the mobile app uses to color the
+            green/orange/red safety badge. Limits are tied to a{" "}
+            <span className="font-medium">rulebook</span> (WHO, US EPA,
+            US-NY…), not to a city. When a row is missing, the mobile app
+            cascades to the parent jurisdiction and finally to WHO
+            (US-NY&nbsp;→&nbsp;US&nbsp;→&nbsp;WHO), so deleting a row may
+            change nothing visible if a parent threshold already covers it.
           </p>
         </div>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
@@ -270,8 +277,8 @@ export default function ThresholdsPage() {
               </DialogTitle>
               <DialogDescription>
                 {editingThreshold
-                  ? "Update the threshold details below."
-                  : "Add a new jurisdiction-specific threshold."}
+                  ? "Update this (contaminant, jurisdiction) limit. The jurisdiction is the rulebook (WHO, US EPA, NY State law) — not a city."
+                  : "Add a (contaminant, jurisdiction) limit. The jurisdiction is the rulebook (WHO, US EPA, NY State law); cities resolve to a jurisdiction at read time. Missing rows cascade to the parent jurisdiction, then to WHO."}
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">


### PR DESCRIPTION
## Summary
- Rewrote the Thresholds page subtitle, create/edit dialog description, and Guide entry so it's unambiguous that a Threshold is a **(contaminant, jurisdiction) limit** — not a (contaminant, city) limit — and that missing rows silently cascade up `parentCode` to WHO.
- Same shape as PR #369 (`/jurisdictions` copy clarity). Copy only — no behavior changes. 2 files / +11 / -4.

## Why
While reviewing the admin portal, the Thresholds page subtitle ("Manage jurisdiction-specific contaminant limits") left two things unclear that came up in conversation:
1. Whether a threshold is keyed by city or by jurisdiction. It's the latter — cities resolve to a jurisdiction at read time on mobile.
2. What actually happens when a threshold is missing. The mobile app cascades up `parentCode` (US-NY → US → WHO), which is also why deleting a row may have no visible effect.

Making this explicit reduces the "why is deleting this row not changing anything?" and "do I add one threshold per city?" questions.

## Test plan
- [ ] Open `/thresholds` on admin staging — subtitle reads as "(contaminant, jurisdiction) pair" with the cascade explanation
- [ ] Click **Add Threshold** — dialog description matches
- [ ] Click **Edit** on any row — dialog description matches edit copy
- [ ] Open `/guide`, scroll to Thresholds card — purpose reflects new framing
- [ ] No console errors / lint regressions
- [ ] Existing Playwright CRUD spec (`apps/admin/e2e/admin/thresholds.spec.ts` from PR #367) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)