### PR TITLE
release: promote staging to main (deploy hotfixes + admin dialog polish)

### DIFF
--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -41,11 +41,17 @@ runs:
         DEADLINE=$(( $(date +%s) + TIMEOUT ))
         FREE=0
         while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-          # `jobSummaries[?…]` returns null when no jobs match (or when the
-          # list is empty), and `length(null)` errors. Coalesce to `[]` so
-          # length() always sees an array. Without this, an idle branch
-          # makes the poll loop spin until the timeout fires.
-          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+          # Two things to handle:
+          # 1. `jobSummaries[?…]` returns null when no jobs match (or when
+          #    the list is empty), and `length(null)` errors. Coalesce to
+          #    `[]` so length() always sees an array.
+          # 2. `--max-items` enables AWS CLI client-side pagination — each
+          #    page evaluates --query independently and prints to stdout,
+          #    so the script can receive multi-line output like "0\n0".
+          #    Use --no-paginate (with no --max-items) so we get a single
+          #    integer back from the first API response (default page is
+          #    large enough; we only need the count anyway).
+          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --no-paginate \
             --query "length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \`[]\`)" \
             --output text 2>&1); then
             if [ "$BUSY" = "0" ]; then

--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -1,0 +1,83 @@
+name: Amplify Start Job
+description: >
+  Wait for the Amplify branch to be free, then start a RELEASE job.
+  Surfaces a clear timeout error on prolonged contention, and retries
+  start-job on LimitExceededException as a defense against a job
+  slipping in between the poll and the call.
+
+inputs:
+  app-id:
+    description: Amplify app ID
+    required: true
+  branch:
+    description: Amplify branch name (e.g. "staging", "main")
+    required: true
+  sha:
+    description: Commit SHA to deploy
+    required: true
+  timeout-seconds:
+    description: How long to wait for the branch to be free
+    required: false
+    default: "1800"
+
+runs:
+  using: composite
+  steps:
+    - name: Start Amplify job
+      shell: bash
+      env:
+        APP_ID: ${{ inputs.app-id }}
+        BRANCH: ${{ inputs.branch }}
+        SHA: ${{ inputs.sha }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+      run: |
+        set -uo pipefail
+        COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+        COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+        # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+        # branch to be free before calling start-job. Surface a clear
+        # timeout error rather than falling through to the retry loop.
+        DEADLINE=$(( $(date +%s) + TIMEOUT ))
+        FREE=0
+        while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+          if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+            --output text 2>&1); then
+            if [ "$BUSY" = "0" ]; then
+              FREE=1
+              break
+            fi
+            echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+          else
+            echo "list-jobs failed: $BUSY"
+          fi
+          sleep 20
+        done
+        if [ "$FREE" = "0" ]; then
+          echo "Timed out after ${TIMEOUT}s waiting for Amplify branch $BRANCH to be free"
+          exit 1
+        fi
+
+        # Belt-and-suspenders: another caller may have slipped in between
+        # the poll and the call. Retry on LimitExceededException.
+        for attempt in 1 2 3 4 5; do
+          if OUT=$(aws amplify start-job \
+            --app-id "$APP_ID" \
+            --branch-name "$BRANCH" \
+            --job-type RELEASE \
+            --commit-id "$SHA" \
+            --commit-message "$COMMIT_MSG" \
+            --commit-time "$COMMIT_TIME" 2>&1); then
+            echo "$OUT"
+            exit 0
+          fi
+          echo "start-job attempt $attempt failed: $OUT"
+          if echo "$OUT" | grep -q "LimitExceededException"; then
+            sleep 30
+            continue
+          fi
+          exit 1
+        done
+        echo "start-job exhausted retries"
+        exit 1

--- a/.github/actions/amplify-start-job/action.yml
+++ b/.github/actions/amplify-start-job/action.yml
@@ -41,8 +41,12 @@ runs:
         DEADLINE=$(( $(date +%s) + TIMEOUT ))
         FREE=0
         while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+          # `jobSummaries[?…]` returns null when no jobs match (or when the
