### PR TITLE
refactor(mobile): extract useJurisdictionResolver hook (Phase 2c)

### DIFF
--- a/apps/mobile/app/hooks/useJurisdictionResolver.ts
+++ b/apps/mobile/app/hooks/useJurisdictionResolver.ts
@@ -1,0 +1,45 @@
+/**
+ * useJurisdictionResolver
+ *
+ * Thin wrapper over `useContaminants().getJurisdictionForLocation`. Exists so
+ * call sites have a single, replaceable point of access to (state, country) →
+ * jurisdiction resolution.
+ *
+ * Today the resolution is an in-memory lookup against the cached
+ * `jurisdictionMap` (built from the `Jurisdiction` reference table at app
+ * startup). If we ever swap to a different strategy — e.g. reading from the
+ * `Location` DynamoDB table to support city-level jurisdiction overrides —
+ * only this hook needs to change; consumers stay the same.
+ *
+ * Two helpers because call sites split roughly 2:1 on whether they need the
+ * full Jurisdiction record or just the code:
+ *
+ *  - `resolve(state, country)` returns the full `Jurisdiction | undefined` —
+ *    use when the display name or other fields matter (e.g.
+ *    `CategoryDetailScreen` shows `jurisdiction.name.toUpperCase()`).
+ *  - `resolveCode(state, country)` returns the resolved code with `"WHO"` as
+ *    the fallback — use when you just need a code for downstream lookups
+ *    (e.g. `useLocationData` mapping measurements to local thresholds).
+ */
+
+import { useMemo } from "react"
+
+import { useContaminants } from "@/context/ContaminantsContext"
+import type { Jurisdiction } from "@/data/types/safety"
+
+export interface JurisdictionResolver {
+  resolve: (state: string, country: string) => Jurisdiction | undefined
+  resolveCode: (state: string, country: string) => string
+}
+
+export function useJurisdictionResolver(): JurisdictionResolver {
+  const { getJurisdictionForLocation } = useContaminants()
+  return useMemo(
+    () => ({
+      resolve: getJurisdictionForLocation,
+      resolveCode: (state, country) =>
+        getJurisdictionForLocation(state, country)?.code ?? "WHO",
+    }),
+    [getJurisdictionForLocation],
+  )
+}

