### PR TITLE
fix(ci): drop --max-items to stop AWS CLI pagination splitting Amplify poll output

### DIFF
--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -41,11 +41,17 @@ runs:
         DEADLINE=$(( $(date +%s) + TIMEOUT ))
         FREE=0
         while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-          # `jobSummaries[?…]` returns null when no jobs match (or when the
-          # list is empty), and `length(null)` errors. Coalesce to `[]` so
-          # length() always sees an array. Without this, an idle branch
-          # makes the poll loop spin until the timeout fires.
-          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+          # Two things to handle:
+          # 1. `jobSummaries[?…]` returns null when no jobs match (or when
+          #    the list is empty), and `length(null)` errors. Coalesce to
+          #    `[]` so length() always sees an array.
+          # 2. `--max-items` enables AWS CLI client-side pagination — each
+          #    page evaluates --query independently and prints to stdout,
+          #    so the script can receive multi-line output like "0\n0".
+          #    Use --no-paginate (with no --max-items) so we get a single
+          #    integer back from the first API response (default page is
+          #    large enough; we only need the count anyway).
+          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --no-paginate \
             --query "length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \`[]\`)" \
             --output text 2>&1); then
             if [ "$BUSY" = "0" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #393. That PR fixed the JMESPath null-handling, but the action still hangs because of a second, unrelated bug in the same line: `--max-items 5` triggers AWS CLI client-side pagination, and with `--query` + `--output text` each page evaluates the query independently and prints its own line. On an idle branch the script reads `BUSY=\"0\\n0\"` instead of `\"0\"`, so the equality check `[ \"\$BUSY\" = \"0\" ]` fails and the loop hangs until the 30-min timeout.

**Observed from the post-#393 verification run** ([actions/runs/26040411783](https://github.com/epiphanyapps/mapyourhealth/actions/runs/26040411783), Deploy Mobile Web job):

\`\`\`
Amplify branch staging busy (0
0 job(s)); waiting...
...
Timed out after 1800s waiting for Amplify branch staging to be free
\`\`\`

The \`0\\n0\` artifact in the log is the smoking gun — two integer outputs concatenated with a newline.

## Fix

Drop \`--max-items 5\` and add \`--no-paginate\`. The default first page is large enough for the count-only query, and we only need to know whether anything is pending/running — one call to AWS is all that's needed.

\`\`\`diff
-          if BUSY=\$(aws amplify list-jobs --app-id \"\$APP_ID\" --branch-name \"\$BRANCH\" --max-items 5 \\
+          if BUSY=\$(aws amplify list-jobs --app-id \"\$APP_ID\" --branch-name \"\$BRANCH\" --no-paginate \\
             --query \"length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \\\`[]\\\`)\" \\
             --output text 2>&1); then
\`\`\`

## Test plan

- [ ] Merge → trigger \`workflow_dispatch\` on \`mobile-deploy.yml\` → confirm SUCCEED.
- [ ] Verify log shows \`Amplify branch staging busy (0 job(s))\` cleanly once (no \"0\\n0\" splits), then immediately starts the actual \`start-job\` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)