### PR TITLE
fix(admin): stop useCrudResource Edit dialog flashing to "Create" on save

### DIFF
--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -219,8 +219,12 @@ export function useCrudResource<T extends RecordWithId, FormData>(
         toast.success(`${resourceName} created`);
       }
       setIsDialogOpen(false);
-      setEditingRecord(null);
-      setFormData(defaultFormValues);
+      // Don't clear editingRecord / formData here. They'll be set
+      // correctly the next time the dialog opens via openCreate or
+      // openEdit. Clearing them in the same render that closes the
+      // dialog makes Radix's exit animation briefly show "Create
+      // <Resource>" (empty form, title flipped) before the dialog
+      // disappears (#395).
       await refresh();
     } catch (err) {
       console.error(`Error saving ${resourceName}:`, err);


### PR DESCRIPTION
## Summary

Closes #395.

After clicking **Update** on an Edit dialog backed by `useCrudResource`, the dialog stayed open and visibly transitioned to "Create" state — title flipped, fields cleared — before finally disappearing. The mutation still persisted (toast fired, list refreshed) but users had to click the X manually to dismiss the now-confusingly-empty dialog.

## Cause

\`handleSave\` called \`setIsDialogOpen(false)\` then immediately \`setEditingRecord(null)\` and \`setFormData(defaultFormValues)\` in the same render. Radix Dialog's exit animation re-renders the body during the close transition, sees \`editingRecord === null\` + empty form, and renders the Create variant for a few hundred ms.

## Fix

Drop the post-save state clear. \`openCreate\` and \`openEdit\` already set \`editingRecord\` / \`formData\` correctly on the next open, so the clear was redundant — its only effect was the visual flash.

\`\`\`diff
       setIsDialogOpen(false);
-      setEditingRecord(null);
-      setFormData(defaultFormValues);
+      // Don't clear editingRecord / formData here. They'll be set
+      // correctly the next time the dialog opens via openCreate or
+      // openEdit. Clearing them in the same render that closes the
+      // dialog makes Radix's exit animation briefly show \"Create
+      // <Resource>\" (empty form, title flipped) before the dialog
+      // disappears (#395).
       await refresh();
\`\`\`

## Affected pages

All 5 admin CRUD pages that use the hook: \`/jurisdictions\`, \`/contaminants\`, \`/categories\`, \`/subcategories\`, \`/properties\`.

## Test plan

- [ ] After merge, on any of the 5 pages: edit a row → click Update → dialog closes cleanly, no Create flash.
- [ ] Toast still says \"X updated\" (not \"created\").
- [ ] Open Create dialog after an edit — form is empty / default values (proving the deferred reset still works on the next open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)