### PR TITLE
fix(ci): handle null jobSummaries in Amplify start-job poll

### DIFF
--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -41,8 +41,12 @@ runs:
         DEADLINE=$(( $(date +%s) + TIMEOUT ))
         FREE=0
         while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+          # `jobSummaries[?…]` returns null when no jobs match (or when the
+          # list is empty), and `length(null)` errors. Coalesce to `[]` so
+          # length() always sees an array. Without this, an idle branch
+          # makes the poll loop spin until the timeout fires.
           if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-            --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+            --query "length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \`[]\`)" \
             --output text 2>&1); then
             if [ "$BUSY" = "0" ]; then
               FREE=1


### PR DESCRIPTION
## Summary

The composite action introduced in #391 broke all four staging deploy workflows. The poll loop's JMESPath `length(@)` errors when applied to `null` (which AWS returns when no jobs match the filter on an idle branch), the loop catches the error as "list-jobs failed", sleeps 20s, retries until the 30-min timeout fires, then exits 1.

**Observed failure:** All four `workflow_dispatch` runs at 2026-05-18 04:58 UTC (Backend / Mobile Web / Web Landing / Admin Portal) failed identically:

\`\`\`
aws: [ERROR]: In function length(), invalid type for value: None, expected one of: ['string', 'array', 'object'], received: \"null\"
list-jobs failed: 0
...
Timed out after 1800s waiting for Amplify branch staging to be free
##[error]Process completed with exit code 1.
\`\`\`

**Fix:** wrap the inner expression in `|| `\`[]\`` so `length()` always sees an array. JMESPath backticks (literal-list syntax) need shell-escaping inside the double-quoted `--query` argument.

\`\`\`diff
-            --query \"jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)\" \\
+            --query \"length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \\\`[]\\\`)\" \\
\`\`\`

## Test plan

- [x] Manually deployed all three Amplify apps (mobile-web / admin / backend) to HEAD via direct \`aws amplify start-job\` while this PR was being prepared (CLI bypasses the broken action). Confirms infrastructure side is healthy and the bug is purely in the action.
- [ ] After merge, trigger \`workflow_dispatch\` on \`mobile-deploy.yml\` (idle branch — exercises the null path that previously failed). Expect SUCCEED.
- [ ] After merge, normal push-driven deploys (e.g. via the next PR merge) use the fixed action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)