### PR TITLE
release: promote staging to main (useCrudResource dep cleanup)

### DIFF
--- a/apps/admin/src/hooks/useCrudResource.ts
+++ b/apps/admin/src/hooks/useCrudResource.ts
@@ -233,7 +233,6 @@ export function useCrudResource<T extends RecordWithId, FormData>(
       setIsSaving(false);
     }
   }, [
-    defaultFormValues,
     editingRecord,
     formData,
     formToPayload,


### PR DESCRIPTION
## Summary

One PR since the last promotion (#398):

| PR | Type | What |
|---|---|---|
| [#399](https://github.com/epiphanyapps/mapyourhealth/pull/399) | Admin tidy | Drop stale `defaultFormValues` dep from `useCrudResource.handleSave` (follow-up to #397 — that PR removed the body usage but left the dep, giving `handleSave` a fresh identity each render and breaking downstream memoization) |

## Validation on staging

- ✅ Staging admin auto-deployed cleanly (job 51 SUCCEED)
- ✅ Slow-animation Radix dialog test on `/jurisdictions` still passes: dialog title stays "Edit Jurisdiction" / CA-BC through entire exit animation; no "Create" flash; `updateJurisdiction` mutation 200; no console errors

## Post-merge

After this lands on `main`, the prod admin app will pick up the cleanup on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)