### PR TITLE
feat(admin): /threshold-coverage — find cascade gaps before they surprise mobile users

### DIFF
--- a/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
+++ b/apps/admin/src/app/(admin)/guide/data/admin-sections.ts
@@ -342,6 +342,48 @@ const allSections: AdminSection[] = [
     },
   },
   {
+    id: "threshold-coverage",
+    title: "Threshold Coverage",
+    route: "/threshold-coverage",
+    icon: Gauge,
+    group: "reference-data",
+    purpose:
+      "Read-only audit view. For every (jurisdiction, contaminant) pair, answers: where does the mobile safety badge actually get its limit from? Cells bucket into ✓ direct (threshold seeded for this exact jurisdiction), ↓ cascade-parent (no direct row; resolved via the jurisdiction's parentCode), ⚠ cascade-WHO (fell all the way to the WHO global default — this is what makes the mobile app's WHO and LOCAL columns show identical values), or ⊘ none (unregulated, no row anywhere). Mirrors `getThreshold` in mobile's ContaminantsContext. Use this to find the gaps before adding state-specific thresholds.",
+    lists: [
+      {
+        title: "Summary cards",
+        columns: ["✓ Direct", "↓ Cascade to parent", "⚠ Cascade to WHO", "⊘ Unregulated"],
+      },
+      {
+        title: "By Jurisdiction table",
+        columns: [
+          "Code",
+          "Name",
+          "Cascade chain (e.g. US-NY → US → WHO)",
+          "✓ Direct",
+          "↓ Parent",
+          "⚠ WHO",
+          "⊘ None",
+          "Show contaminants",
+        ],
+      },
+    ],
+    actions: [
+      {
+        label: "Show contaminants",
+        description:
+          "Expands the row to list every contaminant under this jurisdiction, gaps first (⚠ WHO-only, ⊘ unregulated), with per-row 'edit' links to /thresholds pre-filtered.",
+      },
+    ],
+    mobileImpact: {
+      summary:
+        "No write surface — this page does not change data. It surfaces the cascade decisions the mobile app makes at read time so admins can spot gaps (e.g. \"Atlanta shows identical WHO + LOCAL columns because US-GA has no state-specific thresholds\") and add the missing rows on /thresholds.",
+      edgeCases: [
+        "Cascade is one-level-parent + WHO, matching mobile's getThreshold. If mobile ever widens the chain, update lib/threshold-cascade.ts to stay in sync.",
+      ],
+    },
+  },
+  {
     id: "jurisdictions",
     title: "Jurisdictions",
     route: "/jurisdictions",

--- a/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
+++ b/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
@@ -22,7 +22,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { toast } from "sonner";
-import { ArrowRight, CheckCircle2, CircleSlash, Loader2 } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CircleSlash,
+  Loader2,
+} from "lucide-react";
 import {
   resolveThresholdCoverage,
   makeThresholdKey,
@@ -48,7 +54,7 @@ function formatChain(
   jurisdictionByCode: Map<string, MinimalJurisdiction>,
 ): string {
   const chain: string[] = [code];
-  let current = jurisdictionByCode.get(code);
+  const current = jurisdictionByCode.get(code);
   // One-level parent + WHO terminator, mirroring resolveThresholdCoverage.
   if (current?.parentCode) chain.push(current.parentCode);
   if (chain[chain.length - 1] !== "WHO") chain.push("WHO");
@@ -61,11 +67,11 @@ export default function ThresholdCoveragePage() {
   const [thresholds, setThresholds] = useState<ContaminantThreshold[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [expandedCode, setExpandedCode] = useState<string | null>(null);
+  const [truncatedLists, setTruncatedLists] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchAll = async () => {
       try {
-        setIsLoading(true);
         const client = generateClient<Schema>();
         const [j, c, t] = await Promise.all([
           client.models.Jurisdiction.list({ limit: 100 }),
@@ -73,13 +79,34 @@ export default function ThresholdCoveragePage() {
           client.models.ContaminantThreshold.list({ limit: 1000 }),
         ]);
         if (j.errors || c.errors || t.errors) {
-          console.error("Coverage fetch errors", { j: j.errors, c: c.errors, t: t.errors });
+          console.error("Coverage fetch errors", {
+            j: j.errors,
+            c: c.errors,
+            t: t.errors,
+          });
           toast.error("Failed to load coverage data");
           return;
         }
         setJurisdictions(j.data || []);
         setContaminants(c.data || []);
         setThresholds(t.data || []);
+
+        // Detect pagination ceiling. Amplify list() returns nextToken when
+        // more rows exist than the page size; we don't paginate here, so a
+        // present nextToken means the audit is reading a partial dataset and
+        // would mis-classify direct rows as cascade-WHO. Surface both as a
+        // toast and a persistent inline banner so the warning doesn't vanish
+        // while the admin reads the table.
+        const truncated: string[] = [];
+        if (j.nextToken) truncated.push("jurisdictions");
+        if (c.nextToken) truncated.push("contaminants");
+        if (t.nextToken) truncated.push("thresholds");
+        setTruncatedLists(truncated);
+        if (truncated.length > 0) {
+          toast.warning(
+            `Partial data: ${truncated.join(", ")} list(s) exceeded page size. Counts may undercount Direct.`,
+          );
+        }
       } catch (err) {
         console.error("Coverage fetch error", err);
         toast.error("Failed to load coverage data");
@@ -175,6 +202,25 @@ export default function ThresholdCoveragePage() {
           <code>getThreshold</code> in mobile&apos;s ContaminantsContext.
         </p>
       </div>
+
+      {truncatedLists.length > 0 && (
+        <Card className="border-amber-300 bg-amber-50">
+          <CardContent className="flex items-start gap-3 py-4">
+            <AlertTriangle className="h-5 w-5 mt-0.5 shrink-0 text-amber-600" />
+            <div className="text-sm text-amber-900">
+              <p className="font-medium">Partial data — audit may undercount.</p>
+              <p>
+                The following list(s) exceeded the page size and were not
+                fully fetched: <code>{truncatedLists.join(", ")}</code>.
+                Missing rows are silently classified as cascading to WHO, so{" "}
+                <span className="font-medium">⚠ Cascade to WHO</span> is
+                inflated and <span className="font-medium">✓ Direct</span> is
+                undercounted until pagination is wired up.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <SummaryCard

--- a/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
+++ b/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "sonner";
+import { ArrowRight, CheckCircle2, CircleSlash, Loader2 } from "lucide-react";
+import {
+  resolveThresholdCoverage,
+  makeThresholdKey,
+  type CoverageState,
+  type MinimalJurisdiction,
+} from "@/lib/threshold-cascade";
+
+type Jurisdiction = Schema["Jurisdiction"]["type"];
+type Contaminant = Schema["Contaminant"]["type"];
+type ContaminantThreshold = Schema["ContaminantThreshold"]["type"];
+
+type Counts = Record<CoverageState, number>;
+
+const EMPTY_COUNTS: Counts = {
+  "direct": 0,
+  "cascade-parent": 0,
+  "cascade-who": 0,
+  "none": 0,
+};
+
+function formatChain(
+  code: string,
+  jurisdictionByCode: Map<string, MinimalJurisdiction>,
+): string {
+  const chain: string[] = [code];
+  let current = jurisdictionByCode.get(code);
+  // One-level parent + WHO terminator, mirroring resolveThresholdCoverage.
+  if (current?.parentCode) chain.push(current.parentCode);
+  if (chain[chain.length - 1] !== "WHO") chain.push("WHO");
+  return chain.join(" → ");
+}
+
+export default function ThresholdCoveragePage() {
+  const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
+  const [contaminants, setContaminants] = useState<Contaminant[]>([]);
+  const [thresholds, setThresholds] = useState<ContaminantThreshold[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [expandedCode, setExpandedCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        setIsLoading(true);
+        const client = generateClient<Schema>();
+        const [j, c, t] = await Promise.all([
+          client.models.Jurisdiction.list({ limit: 100 }),
+          client.models.Contaminant.list({ limit: 1000 }),
+          client.models.ContaminantThreshold.list({ limit: 1000 }),
+        ]);
+        if (j.errors || c.errors || t.errors) {
+          console.error("Coverage fetch errors", { j: j.errors, c: c.errors, t: t.errors });
+          toast.error("Failed to load coverage data");
+          return;
+        }
+        setJurisdictions(j.data || []);
+        setContaminants(c.data || []);
+        setThresholds(t.data || []);
+      } catch (err) {
+        console.error("Coverage fetch error", err);
+        toast.error("Failed to load coverage data");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchAll();
+  }, []);
+
+  const jurisdictionByCode = useMemo(() => {
+    const m = new Map<string, MinimalJurisdiction>();
+    for (const j of jurisdictions) {
+      m.set(j.code, { code: j.code, parentCode: j.parentCode });
+    }
+    return m;
+  }, [jurisdictions]);
+
+  const thresholdKeys = useMemo(() => {
+    const s = new Set<string>();
+    for (const t of thresholds) {
+      if (!t.contaminantId || !t.jurisdictionCode) continue;
+      s.add(makeThresholdKey(t.contaminantId, t.jurisdictionCode));
+    }
+    return s;
+  }, [thresholds]);
+
+  // For each jurisdiction, walk every contaminant and bucket the resolution state.
+  // O(jurisdictions × contaminants) — ~20 × ~170 = 3400 lookups, all in-memory Set
+  // hits. Trivial at this scale.
+  const coverageByJurisdiction = useMemo(() => {
+    const out = new Map<string, { counts: Counts; rows: Array<{
+      contaminant: Contaminant;
+      state: CoverageState;
+      resolvedJurisdictionCode: string | null;
+    }> }>();
+    for (const j of jurisdictions) {
+      const counts: Counts = { ...EMPTY_COUNTS };
+      const rows: Array<{
+        contaminant: Contaminant;
+        state: CoverageState;
+        resolvedJurisdictionCode: string | null;
+      }> = [];
+      for (const c of contaminants) {
+        const cov = resolveThresholdCoverage(
+          c.contaminantId,
+          j.code,
+          jurisdictionByCode,
+          thresholdKeys,
+        );
+        counts[cov.state] += 1;
+        rows.push({
+          contaminant: c,
+          state: cov.state,
+          resolvedJurisdictionCode: cov.resolvedJurisdictionCode,
+        });
+      }
+      out.set(j.code, { counts, rows });
+    }
+    return out;
+  }, [jurisdictions, contaminants, jurisdictionByCode, thresholdKeys]);
+
+  const totals = useMemo(() => {
+    const sum: Counts = { ...EMPTY_COUNTS };
+    for (const { counts } of coverageByJurisdiction.values()) {
+      sum["direct"] += counts["direct"];
+      sum["cascade-parent"] += counts["cascade-parent"];
+      sum["cascade-who"] += counts["cascade-who"];
+      sum["none"] += counts["none"];
+    }
+    return sum;
+  }, [coverageByJurisdiction]);
+
+  const totalCells = jurisdictions.length * contaminants.length;
+  const directPct = totalCells === 0 ? 0 : Math.round((totals.direct * 100) / totalCells);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Threshold Coverage</h1>
+        <p className="text-muted-foreground">
+          For every (jurisdiction, contaminant) pair, where does the mobile
+          app&apos;s safety badge get its limit from? Cells fall into one of:{" "}
+          <span className="font-medium">✓ direct</span> (threshold seeded for
+          this exact jurisdiction),{" "}
+          <span className="font-medium">↓ cascade-parent</span> (no direct row,
+          resolved via the jurisdiction&apos;s <code>parentCode</code>),{" "}
+          <span className="font-medium">⚠ cascade-WHO</span> (fell all the way
+          to the WHO default — this is what causes the mobile app&apos;s WHO
+          and LOCAL columns to show identical values), or{" "}
+          <span className="font-medium">⊘ none</span> (no row anywhere,
+          unregulated for that contaminant). Mirrors{" "}
+          <code>getThreshold</code> in mobile&apos;s ContaminantsContext.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard
+          label="✓ Direct"
+          count={totals.direct}
+          total={totalCells}
+          tone="success"
+        />
+        <SummaryCard
+          label="↓ Cascade to parent"
+          count={totals["cascade-parent"]}
+          total={totalCells}
+          tone="info"
+        />
+        <SummaryCard
+          label="⚠ Cascade to WHO"
+          count={totals["cascade-who"]}
+          total={totalCells}
+          tone="warning"
+        />
+        <SummaryCard
+          label="⊘ Unregulated"
+          count={totals.none}
+          total={totalCells}
+          tone="muted"
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By Jurisdiction</CardTitle>
+          <CardDescription>
+            {jurisdictions.length} jurisdiction
+            {jurisdictions.length === 1 ? "" : "s"} × {contaminants.length}{" "}
+            contaminants = {totalCells.toLocaleString()} pairs.{" "}
+            {directPct}% have a direct threshold; the rest cascade.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : jurisdictions.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No jurisdictions yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Code</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Cascade chain</TableHead>
+                  <TableHead className="text-right">✓ Direct</TableHead>
+                  <TableHead className="text-right">↓ Parent</TableHead>
+                  <TableHead className="text-right">⚠ WHO</TableHead>
+                  <TableHead className="text-right">⊘ None</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {jurisdictions.map((j) => {
+                  const cov = coverageByJurisdiction.get(j.code);
+                  if (!cov) return null;
+                  const isExpanded = expandedCode === j.code;
+                  return (
+                    <Fragment key={j.code}>
+                      <TableRow>
+                        <TableCell className="font-mono font-medium">
+                          {j.code}
+                        </TableCell>
+                        <TableCell>{j.name}</TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {formatChain(j.code, jurisdictionByCode)}
+                        </TableCell>
+                        <CountCell count={cov.counts.direct} tone="success" />
+                        <CountCell count={cov.counts["cascade-parent"]} tone="info" />
+                        <CountCell count={cov.counts["cascade-who"]} tone="warning" />
+                        <CountCell count={cov.counts.none} tone="muted" />
+                        <TableCell className="text-right">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              setExpandedCode(isExpanded ? null : j.code)
+                            }
+                          >
+                            {isExpanded ? "Hide" : "Show contaminants"}
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                      {isExpanded && (
+                        <TableRow>
+                          <TableCell colSpan={8} className="bg-muted/30">
+                            <DetailList
+                              jurisdictionCode={j.code}
+                              rows={cov.rows}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  count,
+  total,
+  tone,
+}: {
+  label: string;
+  count: number;
+  total: number;
+  tone: "success" | "info" | "warning" | "muted";
+}) {
+  const pct = total === 0 ? 0 : Math.round((count * 100) / total);
+  const toneClass = {
+    success: "text-green-600",
+    info: "text-blue-600",
+    warning: "text-amber-600",
+    muted: "text-muted-foreground",
+  }[tone];
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>{label}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-2xl font-bold ${toneClass}`}>
+          {count.toLocaleString()}
+          <span className="text-sm font-normal text-muted-foreground ml-2">
+            {pct}%
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CountCell({
+  count,
+  tone,
+}: {
+  count: number;
+  tone: "success" | "info" | "warning" | "muted";
+}) {
+  if (count === 0) {
+    return (
+      <TableCell className="text-right text-muted-foreground">—</TableCell>
+    );
+  }
+  const toneClass = {
+    success: "text-green-700",
+    info: "text-blue-700",
+    warning: "text-amber-700 font-medium",
+    muted: "text-muted-foreground",
+  }[tone];
+  return (
+    <TableCell className={`text-right tabular-nums ${toneClass}`}>
+      {count}
+    </TableCell>
+  );
+}
+
+function DetailList({
+  jurisdictionCode,
+  rows,
+}: {
+  jurisdictionCode: string;
+  rows: Array<{
+    contaminant: Contaminant;
+    state: CoverageState;
+    resolvedJurisdictionCode: string | null;
+  }>;
+}) {
+  // Order: ⚠ WHO-cascades and ⊘ none first (the gaps), then ↓ parent, then ✓ direct.
+  const order: Record<CoverageState, number> = {
+    "cascade-who": 0,
+    "none": 1,
+    "cascade-parent": 2,
+    "direct": 3,
+  };
+  const sorted = [...rows].sort((a, b) => {
+    const so = order[a.state] - order[b.state];
+    if (so !== 0) return so;
+    return a.contaminant.name.localeCompare(b.contaminant.name);
+  });
+
+  return (
+    <div className="py-2 space-y-1 max-h-[480px] overflow-y-auto">
+      <p className="text-xs text-muted-foreground mb-3">
+        Gaps first (⚠ WHO-only, ⊘ unregulated), then ↓ cascaded-via-parent, then ✓ direct.
+        To add a missing threshold,{" "}
+        <Link
+          href={`/thresholds?jurisdiction=${encodeURIComponent(jurisdictionCode)}`}
+          className="text-foreground underline underline-offset-2"
+        >
+          open /thresholds filtered to {jurisdictionCode}
+          <ArrowRight className="inline h-3 w-3 ml-0.5" />
+        </Link>
+        .
+      </p>
+      {sorted.map(({ contaminant, state, resolvedJurisdictionCode }) => (
+        <div
+          key={contaminant.contaminantId}
+          className="flex items-center gap-3 text-sm"
+        >
+          <StateBadge state={state} />
+          <span className="font-mono text-xs text-muted-foreground w-28 shrink-0">
+            {contaminant.contaminantId}
+          </span>
+          <span className="flex-1 truncate">{contaminant.name}</span>
+          {resolvedJurisdictionCode &&
+            resolvedJurisdictionCode !== jurisdictionCode && (
+              <span className="text-xs text-muted-foreground">
+                resolves via {resolvedJurisdictionCode}
+              </span>
+            )}
+          <Link
+            href={`/thresholds?contaminant=${encodeURIComponent(contaminant.contaminantId)}&jurisdiction=${encodeURIComponent(jurisdictionCode)}`}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            edit
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StateBadge({ state }: { state: CoverageState }) {
+  const config: Record<
+    CoverageState,
+    { label: string; icon: React.ReactNode; className: string }
+  > = {
+    "direct": {
+      label: "direct",
+      icon: <CheckCircle2 className="h-3 w-3" />,
+      className: "border-green-200 bg-green-50 text-green-700",
+    },
+    "cascade-parent": {
+      label: "parent",
+      icon: <ArrowRight className="h-3 w-3" />,
+      className: "border-blue-200 bg-blue-50 text-blue-700",
+    },
+    "cascade-who": {
+      label: "WHO",
+      icon: <ArrowRight className="h-3 w-3" />,
+      className: "border-amber-200 bg-amber-50 text-amber-700",
+    },
+    "none": {
+      label: "none",
+      icon: <CircleSlash className="h-3 w-3" />,
+      className: "border-muted bg-muted/50 text-muted-foreground",
+    },
+  };
+  const { label, icon, className } = config[state];
+  return (
+    <Badge variant="outline" className={`${className} w-20 justify-center`}>
+      {icon}
+      <span>{label}</span>
+    </Badge>
+  );
+}

--- a/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
+++ b/apps/admin/src/app/(admin)/threshold-coverage/page.tsx
@@ -30,6 +30,7 @@ import {
   Loader2,
 } from "lucide-react";
 import {
+  getThresholdChain,
   resolveThresholdCoverage,
   makeThresholdKey,
   type CoverageState,
@@ -43,23 +44,11 @@ type ContaminantThreshold = Schema["ContaminantThreshold"]["type"];
 type Counts = Record<CoverageState, number>;
 
 const EMPTY_COUNTS: Counts = {
-  "direct": 0,
+  direct: 0,
   "cascade-parent": 0,
   "cascade-who": 0,
-  "none": 0,
+  none: 0,
 };
-
-function formatChain(
-  code: string,
-  jurisdictionByCode: Map<string, MinimalJurisdiction>,
-): string {
-  const chain: string[] = [code];
-  const current = jurisdictionByCode.get(code);
-  // One-level parent + WHO terminator, mirroring resolveThresholdCoverage.
-  if (current?.parentCode) chain.push(current.parentCode);
-  if (chain[chain.length - 1] !== "WHO") chain.push("WHO");
-  return chain.join(" → ");
-}
 
 export default function ThresholdCoveragePage() {
   const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
@@ -172,10 +161,10 @@ export default function ThresholdCoveragePage() {
   const totals = useMemo(() => {
     const sum: Counts = { ...EMPTY_COUNTS };
     for (const { counts } of coverageByJurisdiction.values()) {
-      sum["direct"] += counts["direct"];
+      sum.direct += counts.direct;
       sum["cascade-parent"] += counts["cascade-parent"];
       sum["cascade-who"] += counts["cascade-who"];
-      sum["none"] += counts["none"];
+      sum.none += counts.none;
     }
     return sum;
   }, [coverageByJurisdiction]);
@@ -295,7 +284,7 @@ export default function ThresholdCoveragePage() {
                         </TableCell>
                         <TableCell>{j.name}</TableCell>
                         <TableCell className="font-mono text-xs text-muted-foreground">
-                          {formatChain(j.code, jurisdictionByCode)}
+                          {getThresholdChain(j.code, jurisdictionByCode).join(" → ")}
                         </TableCell>
                         <CountCell count={cov.counts.direct} tone="success" />
                         <CountCell count={cov.counts["cascade-parent"]} tone="info" />

--- a/apps/admin/src/components/admin-sidebar.tsx
+++ b/apps/admin/src/components/admin-sidebar.tsx
@@ -85,6 +85,7 @@ const menuGroups: MenuGroup[] = [
     items: [
       { title: "Contaminants", url: "/contaminants", icon: Droplets },
       { title: "Thresholds", url: "/thresholds", icon: Scale },
+      { title: "Threshold Coverage", url: "/threshold-coverage", icon: Gauge },
       { title: "Categories", url: "/categories", icon: FolderTree },
       { title: "Sub-Categories", url: "/subcategories", icon: Layers },
       { title: "Jurisdictions", url: "/jurisdictions", icon: Globe },

--- a/apps/admin/src/lib/threshold-cascade.ts
+++ b/apps/admin/src/lib/threshold-cascade.ts
@@ -1,0 +1,65 @@
+/**
+ * Mirrors the cascade behavior of `getThreshold` in
+ * `apps/mobile/app/context/ContaminantsContext.tsx`. Given a
+ * (contaminantId, jurisdictionCode) lookup the mobile app will try, in order:
+ *
+ *   1. Exact `(contaminantId, jurisdictionCode)` threshold
+ *   2. One-level parent (the jurisdiction's `parentCode`)
+ *   3. `WHO` as the global default
+ *
+ * For admin coverage reporting we don't need the threshold itself, just the
+ * resolution outcome so the UI can show ✓ (exists here), ↓ (cascades), ⚠
+ * (falls all the way to WHO), or ⊘ (nothing at all, including no WHO row).
+ *
+ * Kept in pure-function form so it's trivially unit-testable and can stay in
+ * sync with mobile by inspection. If mobile ever widens the cascade past one
+ * parent level, update both call sites together.
+ */
+
+export type CoverageState = "direct" | "cascade-parent" | "cascade-who" | "none";
+
+export type ThresholdCoverage = {
+  state: CoverageState;
+  /** The jurisdiction code that actually answered the lookup (or null for "none"). */
+  resolvedJurisdictionCode: string | null;
+};
+
+export type ThresholdLookupKey = string; // `${contaminantId}:${jurisdictionCode}`
+
+export function makeThresholdKey(
+  contaminantId: string,
+  jurisdictionCode: string,
+): ThresholdLookupKey {
+  return `${contaminantId}:${jurisdictionCode}`;
+}
+
+export type MinimalJurisdiction = {
+  code: string;
+  parentCode?: string | null;
+};
+
+export function resolveThresholdCoverage(
+  contaminantId: string,
+  jurisdictionCode: string,
+  jurisdictionByCode: Map<string, MinimalJurisdiction>,
+  thresholdKeys: Set<ThresholdLookupKey>,
+): ThresholdCoverage {
+  if (thresholdKeys.has(makeThresholdKey(contaminantId, jurisdictionCode))) {
+    return { state: "direct", resolvedJurisdictionCode: jurisdictionCode };
+  }
+
+  const jurisdiction = jurisdictionByCode.get(jurisdictionCode);
+  const parentCode = jurisdiction?.parentCode ?? null;
+  if (parentCode && thresholdKeys.has(makeThresholdKey(contaminantId, parentCode))) {
+    return { state: "cascade-parent", resolvedJurisdictionCode: parentCode };
+  }
+
+  if (thresholdKeys.has(makeThresholdKey(contaminantId, "WHO"))) {
+    // If the requested jurisdiction *is* WHO, the "direct" branch would have
+    // matched above. Reaching here means the lookup fell through to WHO from
+    // a non-WHO jurisdiction.
+    return { state: "cascade-who", resolvedJurisdictionCode: "WHO" };
+  }
+
+  return { state: "none", resolvedJurisdictionCode: null };
+}

--- a/apps/admin/src/lib/threshold-cascade.ts
+++ b/apps/admin/src/lib/threshold-cascade.ts
@@ -13,7 +13,8 @@
  *
  * Kept in pure-function form so it's trivially unit-testable and can stay in
  * sync with mobile by inspection. If mobile ever widens the cascade past one
- * parent level, update both call sites together.
+ * parent level, only `getThresholdChain` needs to change — the resolver and
+ * the UI's chain display both consume it.
  */
 
 export type CoverageState = "direct" | "cascade-parent" | "cascade-who" | "none";
@@ -38,28 +39,45 @@ export type MinimalJurisdiction = {
   parentCode?: string | null;
 };
 
+/**
+ * The ordered cascade we'd walk for any contaminant under this jurisdiction:
+ * `[jurisdictionCode, parentCode?, "WHO"]`, deduped so the chain doesn't end
+ * in `WHO → WHO` when the parent is already WHO (or when the jurisdiction
+ * itself is WHO). Single source of truth for both the `resolveThresholdCoverage`
+ * walk and the UI's "US-NY → US → WHO" display string.
+ */
+export function getThresholdChain(
+  jurisdictionCode: string,
+  jurisdictionByCode: Map<string, MinimalJurisdiction>,
+): string[] {
+  const chain: string[] = [jurisdictionCode];
+  const parentCode = jurisdictionByCode.get(jurisdictionCode)?.parentCode;
+  if (parentCode && parentCode !== jurisdictionCode) chain.push(parentCode);
+  if (chain[chain.length - 1] !== "WHO") chain.push("WHO");
+  return chain;
+}
+
 export function resolveThresholdCoverage(
   contaminantId: string,
   jurisdictionCode: string,
   jurisdictionByCode: Map<string, MinimalJurisdiction>,
   thresholdKeys: Set<ThresholdLookupKey>,
 ): ThresholdCoverage {
-  if (thresholdKeys.has(makeThresholdKey(contaminantId, jurisdictionCode))) {
-    return { state: "direct", resolvedJurisdictionCode: jurisdictionCode };
+  // Walk the same chain the UI displays. Index 0 is the requested jurisdiction
+  // itself (a hit there is "direct"); the WHO terminator yields "cascade-who"
+  // only when reached via a non-WHO start, because if the request *is* WHO it
+  // sits at index 0 and matches the "direct" branch first.
+  const chain = getThresholdChain(jurisdictionCode, jurisdictionByCode);
+  for (let i = 0; i < chain.length; i++) {
+    const code = chain[i];
+    if (!thresholdKeys.has(makeThresholdKey(contaminantId, code))) continue;
+    if (i === 0) {
+      return { state: "direct", resolvedJurisdictionCode: code };
+    }
+    if (code === "WHO") {
+      return { state: "cascade-who", resolvedJurisdictionCode: "WHO" };
+    }
+    return { state: "cascade-parent", resolvedJurisdictionCode: code };
   }
-
-  const jurisdiction = jurisdictionByCode.get(jurisdictionCode);
-  const parentCode = jurisdiction?.parentCode ?? null;
-  if (parentCode && thresholdKeys.has(makeThresholdKey(contaminantId, parentCode))) {
-    return { state: "cascade-parent", resolvedJurisdictionCode: parentCode };
-  }
-
-  if (thresholdKeys.has(makeThresholdKey(contaminantId, "WHO"))) {
-    // If the requested jurisdiction *is* WHO, the "direct" branch would have
-    // matched above. Reaching here means the lookup fell through to WHO from
-    // a non-WHO jurisdiction.
-    return { state: "cascade-who", resolvedJurisdictionCode: "WHO" };
-  }
-
   return { state: "none", resolvedJurisdictionCode: null };
 }


### PR DESCRIPTION
## Summary
- New page at `/threshold-coverage`. Read-only audit view: for every (jurisdiction, contaminant) pair, classifies where the mobile safety badge actually gets its limit from.
- Pure cascade resolver lives in `apps/admin/src/lib/threshold-cascade.ts` and mirrors `getThreshold` in mobile's `ContaminantsContext` (one-level parent + WHO fallback).
- Sidebar nav entry under **Reference** next to `/thresholds`. New Guide entry documents the four states and the audit workflow.

Phase 1a in the refactor plan, and the highest-leverage item in this batch. Directly addresses the long-standing **CLAUDE.md §11** confusion (\"why do WHO and LOCAL columns show identical values for some cities?\").

## States surfaced

| Symbol | Name | Meaning |
|---|---|---|
| ✓ | `direct` | Threshold seeded for this exact jurisdiction. |
| ↓ | `cascade-parent` | No direct row; resolved via the jurisdiction's `parentCode`. |
| ⚠ | `cascade-who` | Fell all the way to the WHO global default — root cause of the \"identical WHO/LOCAL columns\" bug class. |
| ⊘ | `none` | No row anywhere, unregulated for that contaminant. |

## What you see

- Four summary cards at the top: totals and percentages across all pairs (jurisdictions × contaminants).
- One row per jurisdiction with:
  - Cascade chain (e.g. `US-NY → US → WHO`)
  - Counts in each of the four buckets
  - **Show contaminants** button to expand a detail panel showing every contaminant under that jurisdiction, **gaps first** (⚠ + ⊘), each with an `edit` link to `/thresholds` pre-filtered to that pair (relies on the URL-filter support added in PR #374).

## Why
Today there's no way for an admin to see at a glance \"which states are silently cascading to WHO?\" — you only find out by opening the mobile app and noticing that the WHO and LOCAL columns are identical for a city in that state. CLAUDE.md §11 calls this out as the canonical example: Atlanta, GA shows identical columns because there are no US-GA *and* no US (federal EPA) thresholds for those contaminants. This page makes that visible at the catalog level, and routes the admin straight to the page where they can fix it.

## Implementation notes
- O(jurisdictions × contaminants) ≈ 20 × 170 ≈ 3,400 lookups, all in-memory Set hits. Trivial at this scale.
- Three Amplify list calls in parallel on mount (jurisdictions, contaminants, thresholds). No schema changes, no N+1.
- The cascade resolver returns `{ state, resolvedJurisdictionCode }` so the detail row can show \"resolves via US\" / \"resolves via WHO\" inline.
- Cascade chain is shown as a static string mirroring the resolver's behavior. If mobile ever widens the chain past one-level-parent + WHO, both `lib/threshold-cascade.ts` and `formatChain` need to update together — the file has a comment to that effect.

## Test plan
- [ ] Visit `/threshold-coverage` on admin staging — page renders, four summary cards show real counts and percentages
- [ ] Spot-check a known-empty jurisdiction (e.g. `US-GA` per CLAUDE.md §11) — its ⚠ WHO column should be a large number, ✓ Direct should be 0 or near-zero
- [ ] Click **Show contaminants** on `US-GA` — list opens, ⚠ rows appear first
- [ ] Click **edit** on any contaminant row — lands on `/thresholds` filtered to that (contaminant, jurisdiction) pair, with an empty result if no row exists yet
- [ ] Click the chain `/thresholds?jurisdiction=US-GA` link in the detail panel header — lands filtered
- [ ] Sidebar shows new **Threshold Coverage** entry under Reference, between Thresholds and Categories
- [ ] Open `/guide` — new card for Threshold Coverage with the framing
- [ ] No console errors / lint regressions

## Follow-ups (not in this PR)
- Bulk-add: from a US-GA row, allow \"copy US-NY thresholds → US-GA\" in one click
- Filter the page to only show jurisdictions with gaps (`cascade-who > 0`)
- Per-contaminant view (transpose: rows = contaminants, columns = jurisdictions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)