### PR TITLE
docs(admin): clarify Measurements as cascade coverage view; source is informational

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -641,7 +641,7 @@ const allSections: AdminSection[] = [
     icon: MapPin,
     group: "daily-ops",
     purpose:
-      "View measurements aggregated by city, state, and country. Use this page to verify recent imports and to add a new city as a target for future imports. Three tables surface the cascade levels users actually see.",
+      "Coverage view across the three cascade levels the mobile app reads from: by-city, by-state, and by-country. Mobile resolves a user's selected city by trying city-anchored rows first, then state, then country. Use this page to verify recent imports and to add a new city as a target for future imports. Drilling into Manage opens per-contaminant editing for that city. NOTE: the `source` field on each measurement (e.g. \"EPA\", \"NY DEC\", \"WHO\") is informational data-provenance ONLY — it records where the number came from. It does NOT determine which threshold rulebook is applied to it; that is decided by the city's resolved jurisdiction on the Thresholds page.",
     lists: [
       {
         title: "By City table",

--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -641,7 +641,7 @@ const allSections: AdminSection[] = [
     icon: MapPin,
     group: "daily-ops",
     purpose:
-      "Coverage view across the three cascade levels the mobile app reads from: by-city, by-state, and by-country. Mobile resolves a user's selected city by trying city-anchored rows first, then state, then country. Use this page to verify recent imports and to add a new city as a target for future imports. Drilling into Manage opens per-contaminant editing for that city. NOTE: the `source` field on each measurement (e.g. \"EPA\", \"NY DEC\", \"WHO\") is informational data-provenance ONLY — it records where the number came from. It does NOT determine which threshold rulebook is applied to it; that is decided by the city's resolved jurisdiction on the Thresholds page.",
+      "Coverage view across the three cascade levels the mobile app reads from: by-city, by-state, and by-country. Mobile resolves a user's selected city by trying city-anchored rows first, then state, then country. Use this page to verify recent imports and to add a new city as a target for future imports. Drilling into Manage opens per-contaminant editing for that city. NOTE: the \"source\" field on each measurement (e.g. \"EPA\", \"NY DEC\", \"WHO\") is informational data-provenance ONLY — it records where the number came from. It does NOT determine which threshold rulebook is applied to it; that is decided by the city's resolved jurisdiction on the Thresholds page.",
     lists: [
       {
         title: "By City table",

--- a/apps/admin/src/app/(admin)/measurements/[city]/page.tsx
+++ b/apps/admin/src/app/(admin)/measurements/[city]/page.tsx
@@ -392,7 +392,12 @@ export default function LocationDetailPage({
               <h1 className="text-3xl font-bold tracking-tight">{cityName}</h1>
             </div>
             <p className="text-muted-foreground">
-              Manage contaminant measurements for this location
+              Per-contaminant measurement values for this location. Safety
+              badges on mobile come from comparing these values to the{" "}
+              <span className="font-medium">Thresholds</span> page — the{" "}
+              <span className="font-medium">Data Source</span> field below is
+              informational only (where the number came from) and does NOT
+              decide which threshold is applied.
             </p>
           </div>
         </div>
@@ -618,6 +623,12 @@ export default function LocationDetailPage({
                       setFormData({ ...formData, source: e.target.value })
                     }
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Where this value came from. Informational only — does
+                    not determine which threshold rulebook is used to color
+                    the safety badge (that comes from the city&apos;s resolved
+                    jurisdiction on the Thresholds page).
+                  </p>
                 </div>
 
                 <div className="space-y-2">

--- a/apps/admin/src/app/(admin)/measurements/page.tsx
+++ b/apps/admin/src/app/(admin)/measurements/page.tsx
@@ -281,8 +281,14 @@ export default function ZipCodesPage() {
           Location Measurements
         </h1>
         <p className="text-muted-foreground">
-          View and manage contaminant measurements by city, state/province, or
-          country
+          Coverage view across the three cascade levels the mobile app reads
+          from: by-city, by-state, and by-country. When a user picks a city,
+          mobile reads city-anchored rows first; if none, it falls back to
+          state, then country.{" "}
+          <span className="font-medium">Add new city</span> only creates the
+          location target — to add the actual contaminant values, use{" "}
+          <span className="font-medium">Manage</span> on a row, or the{" "}
+          <span className="font-medium">Import Data</span> page.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Rewrote the `/measurements` page subtitle, the `/measurements/[city]` subtitle, added help text under the **Data Source** field, and tightened the matching Guide entry.
- Same shape as PR #369 (`/jurisdictions`) and PR #370 (`/thresholds`). Copy only — no behavior changes. 3 files / +21 / -4.

## Why
Two recurring sources of confusion on this page:

1. **What is /measurements for?** It looks like an editable list but it's really a coverage view across the three cascade levels mobile reads from (city → state → country fallback). \"Add new city\" only creates a location target; values are added via Import or per-city Manage.
2. **What does the `source` field do?** Today it reads like \"the threshold standard.\" It isn't — it's purely informational data-provenance (\"EPA\", \"NY DEC\", \"WHO\" record where the *number* came from). The *threshold rulebook* applied to color the safety badge is decided by the city's resolved jurisdiction on the Thresholds page. This is the long-standing confusion documented in CLAUDE.md section 10.

## Test plan
- [ ] Open `/measurements` on admin staging — subtitle reads as a cascade coverage view with the Add/Manage/Import pointers
- [ ] Drill into any city via **Manage** — subtitle explains per-contaminant editing and that Data Source is informational
- [ ] Click **Add Measurement** / pencil on a row — under the **Data Source** input you see the help text clarifying it does NOT determine the threshold rulebook
- [ ] Open `/guide`, scroll to Location Stats card — purpose reflects new framing
- [ ] No console errors / lint regressions
- [ ] Existing Playwright admin specs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)