### PR TITLE
fix(backend): route magic-link + email-alert SES through us-east-1

### DIFF
--- a/packages/backend/amplify/functions/request-magic-link/handler.ts
+++ b/packages/backend/amplify/functions/request-magic-link/handler.ts
@@ -20,7 +20,12 @@ import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
 import { checkRateLimit, recordRequest } from './rate-limiter';
 
 const cognitoClient = new CognitoIdentityProviderClient({});
-const sesClient = new SESClient({});
+// SES in ca-central-1 (the rest of the stack's region) is still in sandbox —
+// recipients must be a verified identity. us-east-1 has production access for
+// this AWS account with the mapyourhealth.info domain verified, so route the
+// magic-link emails through there. Matches the pattern already used in
+// resend-confirmation and subscribe-to-newsletter Lambdas.
+const sesClient = new SESClient({ region: 'us-east-1' });
 
 const USER_POOL_ID = process.env.USER_POOL_ID!;
 const FROM_EMAIL = process.env.FROM_EMAIL || 'noreply@mapyourhealth.info';

--- a/packages/backend/amplify/functions/send-email-alert/handler.ts
+++ b/packages/backend/amplify/functions/send-email-alert/handler.ts
@@ -8,8 +8,12 @@
 import type { Handler } from 'aws-lambda'
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses'
 
-// Initialize SES client
-const sesClient = new SESClient({})
+// Initialize SES client. SES in ca-central-1 is still in sandbox (recipients
+// must be verified identities). us-east-1 has production access for this AWS
+// account with the mapyourhealth.info domain verified, so route alert emails
+// through there. Matches the pattern already used in resend-confirmation and
+// subscribe-to-newsletter Lambdas.
+const sesClient = new SESClient({ region: "us-east-1" })
 
 interface EmailAlertEvent {
   /** The stat that changed */


### PR DESCRIPTION
## Summary
SES in `ca-central-1` (the stack region) is still in **sandbox** — recipients must be a verified identity, which is why the magic-link Lambda returned 500 for `walter.vargaspena+staging-test@gmail.com` after #401/#403 fixed the URL and CORS layers. This account already has SES production access in **us-east-1** (50k/day, 14/s, HEALTHY, with `mapyourhealth.info` domain verified). Two other Lambdas (`resend-confirmation`, `subscribe-to-newsletter`) already pin `region: "us-east-1"` for the same reason — match that pattern.

## SES account state today (verified via `aws sesv2 get-account`)
| Region | ProductionAccess | Quota | Verified |
|---|---|---|---|
| us-east-1 | ✅ **True** | 50,000/day, 14/s | `mapyourhealth.info` (DOMAIN), `contact@mapyourhealth.info` |
| ca-central-1 | ❌ False (sandbox) | 200/day, 1/s | `mapyourhealth.info` (DOMAIN), `contact@` |

## Files
- `packages/backend/amplify/functions/request-magic-link/handler.ts` — `new SESClient({ region: 'us-east-1' })`.
- `packages/backend/amplify/functions/send-email-alert/handler.ts` — same change.

IAM already grants `ses:SendEmail` / `ses:SendRawEmail` on `*`, so no policy update is required. From-addresses (`noreply@`, `alerts@`) are on the verified `mapyourhealth.info` domain.

## Test plan
- [x] `cd packages/backend && npx tsc --noEmit -p .` → 0 errors.
- [ ] After staging backend redeploys: from https://staging.d2z5ddqhlc1q5.amplifyapp.com/, "Sign in with email link" using an arbitrary gmail address → expect 200, magic-link email delivered, **no** `MessageRejected: Email address is not verified`.

## Notes
This is the last piece of the magic-link end-to-end fix bundle that started with #401 (URL routing) and #403 (CORS). With this PR, magic links work for any recipient, not just `*@mapyourhealth.info`. Closes the deliverability gate flagged in #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)