### PR TITLE
fix(mobile): unblock 2 pre-existing jest failures + fix warning zone for 'lower is worse' properties

### DIFF
--- a/apps/mobile/app/components/ContaminantTable.test.tsx
+++ b/apps/mobile/app/components/ContaminantTable.test.tsx
@@ -120,6 +120,8 @@ describe("ContaminantTable", () => {
       // test pins.
       expect(queryByText("NO LOCAL STANDARD")).toBeTruthy()
       expect(queryByText("NO STANDARD")).toBeTruthy()
+      // Guard against regression to the old "N/A" wording.
+      expect(queryByText("N/A")).toBeNull()
     })
   })
 

--- a/apps/mobile/app/components/ContaminantTable.test.tsx
+++ b/apps/mobile/app/components/ContaminantTable.test.tsx
@@ -112,9 +112,13 @@ describe("ContaminantTable", () => {
 
       const { queryByText } = render(<ContaminantTable rows={rows} />)
 
-      // Local cell renders "N/A" when localLimit is null; WHO cell
-      // renders "NO STANDARD". Neither should append a unit.
-      expect(queryByText("N/A")).toBeTruthy()
+      // Local cell renders "NO LOCAL STANDARD" when localLimit is null; WHO
+      // cell renders "NO STANDARD". The "NO LOCAL STANDARD" wording (vs the
+      // previous "N/A") was a Rayane-2026-05-15 fix so the column doesn't
+      // look identical to a populated WHO value. Neither label appends a
+      // unit (no "NO STANDARD μg/L"), which is the actual invariant this
+      // test pins.
+      expect(queryByText("NO LOCAL STANDARD")).toBeTruthy()
       expect(queryByText("NO STANDARD")).toBeTruthy()
     })
   })

--- a/apps/mobile/app/data/types/__tests__/safety.test.ts
+++ b/apps/mobile/app/data/types/__tests__/safety.test.ts
@@ -101,6 +101,34 @@ describe("computeStatus", () => {
       expect(computeStatus(15, zeroRatio, false)).toBe("danger")
       expect(computeStatus(16, zeroRatio, false)).toBe("safe")
     })
+
+    it("collapses the warning band to empty when warningRatio === 1", () => {
+      // limit / 1 = limit, so the ladder is { ≤ limit → danger,
+      // > limit → safe } with no intermediate warning band.
+      const fullRatio = { ...baseThreshold, warningRatio: 1 }
+      expect(computeStatus(15, fullRatio, false)).toBe("danger")
+      expect(computeStatus(15.01, fullRatio, false)).toBe("safe")
+    })
+  })
+
+  describe("higherIsBad: true — warningRatio edge cases", () => {
+    it("warningRatio === 0 makes warning band span [0, limit)", () => {
+      // warningThreshold = limit × 0 = 0, so any value ≥ 0 and < limit
+      // matches `value >= 0 → warning`. Surprising but the current
+      // documented behavior — pin it so it doesn't drift silently.
+      const zeroRatio = { ...baseThreshold, warningRatio: 0 }
+      expect(computeStatus(0, zeroRatio, true)).toBe("warning")
+      expect(computeStatus(14.99, zeroRatio, true)).toBe("warning")
+      expect(computeStatus(15, zeroRatio, true)).toBe("danger")
+    })
+
+    it("warningRatio === 1 collapses the warning band to empty", () => {
+      // limit × 1 = limit, so the ladder is { ≥ limit → danger,
+      // < limit → safe } with no warning band.
+      const fullRatio = { ...baseThreshold, warningRatio: 1 }
+      expect(computeStatus(14.99, fullRatio, true)).toBe("safe")
+      expect(computeStatus(15, fullRatio, true)).toBe("danger")
+    })
   })
 })
 

