### PR TITLE
fix(admin): drop stale defaultFormValues dep from useCrudResource handleSave

### DIFF
--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -233,7 +233,6 @@ export function useCrudResource<T extends RecordWithId, FormData>(
       setIsSaving(false);
     }
   }, [
-    defaultFormValues,
     editingRecord,
     formData,
     formToPayload,


### PR DESCRIPTION
## Summary

Follow-up to #397. That PR removed the `setFormData(defaultFormValues)` call from `handleSave` on the save-success path (state cleanup moved to the next `openCreate` / `openEdit` to avoid the Radix dialog flashing "Create Jurisdiction" with an empty form during the exit animation).

The `useCallback` dep array still listed `defaultFormValues`, which is now unused inside the body. Because consumers typically pass the default object as an inline literal (e.g. `defaultFormValues={{ code: "", name: "", country: "" }}`), keeping it in the deps gives `handleSave` a fresh identity every render and breaks any downstream memoization.

ESLint's `react-hooks/exhaustive-deps` rule flags missing deps, not extra ones, so this slipped through #397's checks.

## Diff

```diff
   }, [
-    defaultFormValues,
     editingRecord,
     formData,
     formToPayload,
     getModel,
     refresh,
     resourceName,
     validate,
   ]);
```

## Test plan

- [ ] CI lint + type-check pass
- [ ] After staging deploy, re-run the Chrome DevTools "slow Radix animation" verification on `staging.d26q32gc98goap.amplifyapp.com/jurisdictions` to confirm the #397 fix still holds (no "Create" flash on save)
- [ ] Verify save still completes successfully on at least one other `useCrudResource`-backed page (`/contaminants`, `/categories`, `/subcategories`, or `/properties`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)