--- a/apps/mobile/app/hooks/useJurisdictionResolver.ts
+++ b/apps/mobile/app/hooks/useJurisdictionResolver.ts
@@ -37,8 +37,7 @@ export function useJurisdictionResolver(): JurisdictionResolver {
   return useMemo(
     () => ({
       resolve: getJurisdictionForLocation,
-      resolveCode: (state, country) =>
-        getJurisdictionForLocation(state, country)?.code ?? "WHO",
+      resolveCode: (state, country) => getJurisdictionForLocation(state, country)?.code ?? "WHO",
     }),
     [getJurisdictionForLocation],
   )

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -17,6 +17,7 @@ import {
   type StatStatus,
   StatCategory,
 } from "@/data/types/safety"
+import { useJurisdictionResolver } from "@/hooks/useJurisdictionResolver"
 import { useNetworkStatus } from "@/hooks/useNetworkStatus"
 import { fetchWithLocationFallback, type LocationScope } from "@/lib/locationFallback"
 import { queryKeys } from "@/lib/queryKeys"
@@ -167,9 +168,9 @@ export function useLocationData(
     contaminants,
     getThreshold,
     getWHOThreshold,
-    getJurisdictionForLocation,
     isLoading: defsLoading,
   } = useContaminants()
+  const { resolveCode } = useJurisdictionResolver()
   const { isOffline, isReady: networkReady } = useNetworkStatus()
   const qc = useQueryClient()
 
@@ -281,8 +282,7 @@ export function useLocationData(
       const effectiveState = state || firstMeasurement.state || ""
       const effectiveCountry = country || firstMeasurement.country || ""
       const cityName = scope === "city" ? (firstMeasurement.city ?? city) : city
-      const jurisdictionCode =
-        getJurisdictionForLocation(effectiveState, effectiveCountry)?.code || "WHO"
+      const jurisdictionCode = resolveCode(effectiveState, effectiveCountry)
       const stats = measurements.map((m) => mapMeasurementToLegacyStat(m, jurisdictionCode))
       const newData: CityData = {
         city,
@@ -323,7 +323,7 @@ export function useLocationData(
       scope: "none",
       warning: null,
     }
-  }, [city, state, country, isOffline, mapMeasurementToLegacyStat, getJurisdictionForLocation])
+  }, [city, state, country, isOffline, mapMeasurementToLegacyStat, resolveCode])
 
   const query = useQuery({
     queryKey: queryKeys.measurements.byLocation(city, state, country),

--- a/apps/mobile/app/hooks/useLocationData.ts
+++ b/apps/mobile/app/hooks/useLocationData.ts
@@ -164,12 +164,7 @@ export function useLocationData(
   state: string = "",
   country: string = "",
 ): UseLocationDataResult {
-  const {
-    contaminants,
-    getThreshold,
-    getWHOThreshold,
-    isLoading: defsLoading,
-  } = useContaminants()
+  const { contaminants, getThreshold, getWHOThreshold, isLoading: defsLoading } = useContaminants()
   const { resolveCode } = useJurisdictionResolver()
   const { isOffline, isReady: networkReady } = useNetworkStatus()
   const qc = useQueryClient()

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -110,10 +110,7 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
   const categoryColor = getCategoryColor(categoryId) ?? CATEGORY_COLORS[category] ?? "#6B7280"
 
   // Get jurisdiction name for display
-  const localJurisdiction = resolveJurisdiction(
-    cityData?.state ?? state ?? "",
-    country ?? "",
-  )
+  const localJurisdiction = resolveJurisdiction(cityData?.state ?? state ?? "", country ?? "")
   const localJurisdictionCode = localJurisdiction?.code ?? "WHO"
   const localJurisdictionName =
     localJurisdiction?.name?.toUpperCase() || cityData?.state?.toUpperCase() || "LOCAL"

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -33,6 +33,7 @@ import {
   getLocalStandardsLink,
 } from "@/data/categoryConfig"
 import { StatCategory } from "@/data/types/safety"
+import { useJurisdictionResolver } from "@/hooks/useJurisdictionResolver"
 import {
   useLocationData,
   getRiskStatsForCategory,
@@ -57,7 +58,8 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
   const { category, city, state, country, subCategoryId } = route.params
   const { theme } = useAppTheme()
   const { statDefinitions } = useStatDefinitions()
-  const { getWHOThreshold, getThreshold, getJurisdictionForLocation } = useContaminants()
+  const { getWHOThreshold, getThreshold } = useContaminants()
+  const { resolve: resolveJurisdiction } = useJurisdictionResolver()
   const { getCategoryName, getCategoryColor } = useCategories()
 
   // Fetch data for the passed city from Amplify (with caching, offline support,
@@ -108,7 +110,7 @@ export const CategoryDetailScreen: FC<CategoryDetailScreenProps> = function Cate
   const categoryColor = getCategoryColor(categoryId) ?? CATEGORY_COLORS[category] ?? "#6B7280"
 
   // Get jurisdiction name for display
-  const localJurisdiction = getJurisdictionForLocation(
+  const localJurisdiction = resolveJurisdiction(
     cityData?.state ?? state ?? "",
     country ?? "",
   )

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -26,6 +26,7 @@ import { usePendingAction } from "@/context/PendingActionContext"
 import { useStatDefinitions } from "@/context/StatDefinitionsContext"
 import { useSubscriptions } from "@/context/SubscriptionsContext"
 import { DEFAULT_HIGHER_IS_BAD, StatCategory } from "@/data/types/safety"
+import { useJurisdictionResolver } from "@/hooks/useJurisdictionResolver"
 import { useLocation } from "@/hooks/useLocation"
 import {
   useLocationData,
@@ -38,8 +39,9 @@ import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { recordLocationVisit } from "@/services/amplify/data"
 import { useAppTheme } from "@/theme/context"
 import { trackEvent } from "@/utils/analytics"
-// jurisdiction resolution now uses ContaminantsContext.getJurisdictionForLocation
-// postalCode utilities removed - using city-level granularity
+// jurisdiction resolution goes through useJurisdictionResolver (thin wrapper
+// over ContaminantsContext.getJurisdictionForLocation); postalCode utilities
+// removed when the app moved to city-level granularity.
 
 /** Orange color for WHO-only exceedances */
 const WHO_EXCEEDANCE_COLOR = "#F97316"
@@ -92,8 +94,8 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
   const { isAuthenticated, user, logout } = useAuth()
   const { setPendingAction } = usePendingAction()
   const { statDefinitions } = useStatDefinitions()
-  const { contaminants, getThreshold, getWHOThreshold, getJurisdictionForLocation } =
-    useContaminants()
+  const { contaminants, getThreshold, getWHOThreshold } = useContaminants()
+  const { resolveCode } = useJurisdictionResolver()
   const { primarySubscription, addSubscription, isLoading: subsLoading } = useSubscriptions()
   const {
     getLocationFromGPS,
@@ -233,11 +235,13 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     [cityData, statDefinitions],
   )
 
-  // Determine the jurisdiction code for the current location
-  const currentJurisdictionCode = useMemo(() => {
-    if (!currentLocation) return "WHO"
-    return getJurisdictionForLocation(currentLocation.state, currentLocation.country)?.code || "WHO"
-  }, [currentLocation, getJurisdictionForLocation])
+  // Determine the jurisdiction code for the current location.
+  // `resolveCode` already returns "WHO" for missing/empty inputs (falls through
+  // the in-memory lookup), so the `!currentLocation` early return is folded in.
+  const currentJurisdictionCode = useMemo(
+    () => resolveCode(currentLocation?.state ?? "", currentLocation?.country ?? ""),
+    [currentLocation, resolveCode],
+  )
 
   // Get sub-category status with WHO-vs-national color coding
   const getSubCategoryStatusForCategory = useCallback(


### PR DESCRIPTION
## Summary
Adds `apps/mobile/app/hooks/useJurisdictionResolver.ts` — a thin memoized wrapper over `useContaminants().getJurisdictionForLocation`. Three consumers migrate off the direct context destructure.

4 files / **+66 / -15**.

## What the hook exposes
- **`resolve(state, country): Jurisdiction | undefined`** — full record. Used when the display name matters (CategoryDetailScreen header reads `jurisdiction.name.toUpperCase()`).
- **`resolveCode(state, country): string`** — code with `\"WHO\"` fallback. Used where a string code is all that's needed (the common case).

## Migrations
- `useLocationData.ts` → `resolveCode` inside the `mapMeasurement` query callback; drops the inline `?.code || \"WHO\"` pattern.
- `DashboardScreen.tsx` → `resolveCode`; the `!currentLocation` early return is folded into the resolver because `resolveCode(\"\", \"\")` already returns `\"WHO\"` via the underlying lookup's WHO fallback. Also updated a stale comment.
- `CategoryDetailScreen.tsx` → `resolve` (full record needed for the display name).

## Why
Decoupling. Today the resolution is an in-memory lookup against the cached `jurisdictionMap`. If we later swap to a different strategy — e.g. reading from the `Location` DynamoDB table to support city-level jurisdiction overrides — only this hook changes. Consumers stay the same.

This is the **last item in Phase 2** of the refactor plan.

## Behavior
Preserved exactly. Every call site computes the same jurisdiction (or code) it did before. The `!currentLocation` early-return collapse in DashboardScreen is the only structural simplification — verified that `resolveCode(\"\", \"\")` returns `\"WHO\"` via `getJurisdictionForLocation`'s existing fall-through to `jurisdictionMap.get(\"WHO\")`.

## Test plan
- [ ] CI: lint + tsc + Jest
- [ ] CI: Maestro Android smoke
- [ ] After merge, mobile staging smoke: open Buffalo, NY and Atlanta, GA — confirm the standards table header still shows the right jurisdiction name (\"NY\" / \"GA\"), and the WHO + LOCAL columns render with the same values as before.

## What's left after this
Phase 2 is complete. Remaining plan items per `docs/refactor-handoff-2026-05-17.md`:
- **Phase 3** — admin `useCrudResource()` hook + apply to 8 pages (large infra refactor, deferred)
- **Backend Lambda env-var hardening** (CLAUDE.md §8) and **`process-notifications` defaults** (§6) — small, opened up after the no-production-users constraint was lifted
- **`Location` model surgery / `resolvedJurisdictionCode` schema addition** — medium-large, would let us swap the in-memory lookup behind this very hook for a backend-resolved value
- **CLAUDE.md docs refresh** — tiny, stale Legacy Patterns table

🤖 Generated with [Claude Code](https://claude.com/claude-code)