### PR TITLE
refactor(admin): re-apply /contaminants + migrate /categories to useCrudResource (Phase 3, PR 3/5 + missing 2/5)

### DIFF
--- a/apps/admin/src/app/(admin)/categories/page.tsx
+++ b/apps/admin/src/app/(admin)/categories/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { generateClient } from "aws-amplify/data";
+import { useMemo } from "react";
 import type { Schema } from "@mapyourhealth/backend/amplify/data/resource";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,7 +33,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Plus, Pencil, Trash2, Loader2, Eye, EyeOff } from "lucide-react";
-import { toast } from "sonner";
+import { useCrudResource } from "@/hooks/useCrudResource";
 
 type Category = Schema["Category"]["type"];
 
@@ -42,6 +41,34 @@ interface CategoryLink {
   label: string;
   url: string;
 }
+
+interface CategoryFormData {
+  categoryId: string;
+  name: string;
+  nameFr: string;
+  description: string;
+  descriptionFr: string;
+  icon: string;
+  color: string;
+  sortOrder: number;
+  isActive: boolean;
+  links: CategoryLink[];
+  showStandardsTable: boolean;
+}
+
+const DEFAULT_FORM: CategoryFormData = {
+  categoryId: "",
+  name: "",
+  nameFr: "",
+  description: "",
+  descriptionFr: "",
+  icon: "water",
+  color: "#3B82F6",
+  sortOrder: 0,
+  isActive: true,
+  links: [],
+  showStandardsTable: false,
+};
 
 // Common MaterialCommunityIcons used in the app
 const ICON_OPTIONS = [
@@ -59,196 +86,112 @@ const ICON_OPTIONS = [
   { value: "bacteria", label: "Bacteria" },
 ];
 
-export default function CategoriesPage() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+function parseLinks(raw: Category["links"]): CategoryLink[] {
+  if (!raw) return [];
+  try {
+    return typeof raw === "string" ? JSON.parse(raw) : (raw as CategoryLink[]);
+  } catch {
+    return [];
+  }
+}
 
-  // Form state
-  const [formData, setFormData] = useState({
-    categoryId: "",
-    name: "",
-    nameFr: "",
-    description: "",
-    descriptionFr: "",
-    icon: "water",
-    color: "#3B82F6",
-    sortOrder: 0,
-    isActive: true,
-    links: [] as CategoryLink[],
-    showStandardsTable: false,
+export default function CategoriesPage() {
+  const {
+    data: unsortedCategories,
+    isLoading,
+    isDialogOpen,
+    setIsDialogOpen,
+    editingRecord: editingCategory,
+    openCreate,
+    openEdit,
+    formData,
+    setFormData,
+    isSaving,
+    handleSave,
+    handleDelete,
+  } = useCrudResource<Category, CategoryFormData>({
+    resourceName: "Category",
+    resourceNamePlural: "categories",
+    getModel: (client) => client.models.Category,
+    listOptions: { limit: 100 },
+    defaultFormValues: DEFAULT_FORM,
+    editToForm: (c) => ({
+      categoryId: c.categoryId,
+      name: c.name,
+      nameFr: c.nameFr || "",
+      description: c.description || "",
+      descriptionFr: c.descriptionFr || "",
+      icon: c.icon,
+      color: c.color,
+      sortOrder: c.sortOrder ?? 0,
+      isActive: c.isActive ?? true,
+      links: parseLinks(c.links),
+      showStandardsTable: c.showStandardsTable ?? false,
+    }),
+    validate: (form) => {
+      if (!form.categoryId || !form.name || !form.icon) {
+        return "Please fill in all required fields";
+      }
+      return null;
+    },
+    formToPayload: (form) => ({
+      categoryId: form.categoryId.toLowerCase(),
+      name: form.name,
+      nameFr: form.nameFr || null,
+      description: form.description || null,
+      descriptionFr: form.descriptionFr || null,
+      icon: form.icon,
+      color: form.color,
+      sortOrder: form.sortOrder,
+      isActive: form.isActive,
+      links: form.links.length > 0 ? JSON.stringify(form.links) : null,
+      showStandardsTable: form.showStandardsTable,
+    }),
+    getDisplayName: (c) => c.name,
   });
 
-  const fetchCategories = async () => {
-    try {
-      setIsLoading(true);
-      const client = generateClient<Schema>();
-      const { data, errors } = await client.models.Category.list({
-        limit: 100,
-      });
-
-      if (errors) {
-        console.error("Error fetching categories:", errors);
-        toast.error("Failed to fetch categories");
-        return;
-      }
-
-      // Sort by sortOrder
-      const sorted = [...(data || [])].sort(
+  // Page-side sort by sortOrder for display. The hook returns the raw list;
+  // ordering is a render-time concern.
+  const categories = useMemo(
+    () =>
+      [...unsortedCategories].sort(
         (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0),
-      );
-      setCategories(sorted);
-    } catch (error) {
-      console.error("Error fetching categories:", error);
-      toast.error("Failed to fetch categories");
-    } finally {
-      setIsLoading(false);
-    }
+      ),
+    [unsortedCategories],
+  );
+
+  // Wrap openCreate so the new-row sortOrder defaults to the end of the
+  // current list (matches the prior behavior of resetForm). The hook's
+  // openCreate has already set formData to DEFAULT_FORM; we override
+  // sortOrder via a follow-up setFormData (state updates batch).
+  const handleOpenCreate = () => {
+    openCreate();
+    setFormData((prev) => ({ ...prev, sortOrder: categories.length }));
   };
 
-  useEffect(() => {
-    fetchCategories();
-  }, []);
-
-  const resetForm = () => {
-    setFormData({
-      categoryId: "",
-      name: "",
-      nameFr: "",
-      description: "",
-      descriptionFr: "",
-      icon: "water",
-      color: "#3B82F6",
-      sortOrder: categories.length,
-      isActive: true,
-      links: [],
-      showStandardsTable: false,
-    });
-    setEditingCategory(null);
-  };
-
-  const openCreateDialog = () => {
-    resetForm();
-    setIsDialogOpen(true);
-  };
-
-  const openEditDialog = (category: Category) => {
-    setEditingCategory(category);
-    let links: CategoryLink[] = [];
-    try {
-      if (category.links) {
-        links =
-          typeof category.links === "string"
-            ? JSON.parse(category.links)
-            : category.links;
-      }
-    } catch {
-      links = [];
-    }
-
-    setFormData({
-      categoryId: category.categoryId,
-      name: category.name,
-      nameFr: category.nameFr || "",
-      description: category.description || "",
-      descriptionFr: category.descriptionFr || "",
-      icon: category.icon,
-      color: category.color,
-      sortOrder: category.sortOrder ?? 0,
-      isActive: category.isActive ?? true,
-      links,
-      showStandardsTable: category.showStandardsTable ?? false,
-    });
-    setIsDialogOpen(true);
-  };
-
-  const handleSave = async () => {
-    if (!formData.categoryId || !formData.name || !formData.icon) {
-      toast.error("Please fill in all required fields");
-      return;
-    }
-
-    setIsSaving(true);
-    try {
-      const client = generateClient<Schema>();
-
-      const categoryData = {
-        categoryId: formData.categoryId.toLowerCase(),
-        name: formData.name,
-        nameFr: formData.nameFr || null,
-        description: formData.description || null,
-        descriptionFr: formData.descriptionFr || null,
-        icon: formData.icon,
-        color: formData.color,
-        sortOrder: formData.sortOrder,
-        isActive: formData.isActive,
-        links:
-          formData.links.length > 0 ? JSON.stringify(formData.links) : null,
-        showStandardsTable: formData.showStandardsTable,
-      };
-
-      if (editingCategory) {
-        await client.models.Category.update({
-          id: editingCategory.id,
-          ...categoryData,
-        });
-        toast.success("Category updated");
-      } else {
-        await client.models.Category.create(categoryData);
-        toast.success("Category created");
-      }
-
-      setIsDialogOpen(false);
-      resetForm();
-      fetchCategories();
-    } catch (error) {
-      console.error("Error saving category:", error);
-      toast.error("Failed to save category");
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleDelete = async (category: Category) => {
-    if (!confirm(`Are you sure you want to delete "${category.name}"?`)) {
-      return;
-    }
-
-    try {
-      const client = generateClient<Schema>();
-      await client.models.Category.delete({ id: category.id });
-      toast.success("Category deleted");
-      fetchCategories();
-    } catch (error) {
-      console.error("Error deleting category:", error);
-      toast.error("Failed to delete category");
-    }
-  };
-
+  // Link list helpers — pure setFormData mutations, stay in the page.
   const addLink = () => {
-    setFormData({
-      ...formData,
-      links: [...formData.links, { label: "", url: "" }],
-    });
+    setFormData((prev) => ({
+      ...prev,
+      links: [...prev.links, { label: "", url: "" }],
+    }));
   };
-
   const updateLink = (
     index: number,
     field: "label" | "url",
     value: string,
   ) => {
-    const newLinks = [...formData.links];
-    newLinks[index] = { ...newLinks[index], [field]: value };
-    setFormData({ ...formData, links: newLinks });
-  };
-
-  const removeLink = (index: number) => {
-    setFormData({
-      ...formData,
-      links: formData.links.filter((_, i) => i !== index),
+    setFormData((prev) => {
+      const newLinks = [...prev.links];
+      newLinks[index] = { ...newLinks[index], [field]: value };
+      return { ...prev, links: newLinks };
     });
+  };
+  const removeLink = (index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      links: prev.links.filter((_, i) => i !== index),
+    }));
   };
 
   return (
@@ -262,7 +205,7 @@ export default function CategoriesPage() {
         </div>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogTrigger asChild>
-            <Button onClick={openCreateDialog}>
+            <Button onClick={handleOpenCreate}>
               <Plus className="mr-2 h-4 w-4" />
               Add Category
             </Button>
@@ -574,7 +517,7 @@ export default function CategoriesPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => openEditDialog(category)}
+                          onClick={() => openEdit(category)}
                         >
                           <Pencil className="h-4 w-4" />
                         </Button>

--- a/apps/admin/src/app/(admin)/contaminants/page.tsx
+++ b/apps/admin/src/app/(admin)/contaminants/page.tsx
@@ -39,7 +39,6 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Plus, Pencil, Trash2, Loader2, Scale } from "lucide-react";
-import { toast } from "sonner";
 import {
   CONTAMINANT_CATEGORIES,
   contaminantCategoryColors,
@@ -47,167 +46,102 @@ import {
   type ContaminantCategory,
 } from "@/lib/constants";
 import { LinkedCountBadge } from "@/components/LinkedCountBadge";
+import { useCrudResource } from "@/hooks/useCrudResource";
 
 type Contaminant = Schema["Contaminant"]["type"];
 
-export default function ContaminantsPage() {
-  const [contaminants, setContaminants] = useState<Contaminant[]>([]);
-  const [thresholdCountByContaminant, setThresholdCountByContaminant] =
-    useState<Record<string, number>>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [editingContaminant, setEditingContaminant] =
-    useState<Contaminant | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+interface ContaminantFormData {
+  contaminantId: string;
+  name: string;
+  nameFr: string;
+  unit: string;
+  description: string;
+  descriptionFr: string;
+  category: ContaminantCategory | "";
+  studies: string;
+  higherIsBad: boolean;
+}
 
-  // Form state
-  const [formData, setFormData] = useState({
-    contaminantId: "",
-    name: "",
-    nameFr: "",
-    unit: "",
-    description: "",
-    descriptionFr: "",
-    category: "" as ContaminantCategory | "",
-    studies: "",
-    higherIsBad: true,
+const DEFAULT_FORM: ContaminantFormData = {
+  contaminantId: "",
+  name: "",
+  nameFr: "",
+  unit: "",
+  description: "",
+  descriptionFr: "",
+  category: "",
+  studies: "",
+  higherIsBad: true,
+};
+
+export default function ContaminantsPage() {
+  const {
+    data: contaminants,
+    isLoading,
+    isDialogOpen,
+    setIsDialogOpen,
+    editingRecord: editingContaminant,
+    openCreate,
+    openEdit,
+    formData,
+    setFormData,
+    isSaving,
+    handleSave,
+    handleDelete,
+  } = useCrudResource<Contaminant, ContaminantFormData>({
+    resourceName: "Contaminant",
+    getModel: (client) => client.models.Contaminant,
+    listOptions: { limit: 1000 },
+    defaultFormValues: DEFAULT_FORM,
+    editToForm: (c) => ({
+      contaminantId: c.contaminantId,
+      name: c.name,
+      nameFr: c.nameFr || "",
+      unit: c.unit,
+      description: c.description || "",
+      descriptionFr: c.descriptionFr || "",
+      category: (c.category as ContaminantCategory) || "",
+      studies: c.studies || "",
+      higherIsBad: c.higherIsBad,
+    }),
+    validate: (form) => {
+      if (!form.contaminantId || !form.name || !form.unit || !form.category) {
+        return "Please fill in all required fields";
+      }
+      return null;
+    },
+    formToPayload: (form) => ({
+      contaminantId: form.contaminantId,
+      name: form.name,
+      nameFr: form.nameFr || null,
+      unit: form.unit,
+      description: form.description || null,
+      descriptionFr: form.descriptionFr || null,
+      category: form.category as ContaminantCategory,
+      studies: form.studies || null,
+      higherIsBad: form.higherIsBad,
+    }),
+    getDisplayName: (c) => c.name,
   });
 
-  const fetchContaminants = async () => {
-    try {
-      setIsLoading(true);
-      const client = generateClient<Schema>();
-      const [contaminantsResult, thresholdsResult] = await Promise.all([
-        client.models.Contaminant.list({ limit: 1000 }),
-        client.models.ContaminantThreshold.list({ limit: 1000 }),
-      ]);
+  // Companion fetch for the LinkedCountBadge counts (Thresholds column).
+  // Kept in the page because it reads a different model. Only fetched once on
+  // mount — admins manage thresholds elsewhere, so we don't need to retrigger
+  // on Contaminant CRUD.
+  const [thresholdCountByContaminant, setThresholdCountByContaminant] =
+    useState<Record<string, number>>({});
 
-      if (contaminantsResult.errors) {
-        console.error("Error fetching contaminants:", contaminantsResult.errors);
-        toast.error("Failed to fetch contaminants");
-        return;
-      }
-
-      setContaminants(contaminantsResult.data || []);
-
+  useEffect(() => {
+    const client = generateClient<Schema>();
+    client.models.ContaminantThreshold.list({ limit: 1000 }).then((result) => {
       const counts: Record<string, number> = {};
-      for (const t of thresholdsResult.data || []) {
+      for (const t of result.data || []) {
         if (!t.contaminantId) continue;
         counts[t.contaminantId] = (counts[t.contaminantId] || 0) + 1;
       }
       setThresholdCountByContaminant(counts);
-    } catch (error) {
-      console.error("Error fetching contaminants:", error);
-      toast.error("Failed to fetch contaminants");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchContaminants();
+    });
   }, []);
-
-  const resetForm = () => {
-    setFormData({
-      contaminantId: "",
-      name: "",
-      nameFr: "",
-      unit: "",
-      description: "",
-      descriptionFr: "",
-      category: "",
-      studies: "",
-      higherIsBad: true,
-    });
-    setEditingContaminant(null);
-  };
-
-  const openCreateDialog = () => {
-    resetForm();
-    setIsDialogOpen(true);
-  };
-
-  const openEditDialog = (contaminant: Contaminant) => {
-    setEditingContaminant(contaminant);
-    setFormData({
-      contaminantId: contaminant.contaminantId,
-      name: contaminant.name,
-      nameFr: contaminant.nameFr || "",
-      unit: contaminant.unit,
-      description: contaminant.description || "",
-      descriptionFr: contaminant.descriptionFr || "",
-      category: (contaminant.category as ContaminantCategory) || "",
-      studies: contaminant.studies || "",
-      higherIsBad: contaminant.higherIsBad,
-    });
-    setIsDialogOpen(true);
-  };
-
-  const handleSave = async () => {
-    if (
-      !formData.contaminantId ||
-      !formData.name ||
-      !formData.unit ||
-      !formData.category
-    ) {
-      toast.error("Please fill in all required fields");
-      return;
-    }
-
-    setIsSaving(true);
-    try {
-      const client = generateClient<Schema>();
-
-      const contaminantData = {
-        contaminantId: formData.contaminantId,
-        name: formData.name,
-        nameFr: formData.nameFr || null,
-        unit: formData.unit,
-        description: formData.description || null,
-        descriptionFr: formData.descriptionFr || null,
-        category: formData.category as ContaminantCategory,
-        studies: formData.studies || null,
-        higherIsBad: formData.higherIsBad,
-      };
-
-      if (editingContaminant) {
-        await client.models.Contaminant.update({
-          id: editingContaminant.id,
-          ...contaminantData,
-        });
-        toast.success("Contaminant updated");
-      } else {
-        await client.models.Contaminant.create(contaminantData);
-        toast.success("Contaminant created");
-      }
-
-      setIsDialogOpen(false);
-      resetForm();
-      fetchContaminants();
-    } catch (error) {
-      console.error("Error saving contaminant:", error);
-      toast.error("Failed to save contaminant");
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleDelete = async (contaminant: Contaminant) => {
-    if (!confirm(`Are you sure you want to delete "${contaminant.name}"?`)) {
-      return;
-    }
-
-    try {
-      const client = generateClient<Schema>();
-      await client.models.Contaminant.delete({ id: contaminant.id });
-      toast.success("Contaminant deleted");
-      fetchContaminants();
-    } catch (error) {
-      console.error("Error deleting contaminant:", error);
-      toast.error("Failed to delete contaminant");
-    }
-  };
 
   return (
     <div className="space-y-6">
@@ -220,7 +154,7 @@ export default function ContaminantsPage() {
         </div>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogTrigger asChild>
-            <Button onClick={openCreateDialog}>
+            <Button onClick={openCreate}>
               <Plus className="mr-2 h-4 w-4" />
               Add Contaminant
             </Button>
@@ -429,74 +363,74 @@ export default function ContaminantsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {contaminants.map((contaminant) => (
-                  <TableRow key={contaminant.id}>
-                    <TableCell className="font-mono text-sm">
-                      {contaminant.contaminantId}
-                    </TableCell>
-                    <TableCell className="font-medium">
-                      {contaminant.name}
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        variant="secondary"
-                        className={
-                          contaminant.category
-                            ? contaminantCategoryColors[
+                {contaminants.map((contaminant) => {
+                  const tCount =
+                    thresholdCountByContaminant[contaminant.contaminantId] ?? 0;
+                  return (
+                    <TableRow key={contaminant.id}>
+                      <TableCell className="font-mono text-sm">
+                        {contaminant.contaminantId}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {contaminant.name}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="secondary"
+                          className={
+                            contaminant.category
+                              ? contaminantCategoryColors[
+                                  contaminant.category as ContaminantCategory
+                                ]
+                              : ""
+                          }
+                        >
+                          {contaminant.category
+                            ? contaminantCategoryNames[
                                 contaminant.category as ContaminantCategory
                               ]
-                            : ""
-                        }
-                      >
-                        {contaminant.category
-                          ? contaminantCategoryNames[
-                              contaminant.category as ContaminantCategory
-                            ]
-                          : "—"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>{contaminant.unit}</TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={
-                          contaminant.higherIsBad ? "destructive" : "default"
-                        }
-                      >
-                        {contaminant.higherIsBad ? "Bad" : "Good"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <LinkedCountBadge
-                        count={
-                          thresholdCountByContaminant[
-                            contaminant.contaminantId
-                          ] ?? 0
-                        }
-                        icon={<Scale />}
-                        href={`/thresholds?contaminant=${encodeURIComponent(contaminant.contaminantId)}`}
-                        title={`${thresholdCountByContaminant[contaminant.contaminantId] ?? 0} ${(thresholdCountByContaminant[contaminant.contaminantId] ?? 0) === 1 ? "threshold" : "thresholds"} defined for ${contaminant.contaminantId}`}
-                      />
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => openEditDialog(contaminant)}
+                            : "—"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{contaminant.unit}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            contaminant.higherIsBad ? "destructive" : "default"
+                          }
                         >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDelete(contaminant)}
-                        >
-                          <Trash2 className="h-4 w-4 text-red-500" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
+                          {contaminant.higherIsBad ? "Bad" : "Good"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <LinkedCountBadge
+                          count={tCount}
+                          icon={<Scale />}
+                          href={`/thresholds?contaminant=${encodeURIComponent(contaminant.contaminantId)}`}
+                          title={`${tCount} ${tCount === 1 ? "threshold" : "thresholds"} defined for ${contaminant.contaminantId}`}
+                        />
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => openEdit(contaminant)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDelete(contaminant)}
+                          >
+                            <Trash2 className="h-4 w-4 text-red-500" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           )}


### PR DESCRIPTION
## Summary
Two commits in one PR.

**1. `/contaminants` migration (re-applied).** PR #385 showed as merged on GitHub but its content never made it to staging — it was stacked on PR #384's branch and the squash/merge dance only landed jurisdictions. The contaminants page on staging is still pre-migration (507 LOC, no `useCrudResource` import). This commit is a clean cherry-pick of #385's content onto current staging — applies without conflict.

**2. `/categories` migration (new).** Page goes from 599 → 542 LOC (−57).

Both follow the same recipe as #384/#385. Combined diff: **2 files, +270 / −393**.

## Why bundle both
PR #385's branch (`refactor/admin-crud-hook-contaminants`) still exists with the right content, but re-opening it as a fresh PR vs staging would create two near-empty PR ceremonies. Bundling here keeps reviewer load tight and gets staging back to a consistent state (every migrated page using the hook).

## `/categories` — page-specific glue
Categories has a few patterns the hook can't own:
- **Sort by `sortOrder`** — `useMemo` over the hook's raw `data` (render-time concern).
- **`links` JSON field** — parse on `editToForm`, stringify on `formToPayload`. Three helpers (`addLink` / `updateLink` / `removeLink`) stay in the page as pure `setFormData` mutations.
- **`sortOrder` defaults to end of list on create** — wrapped `openCreate` with a follow-up `setFormData((prev) => ({ ...prev, sortOrder: categories.length }))`. The hook's `setFormData(defaultFormValues)` and this follow-up batch correctly.
- **`resourceNamePlural: \"categories\"`** override — the default `\"Categorys\"` reads ugly in error toasts.

## Behavior preserved
- `/contaminants`: identical to PR #385 (cherry-pick).
- `/categories`:
  - Sort by sortOrder applied to list view
  - `categoryId.toLowerCase()` at write time
  - Links parsing handles both string and object shapes (legacy data tolerance)
  - \"Please fill in all required fields\" toast on missing `categoryId`/`name`/`icon`
  - Delete confirm uses `category.name` via `getDisplayName`

## Test plan
- [ ] CI: lint + tsc + Playwright admin
- [ ] After merge, smoke `/contaminants`:
  - [ ] Table renders (counts visible in Thresholds column)
  - [ ] Add → Save → row appears + toast
  - [ ] Edit → form pre-populates → Update → toast
  - [ ] Delete → confirm with name → toast
- [ ] After merge, smoke `/categories`:
  - [ ] Table renders sorted by sortOrder
  - [ ] Add Category → sortOrder pre-fills to next available; can override
  - [ ] Edit Category with links → links pre-populate correctly
  - [ ] Add Link / Update Link / Remove Link inside dialog all work
  - [ ] Save Category with links → row persists; reopening edit shows the same links
  - [ ] Delete category → confirm with name → row disappears

## Stack status
- ~~PR #384 (jurisdictions)~~ — merged
- ~~PR #385 (contaminants)~~ — \"merged\" on GitHub but content lost in the squash; **re-applied here**
- **PR #386 (this) — contaminants re-apply + categories**
- **PR 4/5** — `/subcategories` (parent select + filter state)
- **PR 5/5** — `/properties` (conditional fields by observationType)

🤖 Generated with [Claude Code](https://claude.com/claude-code)