--- a/apps/mobile/app/data/types/__tests__/safety.test.ts
+++ b/apps/mobile/app/data/types/__tests__/safety.test.ts
@@ -70,18 +70,36 @@ describe("computeStatus", () => {
   })
 
   describe("higherIsBad: false (lower is worse — dissolved oxygen, pH proxies)", () => {
+    // Warning zone for `!higherIsBad` sits *above* the danger limit, not
+    // below: warningThreshold = limit / warningRatio. With limit=15 and
+    // warningRatio=0.8, that's `15 / 0.8 = 18.75`, so:
+    //   value > 18.75 → safe
+    //   15 <  value ≤ 18.75 → warning (close to dangerous)
+    //   value ≤ 15 → danger
+
     it("returns 'danger' at or below the limit", () => {
       expect(computeStatus(15, baseThreshold, false)).toBe("danger")
       expect(computeStatus(10, baseThreshold, false)).toBe("danger")
     })
 
-    it("returns 'warning' at or below limit × warningRatio", () => {
-      // limit=15, warningRatio=0.8 → warning at 12 (and lower, until danger)
-      expect(computeStatus(12, baseThreshold, false)).toBe("warning")
+    it("returns 'warning' between the limit and limit ÷ warningRatio", () => {
+      expect(computeStatus(16, baseThreshold, false)).toBe("warning")
+      expect(computeStatus(18, baseThreshold, false)).toBe("warning")
+      expect(computeStatus(18.75, baseThreshold, false)).toBe("warning")
     })
 
     it("returns 'safe' above the warning threshold", () => {
+      expect(computeStatus(19, baseThreshold, false)).toBe("safe")
       expect(computeStatus(20, baseThreshold, false)).toBe("safe")
+    })
+
+    it("falls back to limit-only comparison when warningRatio is 0", () => {
+      // Defensive: warningRatio=0 would divide by zero. Treat as no
+      // warning zone — every value is either safe (above limit) or
+      // danger (at/below limit), no warning.
+      const zeroRatio = { ...baseThreshold, warningRatio: 0 }
+      expect(computeStatus(15, zeroRatio, false)).toBe("danger")
+      expect(computeStatus(16, zeroRatio, false)).toBe("safe")
     })
   })
 })

