### PR TITLE
test: cover request-magic-link with unit + real-SES E2E

### DIFF
--- a/apps/admin/e2e/admin/magic-link-e2e.spec.ts
+++ b/apps/admin/e2e/admin/magic-link-e2e.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E Test: Magic Link Email Delivery
+ *
+ * Anchors Rayane's 2026-05-15 review finding: requesting a magic link
+ * succeeded at the API level but the email was silently dropped because
+ * SESClient was constructed in ca-central-1 (sandbox), where SES rejects
+ * sends to unverified recipients.
+ *
+ * A mocked Jest unit test (request-magic-link/handler.test.ts) covers the
+ * handler logic but cannot detect that class of failure — only an actual
+ * send through real SES against a real receiving address can.
+ *
+ * This spec generates a unique address at `e2e.mapyourhealth.info` (which
+ * is configured to deliver to S3 via SES receive rules — see
+ * docs/E2E_EMAIL_TESTING.md), POSTs to the staging Lambda Function URL,
+ * polls S3 for the resulting email, and asserts the body contains the
+ * expected magic-link URL with the right token.
+ *
+ * Skipped in PR CI (requires AWS credentials + staging access). Opt in
+ * locally with `RUN_EMAIL_E2E=1 npx playwright test magic-link-e2e`,
+ * or schedule via `workflow_dispatch` against staging.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { test, expect, request } from "@playwright/test";
+
+import {
+  deleteAllEmails,
+  extractMagicLink,
+  generateTestEmail,
+  verifyEmailContent,
+  waitForEmail,
+} from "../helpers/email";
+
+const MAGIC_LINK_URL = (() => {
+  // Read staging Lambda Function URL from the same outputs file the
+  // mobile app uses at runtime, so the test always points at whatever
+  // staging deploys to.
+  const path = join(__dirname, "../../../mobile/amplify_outputs.staging.json");
+  const outputs = JSON.parse(readFileSync(path, "utf8")) as {
+    custom?: { magicLinkApiUrl?: string };
+  };
+  if (!outputs.custom?.magicLinkApiUrl) {
+    throw new Error(
+      "magicLinkApiUrl missing from apps/mobile/amplify_outputs.staging.json — " +
+        "run `yarn sync:amplify` from the repo root before invoking this test.",
+    );
+  }
+  return outputs.custom.magicLinkApiUrl;
+})();
+
+test.describe("Magic link email delivery (Rayane 2026-05-15)", () => {
+  // Skip in PR CI — requires AWS S3 access + a live staging Lambda. Opt in
+  // explicitly via env var to keep accidental runs from racing other tests.
+  test.skip(
+    () => !process.env.RUN_EMAIL_E2E,
+    "Skipping magic-link E2E. Set RUN_EMAIL_E2E=1 to opt in.",
+  );
+
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async () => {
+    // Clear stale fixtures so polling can't accidentally match a previous run.
+    await deleteAllEmails();
+  });
+
+  test("real SES delivery: request → email → magic-link URL contains token", async () => {
+    const testEmail = generateTestEmail("magic-link");
+    const requestedAt = new Date();
+    console.log(`Requesting magic link for ${testEmail}`);
+
+    // ── 1. POST to the staging Lambda ────────────────────────────────────
+    const apiContext = await request.newContext();
+    const response = await apiContext.post(MAGIC_LINK_URL, {
+      data: { email: testEmail },
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(response.status(), "magic-link Lambda should accept the request").toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      success: true,
+      message: expect.stringContaining("Magic link sent"),
+    });
+    expect(body.expiresIn).toBe(900);
+
+    // ── 2. Poll S3 for the delivered email ───────────────────────────────
+    // Allow generous time — SES → S3 receive can take 10–30 seconds end to
+    // end depending on AWS load.
+    const email = await waitForEmail(testEmail, {
+      timeout: 120_000,
+      pollInterval: 3_000,
+      after: requestedAt,
+    });
+    expect(
+      email,
+      "expected an email to arrive at the S3-backed test inbox within 2 min",
+    ).not.toBeNull();
+
+    // ── 3. Assert content envelope is correct ────────────────────────────
+    const contentCheck = verifyEmailContent(email!, {
+      subjectContains: "Sign in to MapYourHealth",
+      fromContains: "mapyourhealth.info",
+      bodyContains: "auth/verify",
+    });
+    expect(
+      contentCheck.errors,
+      `email content did not match expectations: ${contentCheck.errors.join("; ")}`,
+    ).toEqual([]);
+
+    // ── 4. Extract and validate the magic-link URL ───────────────────────
+    const magicLink = extractMagicLink(email!);
+    expect(magicLink, "no magic link found in email body").not.toBeNull();
+    expect(magicLink!).toContain(`email=${encodeURIComponent(testEmail)}`);
+    expect(magicLink!).toMatch(/token=[a-f0-9]{64}/);
+  });
+});

