### PR TITLE
refactor(backend): fail-loud env vars for 3 Lambdas via requireEnv (CLAUDE.md §8)

### DIFF
--- a/packages/backend/amplify/functions/manage-data/handler.ts
+++ b/packages/backend/amplify/functions/manage-data/handler.ts
@@ -27,21 +27,27 @@ import categoriesData from '../../../scripts/seed-data-categories.json';
 // Stub committed to git — regenerate locally with `yarn seed:om` for real data
 import omData from '../../../scripts/seed-om-data.json';
 
+import { requireEnv } from '../../../shared/env';
+
 const dynamodb = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamodb);
 
-// Table names from environment variables (set in backend.ts)
+// Table names from environment variables (wired in backend.ts via the
+// `manageDataLambda.addEnvironment(\`${name.toUpperCase()}_TABLE_NAME\`, ...)`
+// loop). All required at cold-start — a missing one would silently send
+// BatchWriteItem / Scan ops to a table named '' and 'fail loudly with the
+// wrong message'. `requireEnv` fails INIT instead.
 const TABLES: Record<string, string> = {
-  Jurisdiction: process.env.JURISDICTION_TABLE_NAME || '',
-  Contaminant: process.env.CONTAMINANT_TABLE_NAME || '',
-  ContaminantThreshold: process.env.CONTAMINANTTHRESHOLD_TABLE_NAME || '',
-  Location: process.env.LOCATION_TABLE_NAME || '',
-  LocationMeasurement: process.env.LOCATIONMEASUREMENT_TABLE_NAME || '',
-  LocationObservation: process.env.LOCATIONOBSERVATION_TABLE_NAME || '',
-  Category: process.env.CATEGORY_TABLE_NAME || '',
-  SubCategory: process.env.SUBCATEGORY_TABLE_NAME || '',
-  ObservedProperty: process.env.OBSERVEDPROPERTY_TABLE_NAME || '',
-  PropertyThreshold: process.env.PROPERTYTHRESHOLD_TABLE_NAME || '',
+  Jurisdiction: requireEnv('JURISDICTION_TABLE_NAME'),
+  Contaminant: requireEnv('CONTAMINANT_TABLE_NAME'),
+  ContaminantThreshold: requireEnv('CONTAMINANTTHRESHOLD_TABLE_NAME'),
+  Location: requireEnv('LOCATION_TABLE_NAME'),
+  LocationMeasurement: requireEnv('LOCATIONMEASUREMENT_TABLE_NAME'),
+  LocationObservation: requireEnv('LOCATIONOBSERVATION_TABLE_NAME'),
+  Category: requireEnv('CATEGORY_TABLE_NAME'),
+  SubCategory: requireEnv('SUBCATEGORY_TABLE_NAME'),
+  ObservedProperty: requireEnv('OBSERVEDPROPERTY_TABLE_NAME'),
+  PropertyThreshold: requireEnv('PROPERTYTHRESHOLD_TABLE_NAME'),
 };
 
 // Action → table groupings

--- a/packages/backend/amplify/functions/places-autocomplete/handler.ts
+++ b/packages/backend/amplify/functions/places-autocomplete/handler.ts
@@ -12,8 +12,20 @@ import {
   PutItemCommand,
 } from '@aws-sdk/client-dynamodb';
 
+import { requireEnv } from '../../../shared/env';
+
 const dynamodb = new DynamoDBClient({});
-const CACHE_TABLE_NAME = process.env.CACHE_TABLE_NAME || '';
+// CACHE_TABLE_NAME is a plain env var wired in `backend.ts` via
+// `placesAutocompleteLambda.addEnvironment('CACHE_TABLE_NAME', ...)`.
+// `requireEnv` throws at INIT if missing.
+const CACHE_TABLE_NAME = requireEnv('CACHE_TABLE_NAME');
+// GOOGLE_PLACES_API_KEY is an Amplify Gen 2 secret (defined in resource.ts
+// via `secret()`). On the deployed Lambda the env var is literally
+// "<value will be resolved during runtime>" — the real value comes from
+// SSM via the AMPLIFY_SSM_ENV_CONFIG bootstrap. We keep the `|| ''`
+// pattern here because hardening this with `requireEnv` would only
+// validate the placeholder, not the resolved value, and could mask the
+// (rare) case where resolution itself fails.
 const GOOGLE_PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY || '';
 const CACHE_TTL_SECONDS = 3600; // 1 hour
 