+          # list is empty), and `length(null)` errors. Coalesce to `[]` so
+          # length() always sees an array. Without this, an idle branch
+          # makes the poll loop spin until the timeout fires.
           if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-            --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+            --query "length(jobSummaries[?status=='PENDING' || status=='RUNNING'] || \`[]\`)" \
             --output text 2>&1); then
             if [ "$BUSY" = "0" ]; then
               FREE=1

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: admin-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -146,12 +152,50 @@ jobs:
 
       - name: Deploy Admin Portal
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id d26q32gc98goap \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="d26q32gc98goap"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: admin-deploy-${{ github.ref }}
+  group: admin-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -160,22 +160,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/admin-deploy.yml
+++ b/.github/workflows/admin-deploy.yml
@@ -151,57 +151,8 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Admin Portal
-        run: |
-          set -uo pipefail
-          APP_ID="d26q32gc98goap"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_ADMIN_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: backend-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -75,12 +81,50 @@ jobs:
 
       - name: Deploy Amplify backend
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_BACKEND_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -80,57 +80,8 @@ jobs:
           aws-region: ca-central-1
 
       - name: Deploy Amplify backend
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_BACKEND_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_BACKEND_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: backend-deploy-${{ github.ref }}
+  group: backend-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -89,22 +89,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: mobile-deploy-${{ github.ref }}
+  group: mobile-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -160,22 +160,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: mobile-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -146,15 +152,53 @@ jobs:
 
       - name: Deploy Mobile Web
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_MOBILE_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_MOBILE_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1
 
   ota-update:
     name: Publish EAS Update

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -11,12 +11,6 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
-# Serialize deploys per branch so back-to-back pushes don't collide on the
-# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
-concurrency:
-  group: mobile-deploy-${{ github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -138,6 +132,12 @@ jobs:
     if: (needs.detect-changes.outputs.mobile_changed == 'true' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'staging')
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    # Serialize Amplify deploys per branch (one PENDING/RUNNING job per
+    # branch is the AWS limit). Job-level rather than workflow-level so
+    # the parallel ota-update (EAS) job is not gated by this queue.
+    concurrency:
+      group: mobile-deploy-${{ github.ref_name }}
+      cancel-in-progress: false
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -151,60 +151,11 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Mobile Web
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_MOBILE_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_MOBILE_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
 
   ota-update:
     name: Publish EAS Update

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -130,57 +130,8 @@ jobs:
           fetch-depth: 1
 
       - name: Deploy Web Landing Page
-        run: |
-          set -uo pipefail
-          APP_ID="${{ secrets.AMPLIFY_WEB_APP_ID }}"
-          BRANCH="${{ github.ref_name }}"
-          SHA="${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
-
-          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job. Surface a clear
-          # timeout error rather than falling through to the retry loop.
-          DEADLINE=$(( $(date +%s) + 1800 ))
-          FREE=0
-          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
-              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>&1); then
-              if [ "$BUSY" = "0" ]; then
-                FREE=1
-                break
-              fi
-              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
-            else
-              echo "list-jobs failed: $BUSY"
-            fi
-            sleep 20
-          done
-          if [ "$FREE" = "0" ]; then
-            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
-            exit 1
-          fi
-
-          # Belt-and-suspenders: another caller may have slipped in between
-          # the poll and the call. Retry on LimitExceededException.
-          for attempt in 1 2 3 4 5; do
-            if OUT=$(aws amplify start-job \
-              --app-id "$APP_ID" \
-              --branch-name "$BRANCH" \
-              --job-type RELEASE \
-              --commit-id "$SHA" \
-              --commit-message "$COMMIT_MSG" \
-              --commit-time "$COMMIT_TIME" 2>&1); then
-              echo "$OUT"
-              exit 0
-            fi
-            echo "start-job attempt $attempt failed: $OUT"
-            if echo "$OUT" | grep -q "LimitExceededException"; then
-              sleep 30
-              continue
-            fi
-            exit 1
-          done
-          echo "start-job exhausted retries"
-          exit 1
+        uses: ./.github/actions/amplify-start-job
+        with:
+          app-id: ${{ secrets.AMPLIFY_WEB_APP_ID }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -11,6 +11,12 @@ on:
       - 'yarn.lock'
   workflow_dispatch:
 
+# Serialize deploys per branch so back-to-back pushes don't collide on the
+# Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
+concurrency:
+  group: web-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   wait-for-checks:
     name: Wait for Lint and Type Check
@@ -125,12 +131,50 @@ jobs:
 
       - name: Deploy Web Landing Page
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%s "${{ github.sha }}")
-          COMMIT_TIME=$(git log -1 --pretty=%cI "${{ github.sha }}")
-          aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFY_WEB_APP_ID }} \
-            --branch-name ${{ github.ref_name }} \
-            --job-type RELEASE \
-            --commit-id ${{ github.sha }} \
-            --commit-message "$COMMIT_MSG" \
-            --commit-time "$COMMIT_TIME"
+          set -uo pipefail
+          APP_ID="${{ secrets.AMPLIFY_WEB_APP_ID }}"
+          BRANCH="${{ github.ref_name }}"
+          SHA="${{ github.sha }}"
+          COMMIT_MSG=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
+
+          # Amplify allows one PENDING/RUNNING job per branch. Wait for the
+          # branch to be free before calling start-job.
+          DEADLINE=$(( $(date +%s) + 1800 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+              --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
+              --output text 2>/dev/null || echo "ERR")
+            if [ "$BUSY" = "0" ]; then
+              break
+            fi
+            if [ "$BUSY" = "ERR" ]; then
+              echo "list-jobs failed; retrying..."
+            else
+              echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            fi
+            sleep 20
+          done
+
+          # Belt-and-suspenders: another caller may have slipped in between
+          # the poll and the call. Retry on LimitExceededException.
+          for attempt in 1 2 3 4 5; do
+            if OUT=$(aws amplify start-job \
+              --app-id "$APP_ID" \
+              --branch-name "$BRANCH" \
+              --job-type RELEASE \
+              --commit-id "$SHA" \
+              --commit-message "$COMMIT_MSG" \
+              --commit-time "$COMMIT_TIME" 2>&1); then
+              echo "$OUT"
+              exit 0
+            fi
+            echo "start-job attempt $attempt failed: $OUT"
+            if echo "$OUT" | grep -q "LimitExceededException"; then
+              sleep 30
+              continue
+            fi
+            exit 1
+          done
+          echo "start-job exhausted retries"
+          exit 1

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -14,7 +14,7 @@ on:
 # Serialize deploys per branch so back-to-back pushes don't collide on the
 # Amplify branch (one PENDING/RUNNING job per branch is the AWS limit).
 concurrency:
-  group: web-deploy-${{ github.ref }}
+  group: web-deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -139,22 +139,28 @@ jobs:
           COMMIT_TIME=$(git log -1 --pretty=%cI "$SHA")
 
           # Amplify allows one PENDING/RUNNING job per branch. Wait for the
-          # branch to be free before calling start-job.
+          # branch to be free before calling start-job. Surface a clear
+          # timeout error rather than falling through to the retry loop.
           DEADLINE=$(( $(date +%s) + 1800 ))
+          FREE=0
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-            BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
+            if BUSY=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH" --max-items 5 \
               --query "jobSummaries[?status=='PENDING' || status=='RUNNING'] | length(@)" \
-              --output text 2>/dev/null || echo "ERR")
-            if [ "$BUSY" = "0" ]; then
-              break
-            fi
-            if [ "$BUSY" = "ERR" ]; then
-              echo "list-jobs failed; retrying..."
-            else
+              --output text 2>&1); then
+              if [ "$BUSY" = "0" ]; then
+                FREE=1
+                break
+              fi
               echo "Amplify branch $BRANCH busy ($BUSY job(s)); waiting..."
