### PR TITLE
fix(mobile): web share fallback + WHO/local + dashboard category order (#355, #356)

### DIFF
--- a/apps/mobile/app/components/ContaminantTable.tsx
+++ b/apps/mobile/app/components/ContaminantTable.tsx
@@ -165,7 +165,11 @@ export function ContaminantTable(props: ContaminantTableProps) {
     options?: { isUnregulated?: boolean; isLocal?: boolean },
   ): string => {
     if (options?.isUnregulated) return "UNREGULATED"
-    if (value === null) return options?.isLocal ? "N/A" : "NO STANDARD"
+    // Null in the local column means the local jurisdiction has no direct threshold
+    // (CategoryDetailScreen sets it to null when getThreshold cascades to WHO). Use
+    // explicit copy instead of "N/A" so the column doesn't look identical to WHO when
+    // the local jurisdiction is unseeded (GH #356).
+    if (value === null) return options?.isLocal ? "NO LOCAL STANDARD" : "NO STANDARD"
     const effectiveUnit = unit || rowUnit
     return `${value} ${effectiveUnit}`
   }

--- a/apps/mobile/app/screens/CategoryDetailScreen.tsx
+++ b/apps/mobile/app/screens/CategoryDetailScreen.tsx
@@ -6,8 +6,8 @@ import {
   TextStyle,
   ScrollView,
   ActivityIndicator,
+  Alert,
   RefreshControl,
-  Share,
   TouchableOpacity,
   Linking,
 } from "react-native"
@@ -42,6 +42,7 @@ import {
 import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { useAppTheme } from "@/theme/context"
 import { trackEvent } from "@/utils/analytics"
+import { sharePayload } from "@/utils/share"
 
 interface CategoryDetailScreenProps extends AppStackScreenProps<"CategoryDetail"> {}
 
@@ -189,14 +190,15 @@ ${riskDetails || "No risks detected"}
 
 View details: ${shareUrl}`
 
-    try {
-      await Share.share({
-        message: shareMessage,
-        title: `${categoryName} Risk Report - ${cityData.city}`,
-      })
-    } catch (error) {
-      // User cancelled or share failed - no need to show error
-      console.log("Share cancelled or failed:", error)
+    const result = await sharePayload({
+      message: shareMessage,
+      title: `${categoryName} Risk Report - ${cityData.city}`,
+      url: shareUrl,
+    })
+    if (result.outcome === "copied") {
+      Alert.alert("Copied to clipboard", "Paste the risk report into a message or email.")
+    } else if (result.outcome === "error") {
+      console.log("Share failed:", result.error)
     }
   }, [cityData, stats, categoryName, city, state, country, category])
 

--- a/apps/mobile/app/screens/DashboardScreen.tsx
+++ b/apps/mobile/app/screens/DashboardScreen.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-inline-styles, react/no-unescaped-entities */
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { View, ViewStyle, Pressable, TextStyle, Alert, RefreshControl, Share } from "react-native"
+import { View, ViewStyle, Pressable, TextStyle, Alert, RefreshControl } from "react-native"
 import { MaterialCommunityIcons } from "@expo/vector-icons"
 import { CommonActions } from "@react-navigation/native"
 import { formatDistanceToNow } from "date-fns"
@@ -39,6 +39,7 @@ import type { AppStackScreenProps } from "@/navigators/navigationTypes"
 import { recordLocationVisit } from "@/services/amplify/data"
 import { useAppTheme } from "@/theme/context"
 import { trackEvent } from "@/utils/analytics"
+import { sharePayload } from "@/utils/share"
 // jurisdiction resolution goes through useJurisdictionResolver (thin wrapper
 // over ContaminantsContext.getJurisdictionForLocation); postalCode utilities
 // removed when the app moved to city-level granularity.
@@ -103,7 +104,7 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     error: locationError,
     clearError: clearLocationError,
   } = useLocation()
-  const { getCategoryName } = useCategories()
+  const { categories: dynamicCategories, getCategoryName } = useCategories()
   const { banners: adminBanners } = useWarningBanners({
     city: route.params?.city,
     state: route.params?.state,
@@ -342,8 +343,19 @@ export const DashboardScreen: FC<DashboardScreenProps> = function DashboardScree
     [cityData, contaminants, statDefinitions],
   )
 
-  // Categories to display (water and air only - health and disaster removed per issue #126)
-  const categories = useMemo(() => [StatCategory.water, StatCategory.air], [])
+  // Categories to display. Filter to water + air (health and disaster removed per issue #126),
+  // but take the order from the backend Category.sortOrder so admins can re-sequence without
+  // a code change. CategoriesContext already sorts by sortOrder; we just preserve that order
+  // here while keeping the product-decision filter explicit (GH #356).
+  const categories = useMemo(() => {
+    const allowed = new Set<string>([StatCategory.water, StatCategory.air])
+    const sorted = dynamicCategories
+      .map((c) => c.categoryId)
+      .filter((id): id is StatCategory => allowed.has(id))
+    // Fallback to the legacy order if the backend hasn't populated either category yet
+    // (e.g. cold mock state before CategoriesProvider hydrates).
+    return sorted.length > 0 ? sorted : [StatCategory.water, StatCategory.air]
+  }, [dynamicCategories])
 
   // Handle location selection from PlacesSearchBar — updates URL via route params
   const handleLocationSelect = useCallback(
@@ -500,14 +512,15 @@ ${categoryRisks || "No risks detected"}
 
 View details: ${shareUrl}`
 
-    try {
-      await Share.share({
-        message: shareMessage,
-        title: `Safety Report - ${currentLocation?.city || "Location"}`,
-      })
-    } catch (error) {
-      // User cancelled or share failed - no need to show error
-      console.log("Share cancelled or failed:", error)
+    const result = await sharePayload({
+      message: shareMessage,
+      title: `Safety Report - ${currentLocation?.city || "Location"}`,
+      url: shareUrl,
+    })
+    if (result.outcome === "copied") {
+      Alert.alert("Copied to clipboard", "Paste the safety report into a message or email.")
+    } else if (result.outcome === "error") {
+      console.log("Share failed:", result.error)
     }
   }, [cityData, categories, getStatusForCategory, getCategoryDisplayName, currentLocation])
 

--- a/apps/mobile/app/utils/share.ts
+++ b/apps/mobile/app/utils/share.ts
@@ -1,0 +1,73 @@
+import { Platform, Share } from "react-native"
+
+export type ShareOutcome = "shared" | "copied" | "cancelled" | "error"
+
+export interface SharePayload {
+  message: string
+  title?: string
+  url?: string
+}
+
+export interface ShareResult {
+  outcome: ShareOutcome
+  error?: unknown
+}
+
+interface WebShareNavigator {
+  share?: (data: { text?: string; title?: string; url?: string }) => Promise<void>
+  clipboard?: { writeText?: (text: string) => Promise<void> }
+}
+
+function getWebNavigator(): WebShareNavigator | undefined {
+  return typeof navigator !== "undefined" ? (navigator as unknown as WebShareNavigator) : undefined
+}
+
+/**
+ * Share text on whatever surface the current platform supports.
+ *
+ * - Native (iOS/Android): React Native's Share.share().
+ * - Web with Web Share API: navigator.share() (shows the OS share sheet on
+ *   browsers that support it — mobile Safari, Chrome on Android, etc.).
+ * - Web without Web Share API (desktop browsers in the common case): copies
+ *   the message to the clipboard via navigator.clipboard.writeText().
+ *
+ * RN's Share.share() has no web implementation and silently rejects on
+ * Expo Web, which is what caused Rayane's "sharing function is not working
+ * on my PC" report (GH #355). This util gives every surface a working path.
+ */
+export async function sharePayload(payload: SharePayload): Promise<ShareResult> {
+  if (Platform.OS !== "web") {
+    try {
+      const result = await Share.share({ message: payload.message, title: payload.title })
+      return { outcome: result.action === "dismissedAction" ? "cancelled" : "shared" }
+    } catch (error) {
+      return { outcome: "error", error }
+    }
+  }
+
+  const nav = getWebNavigator()
+
+  if (nav?.share) {
+    try {
+      await nav.share({ text: payload.message, title: payload.title, url: payload.url })
+      return { outcome: "shared" }
+    } catch (error) {
+      // AbortError is the user dismissing the share sheet — treat as cancel.
+      if (error instanceof Error && error.name === "AbortError") {
+        return { outcome: "cancelled" }
+      }
+      // Permission denied / other errors → fall through to clipboard.
+    }
+  }
+
+  if (nav?.clipboard?.writeText) {
+    try {
+      await nav.clipboard.writeText(payload.message)
+      return { outcome: "copied" }
+    } catch (error) {
+      return { outcome: "error", error }
+    }
+  }
+
+  return { outcome: "error", error: new Error("No share surface available") }
+}


### PR DESCRIPTION
## Summary
Three small mobile-side fixes for the open items in Rayane's 2026-05-15 review.

- **GH #355 — web share fallback.** RN's `Share.share()` silently rejects on Expo Web, which is the "Share button doesn't work on my PC" symptom. New `apps/mobile/app/utils/share.ts` wraps three surfaces: native (`Share.share`), web with Web Share API (`navigator.share`), web without it (`navigator.clipboard.writeText` + `Alert` toast saying "Copied to clipboard"). Used by both `DashboardScreen.handleShare` and `CategoryDetailScreen.handleShare`.
- **GH #356 — never read as "N/A" in the LOCAL column.** `CategoryDetailScreen` already turns `localLimit` into `null` whenever the local jurisdiction's threshold cascades to WHO (so the two columns don't echo). `ContaminantTable` was rendering that `null` as `"N/A"`, which on a row where WHO had a real value looked broken. Switch the local-column null label to `"NO LOCAL STANDARD"` so the gap is explicit. WHO column copy is unchanged.
- **GH #356 — categories sort.** `DashboardScreen` hardcoded `[StatCategory.water, StatCategory.air]`. Now derive from `CategoriesContext.categories` (already sorted by `Category.sortOrder`) while keeping the explicit water/air filter from issue #126 so health/disaster stay hidden. Falls back to the legacy order when the provider hasn't hydrated yet.

## Files
- `apps/mobile/app/utils/share.ts` (new) — `sharePayload(...)` helper.
- `apps/mobile/app/screens/DashboardScreen.tsx` — wire `sharePayload`, derive categories from context, drop the `Share` import.
- `apps/mobile/app/screens/CategoryDetailScreen.tsx` — wire `sharePayload`, drop the `Share` import, add `Alert`.
- `apps/mobile/app/components/ContaminantTable.tsx` — local-column null → `"NO LOCAL STANDARD"`.

## Test plan
- [x] `npm run lint:check` from `apps/mobile/` → 0 errors.
- [x] `npx tsc --noEmit` from `apps/mobile/` → 0 errors.
- [x] `npm test` from `apps/mobile/` → all suites pass.
- [ ] Staging mobile-web (https://staging.d2z5ddqhlc1q5.amplifyapp.com/):
  - [ ] Search Montreal → tap "Share safety data" on desktop → expect the OS share sheet **or** an "Copied to clipboard" alert. No more silent failure.
  - [ ] Search Atlanta (or any US state outside `US-NY` — see /threshold-coverage) → CategoryDetail → expect `"NO LOCAL STANDARD"` in the LOCAL column for rows where US-GA lacks thresholds, not `"N/A"`.
  - [ ] Admin reorders `Category.sortOrder` → Dashboard categories rerender in the new order.

## Notes
Closes GH #355. Closes the **code half** of GH #356; the threshold-seeding workstream (14 jurisdictions with 0 direct thresholds — see [the diagnostic comment](https://github.com/epiphanyapps/mapyourhealth/issues/356#issuecomment-4482677520)) stays open under that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)