### PR TITLE
fix(backend): drop manual CORS headers in request-magic-link Lambda

### DIFF
--- a/packages/backend/amplify/functions/request-magic-link/handler.ts
+++ b/packages/backend/amplify/functions/request-magic-link/handler.ts
@@ -51,7 +51,13 @@ function isValidEmail(email: string): boolean {
 }
 
 /**
- * Create response with CORS headers
+ * Build a JSON response. CORS headers are intentionally NOT set here — the
+ * Lambda Function URL itself is configured with `cors: { allowedOrigins: ['*'] }`
+ * in `packages/backend/amplify/backend.ts`, and AWS adds those headers to
+ * every response. Adding them again from the Lambda produces duplicate
+ * `Access-Control-Allow-Origin` values (`*` from us + the request origin
+ * reflected by Function URL), which browsers reject as `Failed to fetch`.
+ * That was the post-#401 regression Rayane hit on staging mobile-web.
  */
 function createResponse(
   statusCode: number,
@@ -61,8 +67,6 @@ function createResponse(
     statusCode,
     headers: {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': 'Content-Type',
     },
     body: JSON.stringify(body),
   };


### PR DESCRIPTION
## Summary
Post-#401 follow-up. With the magic-link request actually reaching the Lambda for the first time on staging mobile-web, the browser surfaced this:

> The 'Access-Control-Allow-Origin' header contains multiple values '*, https://staging.d2z5ddqhlc1q5.amplifyapp.com', but only one is allowed.

The Lambda Function URL is already configured with `cors: { allowedOrigins: ['*'] }` in `packages/backend/amplify/backend.ts`, and AWS adds those headers to every response. The Lambda handler was *also* writing `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: Content-Type` in its response body — so clients saw two copies, which is a hard CORS reject.

Drop the manual headers; let Function URL own CORS.

## Files
- `packages/backend/amplify/functions/request-magic-link/handler.ts` — remove the two CORS keys from `createResponse()`.

## Test plan
- [x] `cd packages/backend && npx tsc --noEmit -p .` → 0 errors.
- [ ] After staging backend redeploys: open https://staging.d2z5ddqhlc1q5.amplifyapp.com/, "Sign in with Email Link", submit a valid email → expect 200 from the Lambda, no `Failed to fetch`, magic-link email queued via SES.

## Notes
Closes the regression introduced when #401 enabled real traffic to the request-magic-link Lambda. The CORS preflight (OPTIONS) is unchanged — that's still handled entirely by Function URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)