+            else
+              echo "list-jobs failed: $BUSY"
             fi
             sleep 20
           done
+          if [ "$FREE" = "0" ]; then
+            echo "Timed out after 30 min waiting for Amplify branch $BRANCH to be free"
+            exit 1
+          fi
 
           # Belt-and-suspenders: another caller may have slipped in between
           # the poll and the call. Retry on LimitExceededException.

--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -219,8 +219,12 @@ export function useCrudResource<T extends RecordWithId, FormData>(
         toast.success(`${resourceName} created`);
       }
       setIsDialogOpen(false);
-      setEditingRecord(null);
-      setFormData(defaultFormValues);
+      // Don't clear editingRecord / formData here. They'll be set
+      // correctly the next time the dialog opens via openCreate or
+      // openEdit. Clearing them in the same render that closes the
+      // dialog makes Radix's exit animation briefly show "Create
+      // <Resource>" (empty form, title flipped) before the dialog
+      // disappears (#395).
       await refresh();
     } catch (err) {
       console.error(`Error saving ${resourceName}:`, err);


### PR DESCRIPTION
## Summary

4 PRs since the last `staging → main` promotion (#390):

| PR | Type | What |
|---|---|---|
| [#391](https://github.com/epiphanyapps/mapyourhealth/pull/391) | CI | Serialize Amplify deploys + retry `start-job` on `LimitExceededException` via new composite action |
| [#393](https://github.com/epiphanyapps/mapyourhealth/pull/393) | CI hotfix | Handle null `jobSummaries` in the composite action's JMESPath poll query |
| [#396](https://github.com/epiphanyapps/mapyourhealth/pull/396) | CI hotfix | Drop `--max-items` to stop AWS CLI pagination splitting the poll output |
| [#397](https://github.com/epiphanyapps/mapyourhealth/pull/397) | Admin polish | Stop `useCrudResource` Edit dialog flashing to "Create" on save (closes #395) |

#391 introduced two bugs (#393 and #396 fixed them sequentially). The composite action is now fully functional — verified by triggering `workflow_dispatch` on `mobile-deploy.yml` post-#396 and watching it succeed.

#397 fixes a UX-level state-cleanup bug across all 5 `useCrudResource`-backed admin pages (`/jurisdictions`, `/contaminants`, `/categories`, `/subcategories`, `/properties`).

## Validation on staging

- ✅ CI deploys work via the composite action (last 3 staging deploys all SUCCEED)
- ✅ Admin Edit dialog closes cleanly without "Create" flash (verified on `/jurisdictions` via Chrome DevTools)
- ✅ Vancouver Pollution Sources renders correctly (related cleanup: deleted bad QIT row, closed #394 as not-a-bug)
- ✅ Mobile-web threshold rendering works (related cleanup: backfilled 113 NULL `warningRatio` rows post-#379)

## Post-merge

After this lands on `main`, the same composite-action fix will take effect for **prod** deploys. Prior to #393/#396, any prod CI deploy would have hung the same way staging did. Worth a sanity-check `workflow_dispatch` on the prod `mobile-deploy.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)