### PR TITLE
refactor(admin): useCrudResource hook + migrate /jurisdictions (Phase 3, PR 1/5)

### DIFF
--- a/apps/admin/src/app/(admin)/jurisdictions/page.tsx
+++ b/apps/admin/src/app/(admin)/jurisdictions/page.tsx
@@ -48,181 +48,109 @@ import {
   Scale,
   GitBranch,
 } from "lucide-react";
-import { toast } from "sonner";
 import { LinkedCountBadge } from "@/components/LinkedCountBadge";
+import { useCrudResource } from "@/hooks/useCrudResource";
 
 type Jurisdiction = Schema["Jurisdiction"]["type"];
 
-export default function JurisdictionsPage() {
-  const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
-  const [thresholdCountByJurisdiction, setThresholdCountByJurisdiction] =
-    useState<Record<string, number>>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [editingJurisdiction, setEditingJurisdiction] =
-    useState<Jurisdiction | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+interface JurisdictionFormData {
+  code: string;
+  name: string;
+  nameFr: string;
+  country: string;
+  region: string;
+  parentCode: string;
+  isDefault: boolean;
+}
 
-  // Form state
-  const [formData, setFormData] = useState({
-    code: "",
-    name: "",
-    nameFr: "",
-    country: "",
-    region: "",
-    parentCode: "",
-    isDefault: false,
+const DEFAULT_FORM: JurisdictionFormData = {
+  code: "",
+  name: "",
+  nameFr: "",
+  country: "",
+  region: "",
+  parentCode: "",
+  isDefault: false,
+};
+
+export default function JurisdictionsPage() {
+  const {
+    data: jurisdictions,
+    isLoading,
+    isDialogOpen,
+    setIsDialogOpen,
+    editingRecord: editingJurisdiction,
+    openCreate,
+    openEdit,
+    formData,
+    setFormData,
+    isSaving,
+    handleSave,
+    handleDelete,
+    handleExport,
+  } = useCrudResource<Jurisdiction, JurisdictionFormData>({
+    resourceName: "Jurisdiction",
+    getModel: (client) => client.models.Jurisdiction,
+    listOptions: { limit: 100 },
+    defaultFormValues: DEFAULT_FORM,
+    editToForm: (j) => ({
+      code: j.code,
+      name: j.name,
+      nameFr: j.nameFr || "",
+      country: j.country,
+      region: j.region || "",
+      parentCode: j.parentCode || "",
+      isDefault: j.isDefault ?? false,
+    }),
+    validate: (form) => {
+      if (!form.code || !form.name || !form.country) {
+        return "Please fill in all required fields";
+      }
+      return null;
+    },
+    formToPayload: (form) => ({
+      code: form.code,
+      name: form.name,
+      nameFr: form.nameFr || null,
+      country: form.country,
+      region: form.region || null,
+      parentCode: form.parentCode || null,
+      isDefault: form.isDefault,
+    }),
+    getDisplayName: (j) => j.name,
+    export: {
+      fileName: "jurisdictions.json",
+      transform: (j) => ({
+        code: j.code,
+        name: j.name,
+        nameFr: j.nameFr || null,
+        country: j.country,
+        region: j.region || null,
+        parentCode: j.parentCode || null,
+        isDefault: j.isDefault ?? false,
+      }),
+    },
   });
 
-  const fetchJurisdictions = async () => {
-    try {
-      setIsLoading(true);
-      const client = generateClient<Schema>();
-      const [jurisdictionsResult, thresholdsResult] = await Promise.all([
-        client.models.Jurisdiction.list({ limit: 100 }),
-        client.models.ContaminantThreshold.list({ limit: 1000 }),
-      ]);
+  // Companion fetch for the LinkedCountBadge counts (Thresholds column).
+  // Kept in the page because it's not the page's own model — useCrudResource
+  // owns Jurisdiction lifecycle; threshold counts are derived from a different
+  // table and only need to refresh on initial load (admins don't add/remove
+  // thresholds from this page).
+  const [thresholdCountByJurisdiction, setThresholdCountByJurisdiction] =
+    useState<Record<string, number>>({});
 
-      if (jurisdictionsResult.errors) {
-        console.error(
-          "Error fetching jurisdictions:",
-          jurisdictionsResult.errors,
-        );
-        toast.error("Failed to fetch jurisdictions");
-        return;
-      }
-
-      setJurisdictions(jurisdictionsResult.data || []);
-
+  useEffect(() => {
+    const client = generateClient<Schema>();
+    client.models.ContaminantThreshold.list({ limit: 1000 }).then((result) => {
       const counts: Record<string, number> = {};
-      for (const t of thresholdsResult.data || []) {
+      for (const t of result.data || []) {
         if (!t.jurisdictionCode) continue;
         counts[t.jurisdictionCode] = (counts[t.jurisdictionCode] || 0) + 1;
       }
       setThresholdCountByJurisdiction(counts);
-    } catch (error) {
-      console.error("Error fetching jurisdictions:", error);
-      toast.error("Failed to fetch jurisdictions");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchJurisdictions();
+    });
   }, []);
-
-  const resetForm = () => {
-    setFormData({
-      code: "",
-      name: "",
-      nameFr: "",
-      country: "",
-      region: "",
-      parentCode: "",
-      isDefault: false,
-    });
-    setEditingJurisdiction(null);
-  };
-
-  const openCreateDialog = () => {
-    resetForm();
-    setIsDialogOpen(true);
-  };
-
-  const openEditDialog = (jurisdiction: Jurisdiction) => {
-    setEditingJurisdiction(jurisdiction);
-    setFormData({
-      code: jurisdiction.code,
-      name: jurisdiction.name,
-      nameFr: jurisdiction.nameFr || "",
-      country: jurisdiction.country,
-      region: jurisdiction.region || "",
-      parentCode: jurisdiction.parentCode || "",
-      isDefault: jurisdiction.isDefault ?? false,
-    });
-    setIsDialogOpen(true);
-  };
-
-  const handleSave = async () => {
-    if (!formData.code || !formData.name || !formData.country) {
-      toast.error("Please fill in all required fields");
-      return;
-    }
-
-    setIsSaving(true);
-    try {
-      const client = generateClient<Schema>();
-
-      const jurisdictionData = {
-        code: formData.code,
-        name: formData.name,
-        nameFr: formData.nameFr || null,
-        country: formData.country,
-        region: formData.region || null,
-        parentCode: formData.parentCode || null,
-        isDefault: formData.isDefault,
-      };
-
-      if (editingJurisdiction) {
-        await client.models.Jurisdiction.update({
-          id: editingJurisdiction.id,
-          ...jurisdictionData,
-        });
-        toast.success("Jurisdiction updated");
-      } else {
-        await client.models.Jurisdiction.create(jurisdictionData);
-        toast.success("Jurisdiction created");
-      }
-
-      setIsDialogOpen(false);
-      resetForm();
-      fetchJurisdictions();
-    } catch (error) {
-      console.error("Error saving jurisdiction:", error);
-      toast.error("Failed to save jurisdiction");
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleDelete = async (jurisdiction: Jurisdiction) => {
-    if (!confirm(`Are you sure you want to delete "${jurisdiction.name}"?`)) {
-      return;
-    }
-
-    try {
-      const client = generateClient<Schema>();
-      await client.models.Jurisdiction.delete({ id: jurisdiction.id });
-      toast.success("Jurisdiction deleted");
-      fetchJurisdictions();
-    } catch (error) {
-      console.error("Error deleting jurisdiction:", error);
-      toast.error("Failed to delete jurisdiction");
-    }
-  };
-
-  const handleExport = () => {
-    const exportData = jurisdictions.map((j) => ({
-      code: j.code,
-      name: j.name,
-      nameFr: j.nameFr || null,
-      country: j.country,
-      region: j.region || null,
-      parentCode: j.parentCode || null,
-      isDefault: j.isDefault ?? false,
-    }));
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "jurisdictions.json";
-    a.click();
-    URL.revokeObjectURL(url);
-    toast.success("Exported jurisdictions.json");
-  };
 
   return (
     <div className="space-y-6">
@@ -250,163 +178,163 @@ export default function JurisdictionsPage() {
           </Button>
           <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
             <DialogTrigger asChild>
-              <Button onClick={openCreateDialog}>
+              <Button onClick={openCreate}>
                 <Plus className="mr-2 h-4 w-4" />
                 Add Jurisdiction
               </Button>
             </DialogTrigger>
-          <DialogContent className="sm:max-w-[500px]">
-            <DialogHeader>
-              <DialogTitle>
-                {editingJurisdiction
-                  ? "Edit Jurisdiction"
-                  : "Create Jurisdiction"}
-              </DialogTitle>
-              <DialogDescription>
-                {editingJurisdiction
-                  ? "Update this regulatory standard. A jurisdiction is a rulebook (e.g. WHO, US EPA, New York State law) — not a place."
-                  : "Add a new regulatory standard (e.g. WHO, US EPA, New York State law). Jurisdictions are rulebooks the app compares measurements against — not geographic locations."}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="code">Code *</Label>
-                  <Input
-                    id="code"
-                    placeholder="e.g., US-NY, CA-QC, WHO"
-                    value={formData.code}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        code: e.target.value.toUpperCase(),
-                      })
-                    }
-                    disabled={!!editingJurisdiction}
-                  />
+            <DialogContent className="sm:max-w-[500px]">
+              <DialogHeader>
+                <DialogTitle>
+                  {editingJurisdiction
+                    ? "Edit Jurisdiction"
+                    : "Create Jurisdiction"}
+                </DialogTitle>
+                <DialogDescription>
+                  {editingJurisdiction
+                    ? "Update this regulatory standard. A jurisdiction is a rulebook (e.g. WHO, US EPA, New York State law) — not a place."
+                    : "Add a new regulatory standard (e.g. WHO, US EPA, New York State law). Jurisdictions are rulebooks the app compares measurements against — not geographic locations."}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="code">Code *</Label>
+                    <Input
+                      id="code"
+                      placeholder="e.g., US-NY, CA-QC, WHO"
+                      value={formData.code}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          code: e.target.value.toUpperCase(),
+                        })
+                      }
+                      disabled={!!editingJurisdiction}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="country">Country Code *</Label>
+                    <Input
+                      id="country"
+                      placeholder="e.g., US, CA, INTL"
+                      value={formData.country}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          country: e.target.value.toUpperCase(),
+                        })
+                      }
+                    />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="country">Country Code *</Label>
-                  <Input
-                    id="country"
-                    placeholder="e.g., US, CA, INTL"
-                    value={formData.country}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        country: e.target.value.toUpperCase(),
-                      })
-                    }
-                  />
-                </div>
-              </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="name">Name (English) *</Label>
-                  <Input
-                    id="name"
-                    placeholder="e.g., New York State"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData({ ...formData, name: e.target.value })
-                    }
-                  />
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name (English) *</Label>
+                    <Input
+                      id="name"
+                      placeholder="e.g., New York State"
+                      value={formData.name}
+                      onChange={(e) =>
+                        setFormData({ ...formData, name: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="nameFr">Name (French)</Label>
+                    <Input
+                      id="nameFr"
+                      placeholder="e.g., État de New York"
+                      value={formData.nameFr}
+                      onChange={(e) =>
+                        setFormData({ ...formData, nameFr: e.target.value })
+                      }
+                    />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="nameFr">Name (French)</Label>
-                  <Input
-                    id="nameFr"
-                    placeholder="e.g., État de New York"
-                    value={formData.nameFr}
-                    onChange={(e) =>
-                      setFormData({ ...formData, nameFr: e.target.value })
-                    }
-                  />
-                </div>
-              </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="region">Region/State Code</Label>
-                  <Input
-                    id="region"
-                    placeholder="e.g., NY, QC"
-                    value={formData.region}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        region: e.target.value.toUpperCase(),
-                      })
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="region">Region/State Code</Label>
+                    <Input
+                      id="region"
+                      placeholder="e.g., NY, QC"
+                      value={formData.region}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          region: e.target.value.toUpperCase(),
+                        })
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="parentCode">Parent Jurisdiction Code</Label>
+                    <Select
+                      value={formData.parentCode || "none"}
+                      onValueChange={(value) =>
+                        setFormData({
+                          ...formData,
+                          parentCode: value === "none" ? "" : value,
+                        })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="None (top-level)" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">None (top-level)</SelectItem>
+                        {jurisdictions
+                          .filter((j) => j.code !== formData.code)
+                          .map((j) => (
+                            <SelectItem key={j.id} value={j.code}>
+                              {j.code} - {j.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Parent for threshold fallback (e.g., US for US-NY)
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="isDefault"
+                    checked={formData.isDefault}
+                    onCheckedChange={(checked: boolean) =>
+                      setFormData({ ...formData, isDefault: checked })
                     }
                   />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="parentCode">Parent Jurisdiction Code</Label>
-                  <Select
-                    value={formData.parentCode || "none"}
-                    onValueChange={(value) =>
-                      setFormData({
-                        ...formData,
-                        parentCode: value === "none" ? "" : value,
-                      })
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="None (top-level)" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">None (top-level)</SelectItem>
-                      {jurisdictions
-                        .filter((j) => j.code !== formData.code)
-                        .map((j) => (
-                          <SelectItem key={j.id} value={j.code}>
-                            {j.code} - {j.name}
-                          </SelectItem>
-                        ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Parent for threshold fallback (e.g., US for US-NY)
-                  </p>
+                  <Label htmlFor="isDefault">
+                    Default jurisdiction (for WHO global standard)
+                  </Label>
                 </div>
               </div>
-
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="isDefault"
-                  checked={formData.isDefault}
-                  onCheckedChange={(checked: boolean) =>
-                    setFormData({ ...formData, isDefault: checked })
-                  }
-                />
-                <Label htmlFor="isDefault">
-                  Default jurisdiction (for WHO global standard)
-                </Label>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setIsDialogOpen(false)}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button onClick={handleSave} disabled={isSaving}>
-                {isSaving ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : editingJurisdiction ? (
-                  "Update"
-                ) : (
-                  "Create"
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsDialogOpen(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : editingJurisdiction ? (
+                    "Update"
+                  ) : (
+                    "Create"
+                  )}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
           </Dialog>
         </div>
       </div>
@@ -449,69 +377,72 @@ export default function JurisdictionsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {jurisdictions.map((jurisdiction) => (
-                  <TableRow key={jurisdiction.id}>
-                    <TableCell className="font-mono font-medium">
-                      {jurisdiction.code}
-                    </TableCell>
-                    <TableCell>{jurisdiction.name}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline">{jurisdiction.country}</Badge>
-                    </TableCell>
-                    <TableCell>{jurisdiction.region || "—"}</TableCell>
-                    <TableCell>
-                      {jurisdiction.parentCode ? (
-                        <Badge variant="secondary">
-                          {jurisdiction.parentCode}
-                        </Badge>
-                      ) : (
-                        "—"
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <LinkedCountBadge
-                        count={
-                          thresholdCountByJurisdiction[jurisdiction.code] ?? 0
-                        }
-                        icon={<Scale />}
-                        href={`/thresholds?jurisdiction=${encodeURIComponent(jurisdiction.code)}`}
-                        title={`${thresholdCountByJurisdiction[jurisdiction.code] ?? 0} ${(thresholdCountByJurisdiction[jurisdiction.code] ?? 0) === 1 ? "threshold" : "thresholds"} reference ${jurisdiction.code}`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <LinkedCountBadge
-                        count={
-                          jurisdictions.filter(
-                            (j) => j.parentCode === jurisdiction.code,
-                          ).length
-                        }
-                        icon={<GitBranch />}
-                        title={`${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length} ${jurisdictions.filter((j) => j.parentCode === jurisdiction.code).length === 1 ? "jurisdiction" : "jurisdictions"} list ${jurisdiction.code} as parentCode`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {jurisdiction.isDefault ? <Badge>Default</Badge> : null}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => openEditDialog(jurisdiction)}
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDelete(jurisdiction)}
-                        >
-                          <Trash2 className="h-4 w-4 text-red-500" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {jurisdictions.map((jurisdiction) => {
+                  const tCount =
+                    thresholdCountByJurisdiction[jurisdiction.code] ?? 0;
+                  const childCount = jurisdictions.filter(
+                    (j) => j.parentCode === jurisdiction.code,
+                  ).length;
+                  return (
+                    <TableRow key={jurisdiction.id}>
+                      <TableCell className="font-mono font-medium">
+                        {jurisdiction.code}
+                      </TableCell>
+                      <TableCell>{jurisdiction.name}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{jurisdiction.country}</Badge>
+                      </TableCell>
+                      <TableCell>{jurisdiction.region || "—"}</TableCell>
+                      <TableCell>
+                        {jurisdiction.parentCode ? (
+                          <Badge variant="secondary">
+                            {jurisdiction.parentCode}
+                          </Badge>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <LinkedCountBadge
+                          count={tCount}
+                          icon={<Scale />}
+                          href={`/thresholds?jurisdiction=${encodeURIComponent(jurisdiction.code)}`}
+                          title={`${tCount} ${tCount === 1 ? "threshold" : "thresholds"} reference ${jurisdiction.code}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <LinkedCountBadge
+                          count={childCount}
+                          icon={<GitBranch />}
+                          title={`${childCount} ${childCount === 1 ? "jurisdiction" : "jurisdictions"} list ${jurisdiction.code} as parentCode`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        {jurisdiction.isDefault ? (
+                          <Badge>Default</Badge>
+                        ) : null}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => openEdit(jurisdiction)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDelete(jurisdiction)}
+                          >
+                            <Trash2 className="h-4 w-4 text-red-500" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           )}

--- a/apps/admin/src/app/(admin)/jurisdictions/page.tsx
+++ b/apps/admin/src/app/(admin)/jurisdictions/page.tsx
@@ -85,6 +85,7 @@ export default function JurisdictionsPage() {
     formData,
     setFormData,
     isSaving,
+    isDeleting,
     handleSave,
     handleDelete,
     handleExport,
@@ -136,7 +137,9 @@ export default function JurisdictionsPage() {
   // Kept in the page because it's not the page's own model — useCrudResource
   // owns Jurisdiction lifecycle; threshold counts are derived from a different
   // table and only need to refresh on initial load (admins don't add/remove
-  // thresholds from this page).
+  // thresholds from this page). When a jurisdiction is deleted, its entry
+  // here goes stale but never renders — the row that would have read it is
+  // gone — so we intentionally don't refresh the counts on CRUD events.
   const [thresholdCountByJurisdiction, setThresholdCountByJurisdiction] =
     useState<Record<string, number>>({});
 
@@ -435,6 +438,7 @@ export default function JurisdictionsPage() {
                             variant="ghost"
                             size="icon"
                             onClick={() => handleDelete(jurisdiction)}
+                            disabled={isDeleting}
                           >
                             <Trash2 className="h-4 w-4 text-red-500" />
                           </Button>

--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -1,0 +1,276 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
+import { toast } from "sonner";
+
+/**
+ * useCrudResource — generic CRUD lifecycle for one Amplify model.
+ *
+ * Owns the parts every reference-data admin page does the same way:
+ * list state, fetch + loading, dialog open/close + editing-record tracking,
+ * form state, save (create/update) dispatch, delete with confirm, optional
+ * JSON export. Pages stay responsible for their own JSX (table columns,
+ * dialog form fields) and for the page-specific concerns the hook can't
+ * see (companion-model fetches, derived counts, filtering / sort).
+ *
+ * Designed for the 8 admin pages that currently each carry ~500-600 LOC of
+ * near-identical CRUD boilerplate. Each migration removes roughly the same
+ * absolute amount (~70 LOC of state/handler glue per page) — most of what's
+ * left is the form JSX, which doesn't compress. So expected shrink is ~10-15%
+ * per page; the wins compound across the 5-8 pages that share the pattern.
+ *
+ * The hook does NOT replace forms. Form rendering, validation surface, and
+ * field-level event handlers stay in the page — pass `defaultFormValues`,
+ * `editToForm`, `validate`, and `formToPayload` to plug them in.
+ */
+/**
+ * Loose Amplify model shape — the four methods every page-side CRUD touches.
+ * Intentionally permissive on input/output payloads because Amplify's generated
+ * types vary per model.
+ */
+interface CrudModel<TItem> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  list: (options?: any) => Promise<{ data?: TItem[] | null; errors?: unknown }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  create: (data: any) => Promise<unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  update: (data: any) => Promise<unknown>;
+  delete: (data: { id: string }) => Promise<unknown>;
+}
+
+export interface UseCrudResourceConfig<T, FormData> {
+  /** Human-readable name used in toast messages, e.g. "Jurisdiction". */
+  resourceName: string;
+  /** Plural for list-fetch error toasts. Defaults to `resourceName + "s"`. */
+  resourceNamePlural?: string;
+
+  /**
+   * Selector for the Amplify model on the generated client. Function form
+   * (rather than passing the model directly) keeps the `generateClient()`
+   * call inside the hook, matching the existing per-page pattern.
+   *
+   * Typed loosely because Amplify Gen2's per-model create/update signatures
+   * require specific required-field shapes (e.g. `{ code, name, country }`
+   * for Jurisdiction) that don't unify across models. The page-level T and
+   * FormData generics preserve type safety for everything the hook returns
+   * to consumers; the model interface itself is just glue.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getModel: (client: ReturnType<typeof generateClient<Schema>>) => CrudModel<any>;
+
+  /** Default values used to reset the form when opening Create. */
+  defaultFormValues: FormData;
+
+  /** Translate a record into form-shaped data when opening Edit. */
+  editToForm: (record: T) => FormData;
+
+  /** Optional pre-save validator. Return an error message to abort + toast. */
+  validate?: (form: FormData) => string | null;
+
+  /** Transform form data into the Amplify create / update payload. */
+  formToPayload: (form: FormData) => Record<string, unknown>;
+
+  /** Optional list-options passed to `model.list()` on each refresh. */
+  listOptions?: Record<string, unknown>;
+
+  /** Optional accessor for the record's display name. Used in the delete
+   *  confirm prompt: `Are you sure you want to delete "<name>"?`. */
+  getDisplayName?: (record: T) => string;
+
+  /** Optional JSON export configuration. When set, `handleExport` writes
+   *  a file with `transform`-mapped records (defaults to identity). */
+  export?: {
+    fileName: string;
+    transform?: (record: T) => unknown;
+  };
+}
+
+export interface UseCrudResource<T, FormData> {
+  // List
+  data: T[];
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+
+  // Dialog
+  isDialogOpen: boolean;
+  setIsDialogOpen: (open: boolean) => void;
+  editingRecord: T | null;
+  openCreate: () => void;
+  openEdit: (record: T) => void;
+
+  // Form
+  formData: FormData;
+  setFormData: Dispatch<SetStateAction<FormData>>;
+
+  // Mutations
+  isSaving: boolean;
+  handleSave: () => Promise<void>;
+  handleDelete: (record: T) => Promise<void>;
+
+  // Export (no-op when `config.export` is not provided)
+  handleExport: () => void;
+}
+
+type RecordWithId = { id: string };
+
+export function useCrudResource<T extends RecordWithId, FormData>(
+  config: UseCrudResourceConfig<T, FormData>,
+): UseCrudResource<T, FormData> {
+  const {
+    resourceName,
+    defaultFormValues,
+    editToForm,
+    validate,
+    formToPayload,
+    listOptions,
+    getDisplayName,
+    getModel,
+  } = config;
+  const resourceNamePlural = config.resourceNamePlural ?? `${resourceName}s`;
+  const exportConfig = config.export;
+
+  const [data, setData] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingRecord, setEditingRecord] = useState<T | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [formData, setFormData] = useState<FormData>(defaultFormValues);
+
+  const refresh = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const client = generateClient<Schema>();
+      const model = getModel(client);
+      const result = await model.list(listOptions);
+      if (result.errors) {
+        console.error(`Error fetching ${resourceNamePlural}:`, result.errors);
+        toast.error(`Failed to fetch ${resourceNamePlural}`);
+        return;
+      }
+      setData((result.data ?? []) as T[]);
+    } catch (err) {
+      console.error(`Error fetching ${resourceNamePlural}:`, err);
+      toast.error(`Failed to fetch ${resourceNamePlural}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getModel, listOptions, resourceNamePlural]);
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on mount;
+    // subsequent refreshes are caller-triggered via the returned `refresh`.
+  }, []);
+
+  const openCreate = useCallback(() => {
+    setEditingRecord(null);
+    setFormData(defaultFormValues);
+    setIsDialogOpen(true);
+  }, [defaultFormValues]);
+
+  const openEdit = useCallback(
+    (record: T) => {
+      setEditingRecord(record);
+      setFormData(editToForm(record));
+      setIsDialogOpen(true);
+    },
+    [editToForm],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (validate) {
+      const err = validate(formData);
+      if (err) {
+        toast.error(err);
+        return;
+      }
+    }
+    setIsSaving(true);
+    try {
+      const client = generateClient<Schema>();
+      const model = getModel(client);
+      const payload = formToPayload(formData);
+      if (editingRecord) {
+        await model.update({ id: editingRecord.id, ...payload });
+        toast.success(`${resourceName} updated`);
+      } else {
+        await model.create(payload);
+        toast.success(`${resourceName} created`);
+      }
+      setIsDialogOpen(false);
+      setEditingRecord(null);
+      setFormData(defaultFormValues);
+      await refresh();
+    } catch (err) {
+      console.error(`Error saving ${resourceName}:`, err);
+      toast.error(`Failed to save ${resourceName}`);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    defaultFormValues,
+    editingRecord,
+    formData,
+    formToPayload,
+    getModel,
+    refresh,
+    resourceName,
+    validate,
+  ]);
+
+  const handleDelete = useCallback(
+    async (record: T) => {
+      const name = getDisplayName?.(record);
+      const message = name
+        ? `Are you sure you want to delete "${name}"?`
+        : `Are you sure you want to delete this ${resourceName.toLowerCase()}?`;
+      if (!confirm(message)) return;
+      try {
+        const client = generateClient<Schema>();
+        const model = getModel(client);
+        await model.delete({ id: record.id });
+        toast.success(`${resourceName} deleted`);
+        await refresh();
+      } catch (err) {
+        console.error(`Error deleting ${resourceName}:`, err);
+        toast.error(`Failed to delete ${resourceName}`);
+      }
+    },
+    [getDisplayName, getModel, refresh, resourceName],
+  );
+
+  const handleExport = useCallback(() => {
+    if (!exportConfig) return;
+    const exportData = data.map(exportConfig.transform ?? ((r) => r));
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = exportConfig.fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success(`Exported ${exportConfig.fileName}`);
+  }, [data, exportConfig]);
+
+  return {
+    data,
+    isLoading,
+    refresh,
+    isDialogOpen,
+    setIsDialogOpen,
+    editingRecord,
+    openCreate,
+    openEdit,
+    formData,
+    setFormData,
+    isSaving,
+    handleSave,
+    handleDelete,
+    handleExport,
+  };
+}

--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -25,6 +25,14 @@ import { toast } from "sonner";
  * The hook does NOT replace forms. Form rendering, validation surface, and
  * field-level event handlers stay in the page — pass `defaultFormValues`,
  * `editToForm`, `validate`, and `formToPayload` to plug them in.
+ *
+ * Note on referential stability: the returned handlers (`openCreate`,
+ * `openEdit`, `handleSave`, `handleDelete`, `handleExport`, `refresh`) are
+ * NOT referentially stable across renders, because the config callbacks
+ * (`getModel`, `editToForm`, `formToPayload`, …) are typically inline literals
+ * with a fresh identity per render. This is fine when the handlers are used
+ * directly in `onClick` (the common case). If you need to put one in a
+ * `useEffect` dep array, memoize the config object at the call site first.
  */
 /**
  * Loose Amplify model shape — the four methods every page-side CRUD touches.
@@ -107,6 +115,7 @@ export interface UseCrudResource<T, FormData> {
 
   // Mutations
   isSaving: boolean;
+  isDeleting: boolean;
   handleSave: () => Promise<void>;
   handleDelete: (record: T) => Promise<void>;
 
@@ -137,6 +146,7 @@ export function useCrudResource<T extends RecordWithId, FormData>(
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingRecord, setEditingRecord] = useState<T | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [formData, setFormData] = useState<FormData>(defaultFormValues);
 
   const refresh = useCallback(async () => {
@@ -223,11 +233,16 @@ export function useCrudResource<T extends RecordWithId, FormData>(
 
   const handleDelete = useCallback(
     async (record: T) => {
+      // Re-entrancy guard: a previous delete is still in flight. Callers
+      // should also disable trigger UI via the returned `isDeleting`, but
+      // this defends against handler races even when they forget.
+      if (isDeleting) return;
       const name = getDisplayName?.(record);
       const message = name
         ? `Are you sure you want to delete "${name}"?`
         : `Are you sure you want to delete this ${resourceName.toLowerCase()}?`;
       if (!confirm(message)) return;
+      setIsDeleting(true);
       try {
         const client = generateClient<Schema>();
         const model = getModel(client);
@@ -237,13 +252,22 @@ export function useCrudResource<T extends RecordWithId, FormData>(
       } catch (err) {
         console.error(`Error deleting ${resourceName}:`, err);
         toast.error(`Failed to delete ${resourceName}`);
+      } finally {
+        setIsDeleting(false);
       }
     },
-    [getDisplayName, getModel, refresh, resourceName],
+    [getDisplayName, getModel, isDeleting, refresh, resourceName],
   );
 
   const handleExport = useCallback(() => {
-    if (!exportConfig) return;
+    if (!exportConfig) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `useCrudResource: handleExport called for ${resourceName} but no \`export\` config was provided.`,
+        );
+      }
+      return;
+    }
     const exportData = data.map(exportConfig.transform ?? ((r) => r));
     const blob = new Blob([JSON.stringify(exportData, null, 2)], {
       type: "application/json",
@@ -252,10 +276,14 @@ export function useCrudResource<T extends RecordWithId, FormData>(
     const a = document.createElement("a");
     a.href = url;
     a.download = exportConfig.fileName;
+    // Some browsers (Firefox, older Safari) require the anchor to be in the
+    // document for the synthetic click to dispatch the download.
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
     toast.success(`Exported ${exportConfig.fileName}`);
-  }, [data, exportConfig]);
+  }, [data, exportConfig, resourceName]);
 
   return {
     data,
@@ -269,6 +297,7 @@ export function useCrudResource<T extends RecordWithId, FormData>(
     formData,
     setFormData,
     isSaving,
+    isDeleting,
     handleSave,
     handleDelete,
     handleExport,


### PR DESCRIPTION
## Summary
First PR in the Phase 3 series. Adds a generic `useCrudResource` hook for one Amplify model and migrates `/jurisdictions` as the proof.

- **New file**: `apps/admin/src/hooks/useCrudResource.ts` (~270 LOC, half is JSDoc + types).
- **Migrated**: `apps/admin/src/app/(admin)/jurisdictions/page.tsx` (522 → 453 LOC, **−69 / ~13% shrink**).

The shrink-per-page is modest (~13%) because most of what's left is the dialog form JSX, which doesn't compress. What gets removed is the state-setup + handler-glue boilerplate — exactly what's identical across all 8 reference-data pages. Wins compound across PRs 2-5.

## What the hook owns
- List state (`data`, `isLoading`) + `refresh`
- Dialog state (`isDialogOpen`, `setIsDialogOpen`, `editingRecord`)
- Open helpers (`openCreate`, `openEdit`)
- Form state (`formData`, `setFormData`)
- Mutations (`isSaving`, `handleSave`, `handleDelete`)
- Optional JSON export (`handleExport`)
- Toasts for success / error / validation
- Delete-confirm with optional `getDisplayName` for the prompt
- Automatic refresh on mount + after save/delete

## What the page keeps
- JSX (table columns, dialog form fields, page header)
- Form field shape (via the `FormData` generic)
- Validation (returned as `errMessage | null` from `validate(form)`)
- Form → payload transform
- Companion data (e.g. Jurisdictions reads `ContaminantThreshold` to render the count badges; that's a separate `useEffect` in the page, not the hook's concern)

## API at a glance
```ts
const crud = useCrudResource<Jurisdiction, JurisdictionFormData>({
  resourceName: \"Jurisdiction\",
  getModel: (client) => client.models.Jurisdiction,
  listOptions: { limit: 100 },
  defaultFormValues: { code: \"\", name: \"\", ... },
  editToForm: (j) => ({ code: j.code, name: j.name, ... }),
  validate: (form) => !form.code ? \"Code is required\" : null,
  formToPayload: (form) => ({ code: form.code, ... }),
  getDisplayName: (j) => j.name,
  export: { fileName: \"jurisdictions.json\", transform: (j) => ({...}) },
});
```

## TypeScript trade-off
The `getModel` selector returns a loosely-typed model interface (`any` on its create / update payload types). Amplify Gen2's per-model signatures require model-specific required-field shapes (e.g. `{ code, name, country }` for Jurisdiction) that don't unify across models. The page-level `T` and `FormData` generics preserve type safety for everything the hook returns to consumers; only the glue boundary itself is loose. ESLint disable lines are inline-scoped.

## Behavior preserved on /jurisdictions
- The \"Please fill in all required fields\" toast wording matches the old behavior.
- The delete confirm uses the same `Are you sure you want to delete \"<name>\"?` format (via `getDisplayName`).
- `isDefault` toggle null-coalescing in `editToForm` and `formToPayload` matches exactly.
- Threshold-count companion fetch stays in the page as a single `useEffect` — it reads a different model and doesn't need to retrigger on Jurisdiction CRUD events.

## Test plan
- [ ] CI: lint + tsc + Playwright (especially `apps/admin/e2e/admin/admin-route-smoke.spec.ts` which exercises every admin route)
- [ ] After merge, smoke on admin staging `/jurisdictions`:
  - [ ] Table renders with all jurisdictions
  - [ ] Add Jurisdiction → fill required fields → Save → row appears + toast \"Jurisdiction created\"
  - [ ] Edit pencil → form pre-populates → Update → toast \"Jurisdiction updated\"
  - [ ] Save with empty required fields → toast \"Please fill in all required fields\", form stays open
  - [ ] Delete trash → confirm with name → row disappears + toast \"Jurisdiction deleted\"
  - [ ] Export JSON → file downloads
  - [ ] Threshold + Children count badges still render (companion fetch path)

## Follow-up PRs (one per page)
- **2/5** — `/contaminants` (507 LOC, similar shape)
- **3/5** — `/categories` (599 LOC, has link arrays — slightly more page-side glue)
- **4/5** — `/subcategories` (649 LOC, has parent select + filter state)
- **5/5** — `/properties` (597 LOC, has conditional fields by observationType)

`/thresholds` and `/property-thresholds` deferred to a second pass per the plan — they share nuanced filter / conditional-field logic that may need a hook extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)