### PR TITLE
refactor(mobile): extract pollution formatters + a11y polish + scroll race fix

### DIFF
--- a/apps/mobile/app/components/PollutionSourcesCard.test.tsx
+++ b/apps/mobile/app/components/PollutionSourcesCard.test.tsx
@@ -84,6 +84,7 @@ function resetHook(partial: Partial<typeof mockHookResult>) {
 
 beforeEach(() => {
   mockNavigate.mockClear()
+  mockHookResult.refresh.mockClear()
   resetHook({})
 })
 
@@ -226,5 +227,64 @@ describe("PollutionSourcesCard", () => {
       <PollutionSourcesCard city="Sorel-Tracy" state="QC" country="CA" />,
     )
     expect(getByTestId("pollution-sources-scope-badge")).toBeTruthy()
+  })
+
+  it("renders loading state and announces it on the header", () => {
+    resetHook({ isLoading: true, sources: [], scope: "none" })
+    const { getByLabelText, getByText } = render(
+      <PollutionSourcesCard city="Montreal" state="QC" country="CA" />,
+    )
+    expect(getByText("Loading sources…")).toBeTruthy()
+    expect(getByLabelText("Pollution sources, loading")).toBeTruthy()
+  })
+
+  it("renders error state and retries on header tap", () => {
+    resetHook({ error: "boom", scope: "none" })
+    const { getByLabelText, getByText } = render(
+      <PollutionSourcesCard city="Montreal" state="QC" country="CA" />,
+    )
+    expect(getByText("Could not load — tap to retry")).toBeTruthy()
+    fireEvent.press(getByLabelText(/could not load/i))
+    expect(mockHookResult.refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders 'all remediated' summary when every source is inactive", () => {
+    resetHook({
+      sources: [
+        makeSource({ id: "r1", status: "remediated", severityLevel: "high" }),
+        makeSource({ id: "c1", status: "closed", severityLevel: "moderate" }),
+      ],
+      scope: "city",
+    })
+    const { getByText, getByLabelText } = render(
+      <PollutionSourcesCard city="Montreal" state="QC" country="CA" />,
+    )
+    expect(getByText("2 reported · all remediated or closed")).toBeTruthy()
+    // Severity dot is hidden when no inline (active/monitored) sources exist —
+    // the worst-severity affordance only applies to currently-active sources.
+    expect(
+      getByLabelText("Pollution sources, 2 sources reported, all remediated or closed"),
+    ).toBeTruthy()
+  })
+
+  it("pluralises the footer for one vs many sources", () => {
+    resetHook({
+      sources: [makeSource({ id: "only", severityLevel: "moderate" })],
+      scope: "city",
+    })
+    const { getByText, rerender } = render(
+      <PollutionSourcesCard city="Montreal" state="QC" country="CA" />,
+    )
+    expect(getByText("View all 1 source")).toBeTruthy()
+
+    resetHook({
+      sources: [
+        makeSource({ id: "a", severityLevel: "moderate" }),
+        makeSource({ id: "b", severityLevel: "low" }),
+      ],
+      scope: "city",
+    })
+    rerender(<PollutionSourcesCard city="Montreal" state="QC" country="CA" />)
+    expect(getByText("View all 2 sources")).toBeTruthy()
   })
 })