--- a/packages/backend/amplify/functions/request-magic-link/handler.test.ts
+++ b/packages/backend/amplify/functions/request-magic-link/handler.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for request-magic-link handler.
+ *
+ * Anchor case (Rayane's 2026-05-15 review): magic-link emails were silently
+ * dropped. Two distinct failure modes had to be ruled out for the fix —
+ *   (a) SES sandbox region: in ca-central-1, SES rejects all sends to
+ *       unverified recipients. The handler now constructs `SESClient` with
+ *       `{ region: "us-east-1" }`, which has production access for
+ *       mapyourhealth.info.
+ *   (b) The handler must call `SendEmailCommand` exactly once per accepted
+ *       request and never swallow a SES failure as a 200 success.
+ *
+ * These tests pin both invariants by mocking `@aws-sdk/client-ses` and
+ * asserting the command shape + that SES throws are surfaced as 500, not
+ * 200. The rate-limiter and Cognito client are mocked at the module
+ * boundary so the handler runs in isolation.
+ */
+
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Context,
+} from "aws-lambda";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockSesSend = jest.fn();
+
+jest.mock("@aws-sdk/client-ses", () => {
+  class SendEmailCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  class SESClient {
+    send = mockSesSend;
+  }
+  return { SESClient, SendEmailCommand };
+});
+
+const mockCognitoSend = jest.fn();
+
+class FakeUserNotFoundException extends Error {
+  name = "UserNotFoundException";
+}
+
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => {
+  function command(name: string) {
+    return class {
+      static __name = name;
+      input: unknown;
+      constructor(input: unknown) {
+        this.input = input;
+      }
+    };
+  }
+  class CognitoIdentityProviderClient {
+    send = mockCognitoSend;
+  }
+  return {
+    CognitoIdentityProviderClient,
+    AdminGetUserCommand: command("AdminGetUserCommand"),
+    AdminCreateUserCommand: command("AdminCreateUserCommand"),
+    AdminUpdateUserAttributesCommand: command("AdminUpdateUserAttributesCommand"),
+    MessageActionType: { SUPPRESS: "SUPPRESS" },
+    UserNotFoundException: FakeUserNotFoundException,
+  };
+});
+
+const mockCheckRateLimit = jest.fn();
+const mockRecordRequest = jest.fn();
+
+jest.mock("./rate-limiter", () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  recordRequest: (...args: unknown[]) => mockRecordRequest(...args),
+}));
+
+// Env must be set before the handler module is evaluated since values are
+// captured at module init.
+process.env.USER_POOL_ID = "test-user-pool";
+process.env.FROM_EMAIL = "noreply@mapyourhealth.info";
+process.env.APP_URL = "https://staging.example.com/";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/first
+import { handler } from "./handler";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: "POST",
+    isBase64Encoded: false,
+    path: "/request-magic-link",
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent["requestContext"],
+    resource: "",
+    ...overrides,
+  };
+}
+
+async function callHandler(
+  event: Partial<APIGatewayProxyEvent>,
+): Promise<APIGatewayProxyResult> {
+  const result = await handler(
+    buildEvent(event),
+    {} as Context,
+    () => undefined,
+  );
+  if (!result) throw new Error("handler returned void");
+  return result as APIGatewayProxyResult;
+}
+
+function parseBody(result: APIGatewayProxyResult): Record<string, unknown> {
+  return JSON.parse(result.body) as Record<string, unknown>;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 2 });
+  mockRecordRequest.mockResolvedValue(undefined);
+  mockCognitoSend.mockResolvedValue({});
+  mockSesSend.mockResolvedValue({ MessageId: "ses-msg-id" });
+});
+
+describe("request-magic-link handler", () => {
+  // Note on SES region invariant: the handler must construct SESClient with
+  // `region: "us-east-1"` (handler.ts:28). If someone reverts this to the
+  // default ca-central-1 region, SES sandbox silently drops mail to unverified
+  // recipients — the bug Rayane reported on 2026-05-15. Asserting the
+  // constructor argument from inside a Jest mock factory ran into a
+  // hoisting/class-field interaction that swallowed the call. The "SES failure
+  // is surfaced" test below covers the practically important invariant: the
+  // handler must NOT return 200 when the email isn't actually sent.
+
+  describe("input validation", () => {
+    it("returns 400 when the request body is missing", async () => {
+      const result = await callHandler({ body: null });
+      expect(result.statusCode).toBe(400);
+      expect(parseBody(result)).toEqual({ error: "Request body is required" });
+      expect(mockSesSend).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the request body is not valid JSON", async () => {
+      const result = await callHandler({ body: "not-json" });
+      expect(result.statusCode).toBe(400);
+      expect(parseBody(result)).toEqual({ error: "Invalid JSON in request body" });
+      expect(mockSesSend).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the email is missing or malformed", async () => {
+      const missing = await callHandler({ body: JSON.stringify({}) });
+      expect(missing.statusCode).toBe(400);
+      expect(parseBody(missing)).toEqual({ error: "Invalid email address" });
+
+      const malformed = await callHandler({
+        body: JSON.stringify({ email: "not-an-email" }),
+      });
+      expect(malformed.statusCode).toBe(400);
+      expect(parseBody(malformed)).toEqual({ error: "Invalid email address" });
+
+      expect(mockSesSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("preflight", () => {
+    it("returns 200 for OPTIONS without touching any AWS client", async () => {
+      const result = await callHandler({ httpMethod: "OPTIONS" });
+      expect(result.statusCode).toBe(200);
+      expect(mockSesSend).not.toHaveBeenCalled();
+      expect(mockCognitoSend).not.toHaveBeenCalled();
+      expect(mockCheckRateLimit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("returns 429 when the limiter rejects the request, without sending an email", async () => {
+      const resetAt = new Date("2030-01-01T00:00:00.000Z");
+      mockCheckRateLimit.mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt,
+      });
+
+      const result = await callHandler({
+        body: JSON.stringify({ email: "user@example.com" }),
+      });
+
+      expect(result.statusCode).toBe(429);
+      expect(parseBody(result)).toMatchObject({
+        error: expect.stringContaining("Too many requests"),
+        retryAfter: resetAt.toISOString(),
+      });
+      expect(mockSesSend).not.toHaveBeenCalled();
+      expect(mockCognitoSend).not.toHaveBeenCalled();
+      expect(mockRecordRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("success path — existing user", () => {
+    it("sends the email through SES and records the request", async () => {
+      // AdminGetUser succeeds → user exists, no create call.
+      mockCognitoSend.mockResolvedValue({});
+
+      const result = await callHandler({
+        body: JSON.stringify({ email: "Existing@Example.com" }),
+      });
+
+      expect(result.statusCode).toBe(200);
+      const body = parseBody(result);
+      expect(body).toMatchObject({
+        success: true,
+        message: "Magic link sent successfully",
+      });
+      expect(body.expiresIn).toBe(900); // 15 minutes in seconds
+
+      // SES must be hit exactly once with the right shape.
+      expect(mockSesSend).toHaveBeenCalledTimes(1);
+      const sesArg = mockSesSend.mock.calls[0][0];
+      expect(sesArg.input.Source).toBe("noreply@mapyourhealth.info");
+      expect(sesArg.input.Destination.ToAddresses).toEqual(["existing@example.com"]);
+      expect(sesArg.input.Message.Subject.Data).toBe("Sign in to MapYourHealth");
+
+      const htmlBody = sesArg.input.Message.Body.Html.Data as string;
+      const textBody = sesArg.input.Message.Body.Text.Data as string;
+      expect(htmlBody).toContain("auth/verify?email=existing%40example.com&token=");
+      expect(textBody).toContain("auth/verify?email=existing%40example.com&token=");
+
+      expect(mockRecordRequest).toHaveBeenCalledWith("existing@example.com");
+
+      // Existing user — no AdminCreateUserCommand sent.
+      const commandNames = mockCognitoSend.mock.calls.map(
+        (call) => (call[0].constructor as { __name?: string }).__name,
+      );
+      expect(commandNames).not.toContain("AdminCreateUserCommand");
+      expect(commandNames).toContain("AdminGetUserCommand");
+      expect(commandNames).toContain("AdminUpdateUserAttributesCommand");
+    });
+  });
+
+  describe("success path — new user", () => {
+    it("creates the Cognito user with email_verified=true before sending the email", async () => {
+      let getUserCalled = false;
+      mockCognitoSend.mockImplementation((command: { constructor: { __name: string } }) => {
+        const name = command.constructor.__name;
+        if (name === "AdminGetUserCommand") {
+          getUserCalled = true;
+          return Promise.reject(new FakeUserNotFoundException("not found"));
+        }
+        return Promise.resolve({});
+      });
+
+      const result = await callHandler({
+        body: JSON.stringify({ email: "new@example.com" }),
+      });
+
+      expect(getUserCalled).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(mockSesSend).toHaveBeenCalledTimes(1);
+
+      const commandNames = mockCognitoSend.mock.calls.map(
+        (call) => (call[0].constructor as { __name?: string }).__name,
+      );
+      expect(commandNames).toContain("AdminCreateUserCommand");
+
+      const createCall = mockCognitoSend.mock.calls.find(
+        (call) => (call[0].constructor as { __name?: string }).__name === "AdminCreateUserCommand",
+      );
+      expect(createCall?.[0].input).toMatchObject({
+        UserPoolId: "test-user-pool",
+        Username: "new@example.com",
+        MessageAction: "SUPPRESS",
+      });
+      const userAttrs = createCall?.[0].input.UserAttributes as Array<{
+        Name: string;
+        Value: string;
+      }>;
+      expect(userAttrs).toEqual(
+        expect.arrayContaining([
+          { Name: "email", Value: "new@example.com" },
+          { Name: "email_verified", Value: "true" },
+        ]),
+      );
+    });
+  });
+
+  describe("SES failure is surfaced, never silently swallowed", () => {
+    it("returns 500 if SES throws, and does not record the request as fulfilled", async () => {
+      // The original bug masquerade: SES rejected the send and the handler
+      // returned 200. If this case ever returns 200 again, mail delivery is
+      // silently broken for the user.
+      mockSesSend.mockRejectedValueOnce(new Error("SES sandbox rejection"));
+
+      const result = await callHandler({
+        body: JSON.stringify({ email: "user@example.com" }),
+      });
+
+      expect(result.statusCode).toBe(500);
+      expect(parseBody(result)).toEqual({
+        error: "An error occurred. Please try again.",
+      });
+      expect(mockRecordRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("email normalisation", () => {
+    it("lowercases the email before downstream side effects", async () => {
+      // The handler validates email before trimming (handler.ts:186-190), so
+      // a whitespace-padded address fails the regex. Mixed-case input is the
+      // realistic shape — most form inputs send `User@Example.com` rather
+      // than canonical lower-case.
+      await callHandler({
+        body: JSON.stringify({ email: "User@Example.com" }),
+      });
+      expect(mockCheckRateLimit).toHaveBeenCalledWith("user@example.com");
+      expect(mockRecordRequest).toHaveBeenCalledWith("user@example.com");
+      const sesArg = mockSesSend.mock.calls[0][0];
+      expect(sesArg.input.Destination.ToAddresses).toEqual(["user@example.com"]);
+    });
+  });
+});

--- a/packages/backend/amplify/functions/request-magic-link/jest.config.js
+++ b/packages/backend/amplify/functions/request-magic-link/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+export default {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: false,
+        tsconfig: {
+          module: "commonjs",
+          moduleResolution: "node",
+          esModuleInterop: true,
+          verbatimModuleSyntax: false,
+        },
+      },
+    ],
+  },
+};

--- a/packages/backend/amplify/functions/request-magic-link/package.json
+++ b/packages/backend/amplify/functions/request-magic-link/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "request-magic-link",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.143",
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16080,6 +16080,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/aws-lambda@npm:^8.10.143":
+  version: 8.10.161
+  resolution: "@types/aws-lambda@npm:8.10.161"
+  checksum: 10c0/5a779901bb29a1989fe0ef30e4a515522af8fc66c237e0eedc954ab650651920540196b4629df25068c130a05a2a6142f661db7e26c7fbacc17ce11338367eb1
+  languageName: node
+  linkType: hard
+
 "@types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -28030,6 +28037,17 @@ __metadata:
   checksum: 10c0/7f5cd293ec47d9c074ef0852800d5ff5c49028ce65242a7528d84f32bd2fe200b142930562af58c96d869c5a3046e87253030058e45231acaa129c1a7087d2e7
   languageName: node
   linkType: hard
+
+"request-magic-link@workspace:packages/backend/amplify/functions/request-magic-link":
+  version: 0.0.0-use.local
+  resolution: "request-magic-link@workspace:packages/backend/amplify/functions/request-magic-link"
+  dependencies:
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/jest": "npm:^29.5.14"
+    jest: "npm:^29.7.0"
+    ts-jest: "npm:^29.3.4"
+  languageName: unknown
+  linkType: soft
 
 "require-directory@npm:^2.1.1":
   version: 2.1.1


### PR DESCRIPTION
## Summary

Pair of tests anchored to Rayane's 2026-05-15 review finding: magic-link emails were silently dropped because `SESClient` was constructed in ca-central-1 (sandbox), where SES rejects sends to unverified recipients. The handler had zero coverage at the time, so the next refactor could easily revert the region or swallow a SES failure as a 200 success.

This PR adds two complementary tests covering the silent-drop class of bug from different angles.

## What changes

### 1. `packages/backend/amplify/functions/request-magic-link/handler.test.ts` (new, 9 tests)

Per-function Jest suite following the `confirm-newsletter` pattern (own `package.json` + `jest.config.js`). Mocks SES, Cognito, and the DynamoDB rate-limiter at the SDK boundary.

Pins the handler-level invariants:

- Input validation: missing body, malformed JSON, missing/invalid email all return 400 without touching SES.
- Preflight `OPTIONS` returns 200 without any AWS calls.
- Rate-limited (429) requests never call SES, Cognito update, or `recordRequest`.
- Success path (existing user) sends exactly one SES email with the right `Source` / `To` / `Subject` / `Body` and a magic-link URL containing the normalised email + token; `recordRequest` is called with the lowercased email.
- Success path (new user) calls `AdminCreateUserCommand` with `email_verified=true` and `MessageAction: SUPPRESS` before continuing into the same SES send.
- **SES failure is surfaced as 500, never silently swallowed as 200** — the load-bearing assertion that would have caught the original bug.
- Email normalisation: mixed-case input lowercases before rate-limit check, `recordRequest`, and the SES `To` address.

9/9 pass locally.

A would-be 10th test pinning `new SESClient({ region: "us-east-1" })` ran into a Jest hoisting / ts-jest class-field interaction that swallowed the constructor spy. Documented inline; the "SES failure is surfaced" test covers the user-visible invariant that matters either way.

### 2. `apps/admin/e2e/admin/magic-link-e2e.spec.ts` (new, 1 test)

The Jest unit tests mock the AWS SDK, so they cannot detect the *delivery* failure mode that Rayane actually hit. This Playwright spec exercises the real path:

1. Generates a unique `magic-link-<ts>-<rand>@e2e.mapyourhealth.info`.
2. POSTs to the staging Lambda Function URL (read from `apps/mobile/amplify_outputs.staging.json` so the test always tracks the deployed endpoint).
3. Polls the S3 bucket where SES receive rules drop incoming mail to `*@e2e.mapyourhealth.info` (see `docs/E2E_EMAIL_TESTING.md`).
4. Asserts subject, sender, and body envelope; extracts the magic-link URL; verifies it contains the encoded test address and a 64-char hex token.

**Verified locally against staging: end-to-end run completes in ~6 s, real email lands in S3.**

Skipped in PR CI by default (`RUN_EMAIL_E2E` env gate, same pattern as `email-notification.spec.ts`) because it needs AWS credentials + staging. Opt in with:

```bash
AWS_PROFILE=rayane RUN_EMAIL_E2E=1 npx playwright test magic-link-e2e --project=admin-chromium
```

If the SES region ever regresses to ca-central-1 — the bug from 2026-05-15 — no email lands in S3 and this test fails immediately.

## What does *not* change

- No production code (handler, rate-limiter, Lambda URL) touched.
- No CI workflow changes. The Jest suite will run when `packages/backend/**` changes if a backend-test workflow is added; today it's invoked manually via `cd packages/backend/amplify/functions/request-magic-link && npm test`.

## Test plan

- [x] `cd packages/backend/amplify/functions/request-magic-link && npx jest` → 9/9 pass
- [x] `AWS_PROFILE=rayane RUN_EMAIL_E2E=1 npx playwright test magic-link-e2e --project=admin-chromium` → 1/1 pass, ~6 s, real email in S3
- [ ] `cd apps/admin && npx tsc --noEmit && npx eslint e2e/admin/magic-link-e2e.spec.ts` → clean (verified locally)
- [ ] Playwright PR check on the admin e2e suite (will skip the new spec by default because `RUN_EMAIL_E2E` isn't set in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)