### PR TITLE
fix(auth): source magic-link URL from amplify_outputs per env (#353)

### DIFF
--- a/apps/mobile/amplify_outputs.staging.json
+++ b/apps/mobile/amplify_outputs.staging.json
@@ -3906,5 +3906,8 @@
       "app_id": "b24826e79d90457ba3b3a33374632a5c",
       "aws_region": "ca-central-1"
     }
+  },
+  "custom": {
+    "magicLinkApiUrl": "https://7eidridev5cfzbktaa3s5hueva0ccnej.lambda-url.ca-central-1.on.aws/"
   }
 }

--- a/apps/mobile/app/context/AuthContext.tsx
+++ b/apps/mobile/app/context/AuthContext.tsx
@@ -26,6 +26,10 @@ import {
   getLastNotificationResponse,
   NotificationStatus,
 } from "@/services/notifications"
+import { getEnvOverride } from "@/utils/envOverride"
+
+import prodOutputs from "../../amplify_outputs.json" // eslint-disable-line import/no-unresolved
+import stagingOutputs from "../../amplify_outputs.staging.json" // eslint-disable-line import/no-unresolved
 
 /**
  * Notification data structure from backend (process-notifications Lambda)
@@ -55,8 +59,14 @@ function handleNotificationNavigation(data: NotificationData | undefined): void 
   }
 }
 
-// Magic link API endpoint - this will be set from backend outputs
-const MAGIC_LINK_API_URL = Config.MAGIC_LINK_API_URL || ""
+// Magic link API endpoint. Sourced from amplify_outputs.json's `custom` section
+// per env (so staging and prod each point at their own Lambda Function URL),
+// with the legacy Config value as a build-time fallback. See GH #353.
+const magicLinkOutputs = getEnvOverride() === "staging" ? stagingOutputs : prodOutputs
+const MAGIC_LINK_API_URL =
+  (magicLinkOutputs as { custom?: { magicLinkApiUrl?: string } }).custom?.magicLinkApiUrl ??
+  Config.MAGIC_LINK_API_URL ??
+  ""
 
 export type AuthContextType = {
   isAuthenticated: boolean

--- a/packages/backend/amplify/backend.ts
+++ b/packages/backend/amplify/backend.ts
@@ -217,6 +217,15 @@ new CfnOutput(authStack, 'RequestMagicLinkFunctionUrl', {
   exportName: `${authStack.stackName}-RequestMagicLinkUrl`,
 });
 
+// Expose the magic-link URL through amplify_outputs.json so the mobile app
+// can read the per-env URL at runtime instead of relying on a hardcoded
+// string in app/config (GH #353).
+backend.addOutput({
+  custom: {
+    magicLinkApiUrl: functionUrl.url,
+  },
+});
+
 // ============================================
 // Process Notifications Lambda Setup
 // ============================================


### PR DESCRIPTION
## Summary
- Mobile hardcoded `https://qbjcrjcwz6y4v23pwnk7aoxgy40tndki.lambda-url.us-east-1.on.aws/` in `config.dev.ts` and `config.prod.ts`; that Function URL no longer exists, which is the `NetworkError when attempting to fetch resource` Rayane saw on the "Sign in with Email Link" page on 2026-05-15.
- Move the URL into `amplify_outputs.json#/custom/magicLinkApiUrl` so staging and prod each carry their own Function URL (different Cognito user pools, different Lambdas).
- Hand-patch `apps/mobile/amplify_outputs.staging.json` with the live staging URL so this lands without waiting for a backend redeploy. The CDK `backend.addOutput(...)` change keeps it self-healing on the next deploy.

## Files
- `packages/backend/amplify/backend.ts` — `backend.addOutput({ custom: { magicLinkApiUrl: functionUrl.url } })` right after the existing `CfnOutput`.
- `apps/mobile/amplify_outputs.staging.json` — adds the `custom` section with the verified staging URL `https://7eidridev5cfzbktaa3s5hueva0ccnej.lambda-url.ca-central-1.on.aws/`.
- `apps/mobile/app/context/AuthContext.tsx` — picks the right outputs based on `getEnvOverride()` and prefers `outputs.custom.magicLinkApiUrl`, falling back to `Config.MAGIC_LINK_API_URL` for old dev builds.

## Test plan
- [ ] CI lint + type-check (mobile, backend).
- [ ] After staging deploy, open https://staging.d2z5ddqhlc1q5.amplifyapp.com/ → Sign in → "Send Magic Link" for a known staging Cognito user — expect 200 from the Lambda (network panel) and a magic-link email via SES, **no** `NetworkError`.
- [ ] DevTools console shows the resolved URL is the ca-central-1 Function URL, not the legacy us-east-1 one.

## Notes
Closes the magic-link half of GH #353. The Cognito recovery-email half already shipped via #362.

Prod still inherits the URL from the synced `amplify_outputs.json` once the next staging→main promotion ships and the prod backend redeploys; the prod Function URL `https://ozddviab3svysnzphlmhlphwru0stbic.lambda-url.ca-central-1.on.aws/` already exists in CloudFormation but was never threaded into `amplify_outputs.json` until this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)