### PR TITLE
fix(admin): pluralize LinkedCountBadge tooltip when count is 1

### DIFF
--- a/apps/admin/src/app/(admin)/contaminants/page.tsx
+++ b/apps/admin/src/app/(admin)/contaminants/page.tsx
@@ -474,7 +474,7 @@ export default function ContaminantsPage() {
                         }
                         icon={<Scale />}
                         href={`/thresholds?contaminant=${encodeURIComponent(contaminant.contaminantId)}`}
-                        title={`${thresholdCountByContaminant[contaminant.contaminantId] ?? 0} thresholds defined for ${contaminant.contaminantId}`}
+                        title={`${thresholdCountByContaminant[contaminant.contaminantId] ?? 0} ${(thresholdCountByContaminant[contaminant.contaminantId] ?? 0) === 1 ? "threshold" : "thresholds"} defined for ${contaminant.contaminantId}`}
                       />
                     </TableCell>
                     <TableCell className="text-right">

--- a/apps/admin/src/app/(admin)/jurisdictions/page.tsx
+++ b/apps/admin/src/app/(admin)/jurisdictions/page.tsx
@@ -475,7 +475,7 @@ export default function JurisdictionsPage() {
                         }
                         icon={<Scale />}
                         href={`/thresholds?jurisdiction=${encodeURIComponent(jurisdiction.code)}`}
-                        title={`${thresholdCountByJurisdiction[jurisdiction.code] ?? 0} thresholds reference ${jurisdiction.code}`}
+                        title={`${thresholdCountByJurisdiction[jurisdiction.code] ?? 0} ${(thresholdCountByJurisdiction[jurisdiction.code] ?? 0) === 1 ? "threshold" : "thresholds"} reference ${jurisdiction.code}`}
                       />
                     </TableCell>
                     <TableCell>
@@ -486,7 +486,7 @@ export default function JurisdictionsPage() {
                           ).length
                         }
                         icon={<GitBranch />}
-                        title={`${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length} jurisdictions list ${jurisdiction.code} as parentCode`}
+                        title={`${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length} ${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length === 1 ? "jurisdiction" : "jurisdictions"} list ${jurisdiction.code} as parentCode`}
                       />
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
## Summary
Follow-up to #374. The new `LinkedCountBadge` tooltip rendered the noun as a plural regardless of count — e.g. **"1 thresholds defined for dichloroacetate"** on `/contaminants`, **"1 thresholds reference US-NY"** on `/jurisdictions`. Pluralize at each of the three call sites (`count === 1 ? "threshold" : "thresholds"`, same for `jurisdiction`).

Caught while running the #374 test plan against admin staging. The badge component itself takes `title` as a string, so the fix lives at the call sites; no component-level change.

## Test plan
- [ ] Hover a non-zero badge on `/contaminants` for any contaminant with exactly 1 threshold (e.g. `dichloroacetate`) → tooltip reads **"1 threshold defined for dichloroacetate"**
- [ ] Hover a non-zero badge on `/jurisdictions` for any jurisdiction with exactly 1 threshold → tooltip reads **"1 threshold reference …"**
- [ ] Hover a Children badge on a jurisdiction with exactly 1 child → tooltip reads **"1 jurisdiction list … as parentCode"**
- [ ] Multi-count cases (≥2) still read **"N thresholds defined for …"** etc.
- [ ] Lint + type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)