--- a/apps/mobile/app/components/PollutionSourcesCard.tsx
+++ b/apps/mobile/app/components/PollutionSourcesCard.tsx
@@ -16,7 +16,6 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import Animated, {
   Easing,
   interpolate,
-  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -25,6 +24,7 @@ import Animated, {
 import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { Text } from "@/components/Text"
 import { usePollutionSources } from "@/hooks/usePollutionSources"
+import { formatRadius, formatSourceType } from "@/lib/pollutionFormat"
 import type { AppStackParamList } from "@/navigators/navigationTypes"
 import type { AmplifyPollutionSource } from "@/services/amplify/data"
 import { useAppTheme } from "@/theme/context"
@@ -50,36 +50,6 @@ export interface PollutionSourcesCardProps {
   style?: StyleProp<ViewStyle>
 }
 
-function titleCase(value: string): string {
-  if (!value) return ""
-  return value.charAt(0).toUpperCase() + value.slice(1)
-}
-
-function formatSourceType(type: string | null | undefined): string {
-  if (!type) return "Unknown"
-  return type
-    .split("_")
-    .map((part, index) => (index === 0 ? titleCase(part) : part))
-    .join(" ")
-}
-
-function formatRadius(meters: number): string {
-  if (meters >= 1000) {
-    return `${(meters / 1000).toFixed(1)} km`
-  }
-  return `${Math.round(meters)} m`
-}
-
-function summariseCounts(sources: AmplifyPollutionSource[]): {
-  total: number
-  worst: PollutionSeverity | null
-} {
-  return {
-    total: sources.length,
-    worst: worstSeverity(sources),
-  }
-}
-
 export function PollutionSourcesCard(props: PollutionSourcesCardProps) {
   const { city, state, country, style } = props
   const { theme } = useAppTheme()
@@ -90,27 +60,21 @@ export function PollutionSourcesCard(props: PollutionSourcesCardProps) {
   const orderedInline = sortBySeverityDesc(inlineSources).slice(0, INLINE_ROW_LIMIT)
   const totalCount = sources.length
   const inlineCount = inlineSources.length
-  const { worst } = summariseCounts(inlineSources)
+  const worst: PollutionSeverity | null = worstSeverity(inlineSources)
   const worstColor = worst ? SEVERITY_COLORS[worst] : theme.colors.tint
 
   const [expanded, setExpanded] = useState(false)
-  const [, setMeasured] = useState(false)
   const contentHeight = useSharedValue(0)
   const progress = useSharedValue(0)
-
-  const handleMeasured = useCallback(() => {
-    setMeasured(true)
-  }, [])
 
   const onContentLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const height = event.nativeEvent.layout.height
       if (height > 0 && contentHeight.value === 0) {
         contentHeight.value = height
-        runOnJS(handleMeasured)()
       }
     },
-    [contentHeight, handleMeasured],
+    [contentHeight],
   )
 
   const toggleExpand = useCallback(() => {
@@ -166,15 +130,20 @@ export function PollutionSourcesCard(props: PollutionSourcesCardProps) {
       return `${totalCount} reported · all remediated or closed`
     }
     const noun = inlineCount === 1 ? "active source" : "active sources"
-    if (!worst) return `${inlineCount} ${noun} nearby`
     return `${inlineCount} ${noun} nearby`
   })()
 
-  const collapsedAccessibilityLabel = error
-    ? "Pollution sources, could not load, double tap to retry"
-    : `Pollution sources, ${inlineCount} ${inlineCount === 1 ? "active source" : "active sources"} nearby${
-        worst ? `, worst severity ${worst}` : ""
-      }`
+  const collapsedAccessibilityLabel = (() => {
+    if (isLoading) return "Pollution sources, loading"
+    if (error) return "Pollution sources, could not load, double tap to retry"
+    if (inlineCount === 0 && totalCount > 0) {
+      const noun = totalCount === 1 ? "source" : "sources"
+      return `Pollution sources, ${totalCount} ${noun} reported, all remediated or closed`
+    }
+    const noun = inlineCount === 1 ? "active source" : "active sources"
+    const severitySuffix = worst ? `, worst severity ${worst}` : ""
+    return `Pollution sources, ${inlineCount} ${noun} nearby${severitySuffix}`
+  })()
 
   return (
     <View
@@ -216,7 +185,12 @@ export function PollutionSourcesCard(props: PollutionSourcesCardProps) {
             {worst && !isLoading && !error ? (
               <>
                 <Text style={[$summaryDivider, { color: theme.colors.textDim }]}> · </Text>
-                <Text style={[$severityDot, { color: SEVERITY_COLORS[worst] }]}>●</Text>
+                <View
+                  // eslint-disable-next-line react-native/no-inline-styles
+                  style={[$severityDot, { backgroundColor: SEVERITY_COLORS[worst] }]}
+                  accessibilityElementsHidden
+                  importantForAccessibility="no-hide-descendants"
+                />
                 <Text style={[$severityLabel, { color: theme.colors.textDim }]}> {worst}</Text>
               </>
             ) : null}
@@ -287,7 +261,12 @@ function SourceRow({ source, onPress }: SourceRowProps) {
       accessibilityLabel={accessibilityLabel}
     >
       <View style={$rowSeverityCol}>
-        <Text style={[$rowDot, { color: severityColor }]}>●</Text>
+        <View
+          // eslint-disable-next-line react-native/no-inline-styles
+          style={[$rowDot, { backgroundColor: severityColor }]}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        />
         <Text style={[$rowSeverityLabel, { color: theme.colors.textDim }]} numberOfLines={1}>
           {severity ?? "unknown"}
         </Text>
@@ -359,8 +338,10 @@ const $summaryDivider: TextStyle = {
   fontSize: 13,
 }
 
-const $severityDot: TextStyle = {
-  fontSize: 12,
+const $severityDot: ViewStyle = {
+  width: 8,
+  height: 8,
+  borderRadius: 4,
 }
 
 const $severityLabel: TextStyle = {
@@ -410,8 +391,10 @@ const $rowSeverityCol: ViewStyle = {
   gap: 4,
 }
 
-const $rowDot: TextStyle = {
-  fontSize: 12,
+const $rowDot: ViewStyle = {
+  width: 8,
+  height: 8,
+  borderRadius: 4,
 }
 
 const $rowSeverityLabel: TextStyle = {

--- a/apps/mobile/app/lib/pollutionFormat.ts
+++ b/apps/mobile/app/lib/pollutionFormat.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared formatters for pollution-source presentation.
+ *
+ * Kept separate from `theme/pollutionColors.ts` so colour/severity logic stays
+ * decoupled from text rendering — both the Dashboard card and the detail
+ * screen import from here.
+ */
+
+export function formatRadius(meters: number): string {
+  if (meters >= 1000) {
+    return `${(meters / 1000).toFixed(1)} km`
+  }
+  return `${Math.round(meters)} m`
+}
+
+export function formatSourceType(type: string | null | undefined): string {
+  if (!type) return "Unknown"
+  const [first, ...rest] = type.split("_")
+  if (!first) return "Unknown"
+  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(" ")
+}

--- a/apps/mobile/app/screens/PollutionSourcesScreen.tsx
+++ b/apps/mobile/app/screens/PollutionSourcesScreen.tsx
@@ -30,6 +30,7 @@ import { LocationScopeBadge } from "@/components/LocationScopeBadge"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import { usePollutionSources } from "@/hooks/usePollutionSources"
+import { formatRadius, formatSourceType } from "@/lib/pollutionFormat"
 import type { AppStackParamList } from "@/navigators/navigationTypes"
 import type { AmplifyPollutionSource } from "@/services/amplify/data"
 import { useAppTheme } from "@/theme/context"
@@ -42,22 +43,6 @@ import {
 
 type PollutionSourcesRouteProp = RouteProp<AppStackParamList, "PollutionSources">
 type NavigationProp = NativeStackNavigationProp<AppStackParamList>
-
-function formatRadius(meters: number): string {
-  if (meters >= 1000) {
-    return `${(meters / 1000).toFixed(1)} km`
-  }
-  return `${Math.round(meters)} m`
-}
-
-function formatSourceType(type: string | null | undefined): string {
-  if (!type) return "Unknown"
-  // industrial → Industrial; waste_site → Waste site
-  return type
-    .split("_")
-    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
-    .join(" ")
-}
 
 function formatTitleCase(value: string | null | undefined): string {
   if (!value) return ""
@@ -83,9 +68,16 @@ export function PollutionSourcesScreen() {
   }, [refresh])
 
   const scrollRef = useRef<ScrollView>(null)
-  const cardOffsets = useRef<Record<string, number>>({})
   const didScrollToTargetRef = useRef(false)
+  // Offsets live in state so the scroll-to-target effect re-runs when the
+  // target card's `onLayout` fires (which is async from native). With a ref
+  // we'd race the effect and silently miss the scroll on first paint.
+  const [cardOffsets, setCardOffsets] = useState<Record<string, number>>({})
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
+
+  const recordCardOffset = useCallback((id: string, y: number) => {
+    setCardOffsets((prev) => (prev[id] === y ? prev : { ...prev, [id]: y }))
+  }, [])
 
   // Reset the scroll-to-target flag whenever the requested source changes so
   // navigating to a fresh source from the dashboard scrolls again.
@@ -96,8 +88,7 @@ export function PollutionSourcesScreen() {
 
   useEffect(() => {
     if (!sourceId || didScrollToTargetRef.current) return
-    if (sources.length === 0) return
-    const offset = cardOffsets.current[sourceId]
+    const offset = cardOffsets[sourceId]
     if (offset === undefined) return
     scrollRef.current?.scrollTo({ y: Math.max(offset - 24, 0), animated: true })
     didScrollToTargetRef.current = true
@@ -105,7 +96,7 @@ export function PollutionSourcesScreen() {
       setHighlightedId(null)
     }, 2000)
     return () => clearTimeout(timer)
-  }, [sourceId, sources])
+  }, [sourceId, cardOffsets])
 
   return (
     <Screen safeAreaEdges={["top"]} preset="fixed" contentContainerStyle={$root}>
@@ -152,9 +143,7 @@ export function PollutionSourcesScreen() {
                 key={source.id}
                 source={source}
                 highlighted={highlightedId === source.id}
-                onLayout={(event) => {
-                  cardOffsets.current[source.id] = event.nativeEvent.layout.y
-                }}
+                onLayout={(event) => recordCardOffset(source.id, event.nativeEvent.layout.y)}
               />
             ))}
           </View>


### PR DESCRIPTION
## Summary

Three threads of cleanup around the mobile pollution-source surfaces shipped in #407.

### 1. Shared formatters
Extract `formatRadius` and `formatSourceType` into `apps/mobile/app/lib/pollutionFormat.ts`. They were duplicated as private functions in both `PollutionSourcesCard.tsx` and `PollutionSourcesScreen.tsx`.

### 2. Accessibility + dead-code polish on `PollutionSourcesCard`

- **Severity dots**: replace text-glyph `●` with a small styled `<View>` marked `accessibilityElementsHidden` / `importantForAccessibility="no-hide-descendants"`. The accessibility label already conveys severity ("worst severity moderate"); the dot is visual-only.
- **State coverage on the summary line + a11y label**:
  - Loading: `"Loading sources…"` / `"Pollution sources, loading"`
  - Error: `"Could not load — tap to retry"` / `"Pollution sources, could not load, double tap to retry"`
  - All remediated/closed: `"{N} reported · all remediated or closed"` / `"Pollution sources, {N} {source|sources} reported, all remediated or closed"`
  - Plural / singular: `1 active source nearby` vs `2 active sources nearby`; `View all 1 source` vs `View all 2 sources`
- **Drop dead code**: unused `runOnJS` import, unused `setMeasured` state, the one-line `summariseCounts` helper.
- **Four new unit tests**: loading announcement, error/retry behaviour, all-remediated summary, footer pluralisation. **14/14 pass** (10 original + 4 new).

### 3. Scroll race fix on `PollutionSourcesScreen`

When the dashboard card deep-links into a specific source (`navigate('PollutionSources', { sourceId })`), the screen scrolls the matched card into view and applies a 2-second highlight ring. The previous implementation kept `cardOffsets` in a `useRef`. If the scroll-to-target effect ran before any `onLayout` fired (very likely on first paint), the offset was undefined and the scroll silently missed.

Move `cardOffsets` into `useState`, with a `recordCardOffset(id, y)` callback that does a cheap shallow-equality check before triggering a re-render. The effect now correctly re-runs when offsets become known.

## Test plan

- [x] `cd apps/mobile && npx tsc --noEmit && npx eslint app/lib/pollutionFormat.ts app/components/PollutionSourcesCard* app/screens/PollutionSourcesScreen.tsx` — clean
- [x] `npm test -- --testPathPattern=PollutionSourcesCard --forceExit` — 14/14 pass
- [ ] After staging deploy, deep-link verification on `https://staging.d2z5ddqhlc1q5.amplifyapp.com/?city=Sorel-Tracy&state=QC&country=CA`: open the Dashboard card, tap a row, confirm the detail screen scrolls to and highlights the matched card on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)