--- a/apps/mobile/app/data/types/safety.ts
+++ b/apps/mobile/app/data/types/safety.ts
@@ -531,8 +531,17 @@ export interface ComputeStatusOptions {
  *
  * Numeric comparison, given a limit:
  *  - `warningThreshold = limit * threshold.warningRatio`
- *  - `higherIsBad`: at-or-above limit → `"danger"`; at-or-above warning → `"warning"`; below → `"safe"`
- *  - `!higherIsBad`: at-or-below limit → `"danger"`; at-or-below warning → `"warning"`; above → `"safe"`
+ *  - `higherIsBad`: at-or-above limit → `"danger"`; at-or-above limit × warningRatio → `"warning"`; below → `"safe"`
+ *  - `!higherIsBad`: at-or-below limit → `"danger"`; at-or-below limit ÷ warningRatio → `"warning"`; above → `"safe"`
+ *
+ * The asymmetry on warningThreshold is intentional. For `higherIsBad: true`
+ * the warning zone sits *just below* the danger limit (multiply pulls the
+ * threshold down). For `!higherIsBad` the warning zone sits *just above* the
+ * danger limit (divide pushes the threshold up). Using the same multiply on
+ * both branches leaves `warningThreshold < limit`, which made every
+ * `value <= warningThreshold` case fall through the `value <= limit → danger`
+ * check first — `warning` was unreachable for "lower is worse" properties
+ * (dissolved oxygen, pH proxies). #EPI-NN.
  *
  * Special case for `higherIsBad`: when `limit === 0` ("must be absent" rule —
  * e.g. lead, asbestos), `value === 0` means "none detected" → `"safe"`, not
@@ -553,14 +562,18 @@ export function computeStatus(
   }
 
   const limit = threshold.limitValue
-  const warningThreshold = limit * threshold.warningRatio
 
   if (higherIsBad) {
     if (limit === 0 && value === 0) return "safe"
+    const warningThreshold = limit * threshold.warningRatio
     if (value >= limit) return "danger"
     if (value >= warningThreshold) return "warning"
     return "safe"
   }
+  // `!higherIsBad` — lower is worse. Warning zone sits just above the limit,
+  // not just below: warningThreshold > limit so the conditional ladder
+  // resolves as { safe → warning → danger } as value falls.
+  const warningThreshold = threshold.warningRatio > 0 ? limit / threshold.warningRatio : limit
   if (value <= limit) return "danger"
   if (value <= warningThreshold) return "warning"
   return "safe"

--- a/apps/mobile/app/data/types/safety.ts
+++ b/apps/mobile/app/data/types/safety.ts
@@ -541,7 +541,7 @@ export interface ComputeStatusOptions {
  * both branches leaves `warningThreshold < limit`, which made every
  * `value <= warningThreshold` case fall through the `value <= limit → danger`
  * check first — `warning` was unreachable for "lower is worse" properties
- * (dissolved oxygen, pH proxies). #EPI-NN.
+ * (dissolved oxygen, pH proxies).
  *
  * Special case for `higherIsBad`: when `limit === 0` ("must be absent" rule —
  * e.g. lead, asbestos), `value === 0` means "none detected" → `"safe"`, not
@@ -573,7 +573,8 @@ export function computeStatus(
   // `!higherIsBad` — lower is worse. Warning zone sits just above the limit,
   // not just below: warningThreshold > limit so the conditional ladder
   // resolves as { safe → warning → danger } as value falls.
-  const warningThreshold = threshold.warningRatio > 0 ? limit / threshold.warningRatio : limit
+  const ratio = threshold.warningRatio
+  const warningThreshold = Number.isFinite(ratio) && ratio > 0 ? limit / ratio : limit
   if (value <= limit) return "danger"
   if (value <= warningThreshold) return "warning"
   return "safe"


### PR DESCRIPTION
## Summary

Two unrelated mobile jest tests were red on `origin/staging`. Both now pass; full mobile suite is **278/278 across 24 suites**.

## 1. `safety.ts` — `computeStatus` had an unreachable `warning` branch for `!higherIsBad`

For `higherIsBad: true` (lead, nitrate, PM2.5 — higher is worse), the warning zone correctly sits *just below* the danger limit as `limit × warningRatio` (e.g. limit=15, ratio=0.8 → warning at 12–15).

For `higherIsBad: false` (dissolved oxygen, pH proxies — lower is worse), the warning zone should sit *just above* the danger limit, i.e. `limit ÷ warningRatio` (limit=15, ratio=0.8 → warning at 15–18.75). The old code reused `limit × warningRatio` for both branches, producing `warningThreshold = 12` — which is *below* `limit = 15`, so every `value ≤ 12` already matched `value <= limit → danger` and the `value <= warningThreshold → warning` line was unreachable.

**Result:** for any "lower is worse" property, `computeStatus` could only ever return `safe` or `danger`. Warning status never fired for DO/pH-style measurements.

The new logic divides instead of multiplies for `!higherIsBad` and adds a defensive `warningRatio > 0` guard. Test coverage now pins:

```
value > 18.75 → safe
15 < value ≤ 18.75 → warning
value ≤ 15 → danger
warningRatio === 0 → safe/danger only (no warning zone)
```

## 2. `ContaminantTable.test.tsx` — assertion stale after Rayane's 2026-05-15 review

The component used to render `N/A` for an absent local threshold, but that read identical to a populated WHO value visually. An earlier PR swapped it to `"NO LOCAL STANDARD"` so the column is unambiguously empty. The test's assertion was missed; updated to expect `"NO LOCAL STANDARD"` and clarified the comment.

The actual invariant the test pins (no unit suffix on the placeholder, no `"NO STANDARD μg/L"`) is unchanged.

## Test plan

- [x] `cd apps/mobile && npm test -- --testPathPattern="safety.test.ts|ContaminantTable.test.tsx"` — 62/62 pass
- [x] `cd apps/mobile && npm test -- --forceExit` — **278/278** across 24 suites, no regressions
- [x] `cd apps/mobile && npx tsc --noEmit && npx eslint app/data/types/safety.ts app/data/types/__tests__/safety.test.ts app/components/ContaminantTable.test.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)