### PR TITLE
docs(admin): clarify Properties (non-numeric) and Property Thresholds framing

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -1152,7 +1152,7 @@ const allSections: AdminSection[] = [
     icon: Activity,
     group: "orphan",
     purpose:
-      "Defines observable phenomena beyond classical numeric contaminants — radon zones, endemic disease flags, incidence rates, binary presence indicators. Each property declares its observationType, which dictates how thresholds and observations are entered and rendered.",
+      "Non-numeric observations the app can track — radon zones, endemic disease flags, per-100k incidence rates, binary presence indicators. The numeric counterpart is Contaminants (lead in ppb, PM2.5 in μg/m³, etc.); Properties is for everything that doesn't reduce to a single measured number. Each property declares an observationType (numeric / zone / endemic / incidence / binary) which decides which fields appear on Property Thresholds and observation forms downstream.",
     lists: [
       {
         title: "Table",
@@ -1222,7 +1222,7 @@ const allSections: AdminSection[] = [
     icon: Gauge,
     group: "orphan",
     purpose:
-      "Per-jurisdiction thresholds for non-numeric properties. The form fields you see depend on the parent property's observationType.",
+      "One row per (property, jurisdiction) pair — like Thresholds but for non-numeric Observed Properties. The jurisdiction is the rulebook (WHO, US EPA, US-NY, CA-QC…), NOT a city. The fields you see in the dialog change based on the parent property's observationType: a zone property surfaces zone-mapping fields, an incidence property surfaces per-100k rate fields, and so on. Missing rows cascade the same way contaminant thresholds do (US-NY → US → WHO).",
     lists: [
       {
         title: "Table",

--- a/apps/admin/src/app/(admin)/properties/page.tsx
+++ b/apps/admin/src/app/(admin)/properties/page.tsx
@@ -247,7 +247,17 @@ export default function PropertiesPage() {
             Observed Properties
           </h1>
           <p className="text-muted-foreground">
-            Manage what can be measured or observed
+            Properties are{" "}
+            <span className="font-medium">non-numeric observations</span> the
+            app can track — radon zones, endemic disease flags, per-100k
+            incidence rates, binary presence indicators. For{" "}
+            <span className="font-medium">numeric</span> measurements (lead in
+            ppb, PM2.5 in μg/m³, etc.) use the{" "}
+            <span className="font-medium">Contaminants</span> page instead.
+            Each property declares its{" "}
+            <span className="font-medium">observationType</span> (numeric /
+            zone / endemic / incidence / binary), which decides which fields
+            appear on the Property Thresholds and observation forms downstream.
           </p>
         </div>
         <div className="flex gap-2">
@@ -273,8 +283,8 @@ export default function PropertiesPage() {
                 </DialogTitle>
                 <DialogDescription>
                   {editingProperty
-                    ? "Update the property details below."
-                    : "Add a new observed property."}
+                    ? "Update this observed property (non-numeric: zone, endemic, incidence, binary). The observationType drives which fields appear on Property Thresholds and observation forms."
+                    : "Add a non-numeric observation type (zone, endemic, incidence, binary). For numeric values like ppb/μg-per-L, use Contaminants instead. The observationType you pick decides which fields appear downstream."}
                 </DialogDescription>
               </DialogHeader>
               <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">

--- a/apps/admin/src/app/(admin)/property-thresholds/page.tsx
+++ b/apps/admin/src/app/(admin)/property-thresholds/page.tsx
@@ -329,7 +329,18 @@ export default function PropertyThresholdsPage() {
             Property Thresholds
           </h1>
           <p className="text-muted-foreground">
-            Manage jurisdiction-specific thresholds for observed properties
+            One row per{" "}
+            <span className="font-medium">(property, jurisdiction)</span> pair
+            — like Thresholds, but for non-numeric{" "}
+            <span className="font-medium">Observed Properties</span> (zone,
+            endemic, incidence, binary). The jurisdiction is the{" "}
+            <span className="font-medium">rulebook</span> (WHO, US EPA,
+            US-NY…), not a city. The fields you see in the dialog change
+            based on the parent property&apos;s{" "}
+            <span className="font-medium">observationType</span> — a zone
+            property shows zone-mapping fields; an incidence property shows
+            per-100k rate fields; and so on. Missing rows cascade the same
+            way contaminant thresholds do (US-NY&nbsp;→&nbsp;US&nbsp;→&nbsp;WHO).
           </p>
         </div>
         <div className="flex gap-2">
@@ -353,11 +364,19 @@ export default function PropertyThresholdsPage() {
                 <DialogTitle>
                   {editingThreshold ? "Edit Threshold" : "Create Threshold"}
                 </DialogTitle>
-                <DialogDescription>
-                  {editingThreshold
-                    ? "Update the threshold details below."
-                    : "Add a new jurisdiction-specific threshold."}
-                </DialogDescription>
+                {(() => {
+                  const obsType = selectedProperty?.observationType;
+                  const typeNote = obsType
+                    ? ` This property is "${obsType}" — the fields below match that observationType.`
+                    : "";
+                  return (
+                    <DialogDescription>
+                      {editingThreshold
+                        ? `Update this (property, jurisdiction) limit. The jurisdiction is the rulebook (WHO, US EPA, NY State law) — not a city.${typeNote}`
+                        : `Add a (property, jurisdiction) limit. The jurisdiction is the rulebook (WHO, US EPA, NY State law); the visible fields depend on the parent property's observationType.${typeNote}`}
+                    </DialogDescription>
+                  );
+                })()}
               </DialogHeader>
               <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
                 <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Rewrote the `/properties` and `/property-thresholds` page subtitles, both create/edit dialog descriptions, and the matching Guide entries.
- The Property Threshold dialog description is now reactive: once a property is selected it surfaces its `observationType` inline (\"This property is 'zone' — the fields below match that observationType\"), which closes the loop on the long-standing \"why did the form change?\" confusion.
- Same shape as PR #369 (`/jurisdictions`), #370 (`/thresholds`), #371 (`/measurements`). Copy only — no behavior changes. 3 files / +40 / -11.

## Why
Two recurring confusions on these pages:

1. **Properties vs Contaminants.** Today the subtitle just says \"Manage what can be measured or observed,\" leaving users with no anchor for when to use Properties vs Contaminants. Properties is for *non-numeric* observations (radon zones, endemic flags, per-100k incidence, binary presence); Contaminants is for numeric measurements (ppb, μg/L, Bq/m³). The new copy says this directly.
2. **Why do Property Threshold form fields change?** The dialog renders different inputs depending on the parent property's `observationType`, but never explains why. Now both the static subtitle and the dynamic dialog description call this out, and the dialog cites the *actual* observationType of the selected property.

The jurisdiction = rulebook framing from #369/#370 is also extended to Property Thresholds, with the same cascade explanation (US-NY → US → WHO).

## Test plan
- [ ] Open `/properties` on admin staging — subtitle contrasts non-numeric Properties with numeric Contaminants
- [ ] Click **Add Property** / **Edit** — dialog description matches (mentions observationType driving downstream forms)
- [ ] Open `/property-thresholds` — subtitle explains (property, jurisdiction) keying, cascade, and conditional fields
- [ ] Click **Add Threshold**, pick a property — dialog description updates to cite that property's observationType
- [ ] Open `/guide`, scroll to Properties and Property Thresholds cards — purposes reflect new framing
- [ ] No console errors / lint regressions
- [ ] Existing Playwright admin specs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)