--- a/packages/backend/amplify/functions/resolve-location/handler.ts
+++ b/packages/backend/amplify/functions/resolve-location/handler.ts
@@ -20,12 +20,23 @@ import {
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { randomUUID } from 'crypto';
 
+import { requireEnv } from '../../../shared/env';
+
 const dynamodb = new DynamoDBClient({});
+// Plain env vars wired in `backend.ts` via
+// `resolveLocationLambda.addEnvironment(...)`. `requireEnv` throws (failing
+// INIT) on any missing var so we don't silently send DynamoDB ops to a
+// table named ''.
+const CACHE_TABLE_NAME = requireEnv('CACHE_TABLE_NAME');
+const LOCATION_TABLE_NAME = requireEnv('LOCATION_TABLE_NAME');
+const JURISDICTION_TABLE_NAME = requireEnv('JURISDICTION_TABLE_NAME');
+const LOCATION_MEASUREMENT_TABLE_NAME = requireEnv('LOCATION_MEASUREMENT_TABLE_NAME');
+// GOOGLE_PLACES_API_KEY is an Amplify Gen 2 secret (resource.ts uses
+// `secret()`). On the deployed Lambda the env var is literally
+// "<value will be resolved during runtime>" — the real value comes from
+// SSM via AMPLIFY_SSM_ENV_CONFIG. Kept on the existing `|| ''` pattern;
+// see the matching note in places-autocomplete/handler.ts.
 const GOOGLE_PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY || '';
-const CACHE_TABLE_NAME = process.env.CACHE_TABLE_NAME || '';
-const LOCATION_TABLE_NAME = process.env.LOCATION_TABLE_NAME || '';
-const JURISDICTION_TABLE_NAME = process.env.JURISDICTION_TABLE_NAME || '';
-const LOCATION_MEASUREMENT_TABLE_NAME = process.env.LOCATION_MEASUREMENT_TABLE_NAME || '';
 
 const CACHE_TTL_SECONDS = 86400; // 24 hours for location data (changes rarely)
 

--- a/packages/backend/shared/env.ts
+++ b/packages/backend/shared/env.ts
@@ -1,0 +1,40 @@
+/**
+ * Required-env helpers shared across Lambda handlers.
+ *
+ * Background: many handlers used to read `process.env.FOO || ''` at module
+ * scope. A misconfigured deploy (env var missing or unset) would silently
+ * propagate the empty string into downstream API calls (`fetch(..., apiKey: '')`)
+ * or DynamoDB commands (`TableName: ''`). The Lambda would appear healthy —
+ * cold-start fine, requests reach the handler — but every operation would
+ * fail in a confusing, deep-stack way (Google rejects with HTTP 400, DDB
+ * throws ResourceNotFoundException, etc.).
+ *
+ * `requireEnv` flips that: a missing var throws during cold-start init.
+ * CloudWatch shows it as an INIT_REPORT failure with a clear message
+ * naming the variable, and the Lambda stays in a failed state until it's
+ * fixed. Loud, immediate, debuggable.
+ *
+ * Call at module top-level so the throw runs once on cold start, not on
+ * every invocation.
+ */
+
+export class MissingEnvError extends Error {
+  constructor(name: string) {
+    super(
+      `Required environment variable ${name} is missing or empty. ` +
+        `Check the Lambda's resource.ts / backend.ts wiring.`,
+    );
+    this.name = "MissingEnvError";
+  }
+}
+
+/**
+ * Read a required env var. Throws `MissingEnvError` if unset or empty string.
+ */
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new MissingEnvError(name);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
Replaces silent `process.env.X || ''` fallbacks on plain (CDK-wired) env vars with a `requireEnv` helper that throws on cold-start INIT when a required var is missing or empty. A misconfigured deploy now fails visibly in CloudWatch (INIT_REPORT with a clear message naming the variable) instead of silently passing `''` into DynamoDB ops on a non-existent table name.

**4 files / +85 / −16.** No schema changes.

## What changes

- **New**: `packages/backend/shared/env.ts` exports `requireEnv(name)` + `MissingEnvError`. Lives in the existing `shared/` folder used for cross-Lambda utilities.
- **places-autocomplete/handler.ts**: `CACHE_TABLE_NAME` → `requireEnv`
- **resolve-location/handler.ts**: `CACHE_TABLE_NAME`, `LOCATION_TABLE_NAME`, `JURISDICTION_TABLE_NAME`, `LOCATION_MEASUREMENT_TABLE_NAME` → `requireEnv` (4 vars)
- **manage-data/handler.ts**: all 10 reference-data table-name env vars → `requireEnv`

## What deliberately stays soft (with inline comments)

### `GOOGLE_PLACES_API_KEY` (places-autocomplete + resolve-location)
This is an Amplify Gen 2 **secret** (resource.ts uses `secret()`). On the deployed Lambda config the env var is literally `\"<value will be resolved during runtime>\"` — the actual value resolves from SSM via `AMPLIFY_SSM_ENV_CONFIG`. `requireEnv` would happily pass the placeholder through (non-empty), so it wouldn't catch a real misconfiguration of the secret itself. Left on the existing `|| ''` pattern with an inline note explaining the trade-off. Future PR could harden secrets via Amplify's runtime SSM resolution callback.

### Defaults pointing at real values (`FROM_EMAIL = 'noreply@...'`, `SES_SENDER_EMAIL = 'alerts@...'`, etc.)
In `request-magic-link`, `send-email-alert`, `subscribe-to-newsletter`, `resend-confirmation`. Those are **intentional soft fallbacks**, not silent-fail bugs. Out of scope here.

## Verification before pushing

✅ **All 17 enforced env vars are set on staging.** Ran `aws lambda get-function-configuration` for all three target Lambdas (`placesautocompletelambda`, `resolvelocationlambda`, `managedatalambda` on staging app `d3jl0ykn4qgj9r`). Every var is present and populated with a real table name (e.g. `CONTAMINANT_TABLE_NAME = \"Contaminant-dwz5zs2ghrc5xplczomoh4fzke-NONE\"`).

✅ TypeScript compile is clean (backend tsconfig).

✅ Consistent with existing handler conventions — no `$amplify/env/<function>` typed-import migration (none of the codebase uses that today).

## Failure mode (what to watch on first deploy)

If for some reason the deploy starts a Lambda with a missing env var (e.g. CloudFormation rollback half-applied a config), the affected Lambda will fail INIT with:

```
MissingEnvError: Required environment variable CONTAMINANT_TABLE_NAME is missing or empty.
Check the Lambda's resource.ts / backend.ts wiring.
```

→ CloudWatch will show INIT_REPORT errors immediately, AppSync queries that hit the broken Lambda will return 5xx with the message in the error chain.

Before this PR, the same misconfiguration would silently pass `''` into `BatchWriteItem({ TableName: '' })` → DynamoDB returns `ResourceNotFoundException` → handler returns confusing error that doesn't name the root cause. **The new failure mode is louder and faster to diagnose; that's the entire point.**

## Test plan

- [ ] CI: backend-ci.yml lint/type-check passes
- [ ] After merge: watch the backend-ci.yml deploy job complete on staging
- [ ] Watch CloudWatch logs for the 3 affected Lambdas — no INIT_REPORT errors
- [ ] Smoke-test functional paths that hit each Lambda:
  - [ ] `places-autocomplete`: search a city in the admin or mobile app — predictions return
  - [ ] `resolve-location`: pick a city — resolves with jurisdiction + writes Location row
  - [ ] `manage-data`: open admin Settings → Manage Data → test \"wipeContaminants\" or similar (only if you have nothing to lose) — confirms the Lambda boots

## Series status
- ✅ #389 — CLAUDE.md docs refresh (merged)
- **This PR — Lambda env-var hardening (§8)**
- ⏳ #3 — process-notifications defaults (§6)
- ⏳ #4 — Phase 3b DeleteConfirmDialog
- ⏳ #5 — /thresholds migration
- ⏳ #6 — /property-thresholds migration
- ⏳ #7 — Location surgery
- ⏳ #8 — resolvedJurisdictionCode schema addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)