### PR TITLE
feat(admin): LinkedCountBadge — cross-link counts on Jurisdictions and Contaminants

### DIFF
--- a/apps/admin/src/app/(admin)/contaminants/page.tsx
+++ b/apps/admin/src/app/(admin)/contaminants/page.tsx
@@ -38,7 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Loader2, Scale } from "lucide-react";
 import { toast } from "sonner";
 import {
   CONTAMINANT_CATEGORIES,
@@ -46,11 +46,14 @@ import {
   contaminantCategoryNames,
   type ContaminantCategory,
 } from "@/lib/constants";
+import { LinkedCountBadge } from "@/components/LinkedCountBadge";
 
 type Contaminant = Schema["Contaminant"]["type"];
 
 export default function ContaminantsPage() {
   const [contaminants, setContaminants] = useState<Contaminant[]>([]);
+  const [thresholdCountByContaminant, setThresholdCountByContaminant] =
+    useState<Record<string, number>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingContaminant, setEditingContaminant] =
@@ -74,17 +77,25 @@ export default function ContaminantsPage() {
     try {
       setIsLoading(true);
       const client = generateClient<Schema>();
-      const { data, errors } = await client.models.Contaminant.list({
-        limit: 1000,
-      });
+      const [contaminantsResult, thresholdsResult] = await Promise.all([
+        client.models.Contaminant.list({ limit: 1000 }),
+        client.models.ContaminantThreshold.list({ limit: 1000 }),
+      ]);
 
-      if (errors) {
-        console.error("Error fetching contaminants:", errors);
+      if (contaminantsResult.errors) {
+        console.error("Error fetching contaminants:", contaminantsResult.errors);
         toast.error("Failed to fetch contaminants");
         return;
       }
 
-      setContaminants(data || []);
+      setContaminants(contaminantsResult.data || []);
+
+      const counts: Record<string, number> = {};
+      for (const t of thresholdsResult.data || []) {
+        if (!t.contaminantId) continue;
+        counts[t.contaminantId] = (counts[t.contaminantId] || 0) + 1;
+      }
+      setThresholdCountByContaminant(counts);
     } catch (error) {
       console.error("Error fetching contaminants:", error);
       toast.error("Failed to fetch contaminants");
@@ -411,6 +422,9 @@ export default function ContaminantsPage() {
                   <TableHead>Category</TableHead>
                   <TableHead>Unit</TableHead>
                   <TableHead>Higher Is</TableHead>
+                  <TableHead title="Number of ContaminantThreshold rows defined for this contaminant across all jurisdictions. Click to view them.">
+                    Thresholds
+                  </TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -450,6 +464,18 @@ export default function ContaminantsPage() {
                       >
                         {contaminant.higherIsBad ? "Bad" : "Good"}
                       </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <LinkedCountBadge
+                        count={
+                          thresholdCountByContaminant[
+                            contaminant.contaminantId
+                          ] ?? 0
+                        }
+                        icon={<Scale />}
+                        href={`/thresholds?contaminant=${encodeURIComponent(contaminant.contaminantId)}`}
+                        title={`${thresholdCountByContaminant[contaminant.contaminantId] ?? 0} thresholds defined for ${contaminant.contaminantId}`}
+                      />
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">

--- a/apps/admin/src/app/(admin)/jurisdictions/page.tsx
+++ b/apps/admin/src/app/(admin)/jurisdictions/page.tsx
@@ -39,13 +39,24 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
-import { Plus, Pencil, Trash2, Loader2, Download } from "lucide-react";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Loader2,
+  Download,
+  Scale,
+  GitBranch,
+} from "lucide-react";
 import { toast } from "sonner";
+import { LinkedCountBadge } from "@/components/LinkedCountBadge";
 
 type Jurisdiction = Schema["Jurisdiction"]["type"];
 
 export default function JurisdictionsPage() {
   const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
+  const [thresholdCountByJurisdiction, setThresholdCountByJurisdiction] =
+    useState<Record<string, number>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingJurisdiction, setEditingJurisdiction] =
@@ -67,17 +78,28 @@ export default function JurisdictionsPage() {
     try {
       setIsLoading(true);
       const client = generateClient<Schema>();
-      const { data, errors } = await client.models.Jurisdiction.list({
-        limit: 100,
-      });
+      const [jurisdictionsResult, thresholdsResult] = await Promise.all([
+        client.models.Jurisdiction.list({ limit: 100 }),
+        client.models.ContaminantThreshold.list({ limit: 1000 }),
+      ]);
 
-      if (errors) {
-        console.error("Error fetching jurisdictions:", errors);
+      if (jurisdictionsResult.errors) {
+        console.error(
+          "Error fetching jurisdictions:",
+          jurisdictionsResult.errors,
+        );
         toast.error("Failed to fetch jurisdictions");
         return;
       }
 
-      setJurisdictions(data || []);
+      setJurisdictions(jurisdictionsResult.data || []);
+
+      const counts: Record<string, number> = {};
+      for (const t of thresholdsResult.data || []) {
+        if (!t.jurisdictionCode) continue;
+        counts[t.jurisdictionCode] = (counts[t.jurisdictionCode] || 0) + 1;
+      }
+      setThresholdCountByJurisdiction(counts);
     } catch (error) {
       console.error("Error fetching jurisdictions:", error);
       toast.error("Failed to fetch jurisdictions");
@@ -416,6 +438,12 @@ export default function JurisdictionsPage() {
                   <TableHead>Country</TableHead>
                   <TableHead>Region</TableHead>
                   <TableHead>Parent</TableHead>
+                  <TableHead title="Number of ContaminantThreshold rows referencing this jurisdiction. Click to view them.">
+                    Thresholds
+                  </TableHead>
+                  <TableHead title="Number of jurisdictions that list this one as their parentCode (used for cascade fallback).">
+                    Children
+                  </TableHead>
                   <TableHead>Default</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -439,6 +467,27 @@ export default function JurisdictionsPage() {
                       ) : (
                         "—"
                       )}
+                    </TableCell>
+                    <TableCell>
+                      <LinkedCountBadge
+                        count={
+                          thresholdCountByJurisdiction[jurisdiction.code] ?? 0
+                        }
+                        icon={<Scale />}
+                        href={`/thresholds?jurisdiction=${encodeURIComponent(jurisdiction.code)}`}
+                        title={`${thresholdCountByJurisdiction[jurisdiction.code] ?? 0} thresholds reference ${jurisdiction.code}`}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <LinkedCountBadge
+                        count={
+                          jurisdictions.filter(
+                            (j) => j.parentCode === jurisdiction.code,
+                          ).length
+                        }
+                        icon={<GitBranch />}
+                        title={`${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length} jurisdictions list ${jurisdiction.code} as parentCode`}
+                      />
                     </TableCell>
                     <TableCell>
                       {jurisdiction.isDefault ? <Badge>Default</Badge> : null}

--- a/apps/admin/src/app/(admin)/thresholds/page.tsx
+++ b/apps/admin/src/app/(admin)/thresholds/page.tsx
@@ -65,6 +65,19 @@ export default function ThresholdsPage() {
   const [filterContaminant, setFilterContaminant] = useState<string>("all");
   const [filterJurisdiction, setFilterJurisdiction] = useState<string>("all");
 
+  // Honor ?contaminant=X&jurisdiction=Y on the URL so cross-page links
+  // (e.g. LinkedCountBadge on /jurisdictions and /contaminants) land
+  // pre-filtered. Read once on mount via window.location to avoid
+  // useSearchParams() Suspense-boundary requirements in the app router.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const c = params.get("contaminant");
+    const j = params.get("jurisdiction");
+    if (c) setFilterContaminant(c);
+    if (j) setFilterJurisdiction(j);
+  }, []);
+
   // Form state
   const [formData, setFormData] = useState({
     contaminantId: "",

--- a/apps/admin/src/components/LinkedCountBadge.tsx
+++ b/apps/admin/src/components/LinkedCountBadge.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+
+type LinkedCountBadgeProps = {
+  count: number;
+  label?: string;
+  icon?: ReactNode;
+  href?: string;
+  title?: string;
+};
+
+export function LinkedCountBadge({
+  count,
+  label,
+  icon,
+  href,
+  title,
+}: LinkedCountBadgeProps) {
+  const tooltip =
+    title ?? (label ? `${count} ${label}` : String(count));
+  const content = (
+    <>
+      {icon}
+      <span>{count}</span>
+      {label ? <span className="text-muted-foreground">{label}</span> : null}
+    </>
+  );
+
+  if (count === 0 || !href) {
+    return (
+      <Badge variant="outline" className="text-muted-foreground" title={tooltip}>
+        {content}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge asChild variant="secondary" title={tooltip}>
+      <Link href={href}>{content}</Link>
+    </Badge>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a reusable `<LinkedCountBadge>` component (`apps/admin/src/components/LinkedCountBadge.tsx`).
- Jurisdictions table gains **Thresholds** + **Children** columns. Thresholds count is a link to `/thresholds?jurisdiction=<code>`.
- Contaminants table gains a **Thresholds** column. Count is a link to `/thresholds?contaminant=<id>`.
- `/thresholds` reads `?contaminant=X` and `?jurisdiction=Y` from the URL once on mount so the badge clicks land filtered.

Phase 1b in the refactor plan. Closes the loop on Phase 1c's copy fixes (#369 / #370 / #371 / #373) by making the cascade relationships visible and navigable, not just described.

## Why
Today the admin tables are isolated lists — you have no idea what a delete will affect. \"Delete US-NY\" looks safe until you realize 27 thresholds and 4 child jurisdictions reference it. Same on Contaminants: deleting lead silently orphans every threshold that names it. Surfacing the counts:

1. Makes blast radius visible **before** the destructive click.
2. Makes the cascade structure visible at a glance — you can see at a glance which jurisdictions have empty Children (no cascade fallbacks pointing here) and which are heavily relied on.
3. Makes navigation natural: click a count to drill into the filtered list.

## Implementation notes
- Counts are computed in-memory from one extra `ContaminantThreshold.list({ limit: 1000 })` call per page (alongside the existing fetches). No schema changes, no N+1 — just a single extra list + a single pass to bucket.
- Children count on Jurisdictions is derived from the already-fetched `jurisdictions` array, no extra query.
- The badge renders as an outlined muted \"0\" when count is zero (no link), and as a secondary clickable badge with icon + count when > 0.
- `/thresholds` URL param read is done in a `useEffect` against `window.location.search` rather than `useSearchParams()` to avoid the app router's Suspense-boundary requirement for the latter.

## Test plan
- [ ] Open `/jurisdictions` on admin staging — two new columns appear (Thresholds, Children) with badges showing real counts; zero counts render muted, non-zero are clickable
- [ ] Click a non-zero Thresholds badge → lands on `/thresholds` with the jurisdiction filter pre-applied (URL has `?jurisdiction=…`, the filter Select shows the right value, the table is filtered)
- [ ] Hover any badge → tooltip explains the count
- [ ] Open `/contaminants` — new Thresholds column behaves the same way for `?contaminant=…`
- [ ] Directly navigate to `/thresholds?contaminant=lead&jurisdiction=US-NY` — filters apply on mount
- [ ] No console errors / lint regressions
- [ ] Existing Playwright admin specs still pass

## Follow-ups (not in this PR)
- Apply the same badge on `/properties` (count of PropertyThresholds per property)
- Add a Measurements count on Contaminants once we know the table size is safe to enumerate
- Wire similar badges on the threshold-coverage view (Phase 1a, next PR in the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)