### PR TITLE
ci: serialize Amplify deploys and retry start-job on collision

### DIFF
--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -1,0 +1,83 @@
+name: Amplify Start Job
+description: >
+  Wait for the Amplify branch to be free, then start a RELEASE job.
+  Surfaces a clear timeout error on prolonged contention, and retries
+  start-job on LimitExceededException as a defense against a job
+  slipping in between the poll and the call.
+
+inputs:
+  app-id:
+    description: Amplify app ID
+    required: true
+  branch:
+    description: Amplify branch name (e.g. "staging", "main")
+    required: true
+  sha:
+    description: Commit SHA to deploy
+    required: true
+  timeout-seconds:
+    description: How long to wait for the branch to be free
+    required: false
+    default: "1800"
+
+runs:
+  using: composite
+  steps:
+    - name: Start Amplify job
+      shell: bash
+      env:
+        APP_ID: ${{ inputs.app-id }}
+        BRANCH: ${{ inputs.branch }}
+        SHA: ${{ inputs.sha }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+      run: |
+        set -uo pipefail
+        COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+        COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+        # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+        # branch to be free before calling start-job. Surface a clear
+        # timeout error rather than falling through to the retry loop.
+        DEADLINE=$(( $(date +%s) + TIMEOUT ))
+        FREE=0
+        while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+            --output text 2>&1); then
+            if [ "$BUSY" = "0" ]; then
+              FREE=1
+              break
+            fi
+            echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+          else
+            echo "list-jobs failed: $BUSY"
+          fi
+          sleep 20
+        done
+        if [ "$FREE" = "0" ]; then
+          echo "Timed out after ${TIMEOUT}s waiting for Amplify branch $BRANCH to be free"
+          exit 1
+        fi
+
+        # Belt-and-suspenders: another caller may have slipped in between
+        # the poll and the call. Retry on LimitExceededException.
+        for attempt in 1 2 3 4 5; do
+          if OUT=$(aws amplify start-job \
+            --app-id "$APP_ID" \
+            --branch-name "$BRANCH" \
+            --job-type RELEASE \
+            --commit-id "$SHA" \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME" 2>&1); then
+            echo "$OUT"
+            exit 0
+          fi
+          echo "start-job attempt $attempt failed: $OUT"
+          if echo "$OUT" | grep -q "LimitExceededException"; then
+            sleep 30
+            continue
+          fi
+          exit 1
+        done
+        echo "start-job exhausted retries"
+        exit 1

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: admin-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -146,12 +152,50 @@ jobs:
 
       - name: Deploy Admin Portal
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id d26q32gc98goap \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="d26q32gc98goap"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: admin-deploy-${{ github.ref }}
+  group: admin-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -160,22 +160,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -151,57 +151,8 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Admin Portal
-        run: |
-          set -uo pipefail
-          APP_ID="d26q32gc98goap"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_ADMIN_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: backend-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -75,12 +81,50 @@ jobs:
 
       - name: Deploy Amplify backend
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -80,57 +80,8 @@ jobs:
           aws-region: ca-central-1
 
       - name: Deploy Amplify backend
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_BACKEND_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: backend-deploy-${{ github.ref }}
+  group: backend-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -89,22 +89,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: mobile-deploy-${{ github.ref }}
+  group: mobile-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -160,22 +160,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: mobile-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -146,15 +152,53 @@ jobs:
 
       - name: Deploy Mobile Web
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_MOBILE_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_MOBILE_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1
 
   ota-update:
     name: Publish EAS Update

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -11,12 +11,6 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
-# Serialize deploys per branch so back-to-back pushes don't collide on the
-# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
-concurrency:
-  group: mobile-deploy-${{ github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -138,6 +132,12 @@ jobs:
     if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    # Serialize Amplify deploys per branch (one PENDING/RUNNING job per
+    # branch is the AWS limit). Job-level rather than workflow-level so
+    # the parallel ota-update (EAS) job is not gated by this queue.
+    concurrency:
+      group: mobile-deploy-${{ github.ref_name }}
+      cancel-in-progress: false
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -151,60 +151,11 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Mobile Web
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_MOBILE_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_MOBILE_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
 
   ota-update:
     name: Publish EAS Update

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -130,57 +130,8 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Web Landing Page
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_WEB_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: web-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -125,12 +131,50 @@ jobs:
 
       - name: Deploy Web Landing Page
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_WEB_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_WEB_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: web-deploy-${{ github.ref }}
+  group: web-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -139,22 +139,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.


### PR DESCRIPTION
## Summary

Fixes the failure mode that took down the admin-deploy run for PR #388 last night ([run 26012633429](https://github.com/epiphanyapps/mapyourhealth/actions/runs/26012633429)):

> `LimitExceededException: The requested branch ... already have pending or running jobs`

Two pushes to `staging` 15s apart (#387 and #388) both reached the `aws amplify start-job` step. The first started Amplify job 48; the second collided because Amplify allows only one PENDING/RUNNING job per branch. The second commit (#388) never got an Amplify deploy.

The same gap exists in **all four** deploy workflows (`admin-deploy.yml`, `web-deploy.yml`, `mobile-deploy.yml`, `backend-ci.yml`) — none had a `concurrency:` group or any retry around `start-job`. Fix is applied uniformly.

## Changes per workflow

- **Workflow-level `concurrency` group**, keyed by `<name>-${{ github.ref }}`, with `cancel-in-progress: false`. Back-to-back pushes to the same branch queue serially instead of racing. (`cancel-in-progress: true` was rejected on purpose — we want each merge to be a deploy checkpoint.)
- **Poll-then-start** in the deploy step: `aws amplify list-jobs --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)"` until the branch is free (30-min deadline, 20s interval).
- **Retry `start-job` on `LimitExceededException`** (5 attempts, 30s backoff) as a belt-and-suspenders guard if another caller slips in between the poll and the call.

Other error classes from `start-job` still fail fast.

## Why both layers

Concurrency alone doesn't solve the Amplify-busy case: Amplify builds take 2–5 min, so the second workflow can finish queueing and call `start-job` while the first job is still running. The poll is the load-bearing fix; concurrency just keeps the queue tidy and avoids redundant `wait-for-checks` / `detect-changes` work.

## Test plan

- [ ] Merge to staging → admin/mobile/web deploy workflows run on the merge commit and succeed.
- [ ] Trigger two pushes to staging close together (e.g. land two small admin-only PRs back-to-back) and confirm both deploy successfully — second run should log `Amplify branch staging busy (1 job(s)); waiting...` before calling `start-job`.
- [ ] After the staging promotion to main, confirm the same behavior on main.

## Notes

- Recovery for the original failure was a no-op by user decision — next merge to `staging` will pick up #388's commit (`049e823`) automatically.
- The other deploy workflows (web, mobile, backend-ci) hadn't failed yet but had identical exposure; bundling them avoids a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)